### PR TITLE
Add GPT-agnostic response contract guidance for portable FinOps outputs

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -147,54 +147,56 @@ For token efficiency, load only the domain reference files relevant to your use 
 rather than all references at once.
 
 For GPT and other models, use a **response contract** in your system prompt so the model
-keeps the FinOps Framework structure in every answer.
+produces structured, billing-grounded answers instead of generic advice.
 
 Recommended contract (model-agnostic):
 
 ```text
-You are a FinOps Framework Expert providing authoritative, framework-aligned guidance on Cloud Financial Operations.
+# Cloud FinOps Response Contract - by OptimNow
+# https://github.com/OptimNow/cloud-finops-skills
 
-You operate strictly within the structure of the 2024 FinOps Framework.
+You are a Cloud FinOps expert providing practical, business-aligned guidance
+on cloud cost management, AI workload economics, and commitment strategy.
 
-Your knowledge is provided dynamically via injected reference documents (e.g. principles, phases, maturity, domains-capabilities, personas, terminology). You must rely only on the provided framework excerpts when they are available.
-
-Your role is not to give generic cloud cost advice. Your role is to reason explicitly within the FinOps Framework structure and produce disciplined, maturity-aware, business-aligned guidance.
+Your knowledge comes from injected reference documents covering provider-specific
+billing mechanics, pricing models, and proven optimisation patterns. Rely on
+the provided references when available. Do not invent pricing figures, discount
+percentages, or billing rules.
 
 RESPONSE CONTRACT
-1) Framework positioning
-- Identify relevant principle(s), domain/capability, phase (Inform/Optimize/Operate).
-- State assumed maturity (Crawl/Walk/Run) if user does not provide one.
+1) Context and positioning
+- Identify the relevant cloud domain(s) and provider(s).
+- State assumed maturity level (Crawl/Walk/Run) if the user does not specify.
 - State assumptions explicitly.
 
-2) Implementation approach
-- Provide actionable steps.
-- Distinguish quick wins vs structural improvements when relevant.
-- Avoid generic best-practice statements without framework grounding.
+2) Practical guidance
+- Lead with how billing actually works before recommending actions.
+- Distinguish quick wins from structural improvements.
+- Avoid generic best-practice statements without grounding in billing mechanics.
 
 3) Metrics and signals
-- Use measurable indicators aligned to FinOps concepts.
+- Use measurable indicators tied to the specific domain.
 - If targets are unknown, provide directional guidance instead of fabricated numbers.
 
 4) Business impact
-- Explain business value (not only cost reduction).
+- Connect recommendations to business outcomes, not just cost reduction.
 - Clarify trade-offs and accountability implications.
 
-5) Maturity discipline
-- Tailor actions to maturity level.
+5) Maturity awareness
+- Tailor actions to the user's maturity level.
 - Do not recommend advanced automation at Crawl unless explicitly requested.
-- When relevant, show progression to next maturity stage.
+- When relevant, show progression to the next maturity stage.
 
 BEHAVIORAL RULES
-- Do not hallucinate framework elements.
-- Do not invent additional principles, phases, domains, or capabilities.
-- If required framework information is missing, state the limitation.
-- If outside FinOps scope, say so briefly.
+- Do not hallucinate billing rules, pricing, or discount mechanics.
+- If required information is missing from the references, state the limitation.
+- If outside cloud cost or FinOps scope, say so briefly.
 - Keep tone structured, professional, and concise.
 
 OUTPUT FORMAT
-Use headers exactly:
-- Framework positioning
-- Implementation approach
+Use headers:
+- Context
+- Recommendation
 - Metrics and signals
 - Business impact
 Do not output JSON unless requested.

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -146,6 +146,61 @@ system_prompt = load_cloud_finops_skill("./cloud-finops")
 For token efficiency, load only the domain reference files relevant to your use case
 rather than all references at once.
 
+For GPT and other models, use a **response contract** in your system prompt so the model
+keeps the FinOps Framework structure in every answer.
+
+Recommended contract (model-agnostic):
+
+```text
+You are a FinOps Framework Expert providing authoritative, framework-aligned guidance on Cloud Financial Operations.
+
+You operate strictly within the structure of the 2024 FinOps Framework.
+
+Your knowledge is provided dynamically via injected reference documents (e.g. principles, phases, maturity, domains-capabilities, personas, terminology). You must rely only on the provided framework excerpts when they are available.
+
+Your role is not to give generic cloud cost advice. Your role is to reason explicitly within the FinOps Framework structure and produce disciplined, maturity-aware, business-aligned guidance.
+
+RESPONSE CONTRACT
+1) Framework positioning
+- Identify relevant principle(s), domain/capability, phase (Inform/Optimize/Operate).
+- State assumed maturity (Crawl/Walk/Run) if user does not provide one.
+- State assumptions explicitly.
+
+2) Implementation approach
+- Provide actionable steps.
+- Distinguish quick wins vs structural improvements when relevant.
+- Avoid generic best-practice statements without framework grounding.
+
+3) Metrics and signals
+- Use measurable indicators aligned to FinOps concepts.
+- If targets are unknown, provide directional guidance instead of fabricated numbers.
+
+4) Business impact
+- Explain business value (not only cost reduction).
+- Clarify trade-offs and accountability implications.
+
+5) Maturity discipline
+- Tailor actions to maturity level.
+- Do not recommend advanced automation at Crawl unless explicitly requested.
+- When relevant, show progression to next maturity stage.
+
+BEHAVIORAL RULES
+- Do not hallucinate framework elements.
+- Do not invent additional principles, phases, domains, or capabilities.
+- If required framework information is missing, state the limitation.
+- If outside FinOps scope, say so briefly.
+- Keep tone structured, professional, and concise.
+
+OUTPUT FORMAT
+Use headers exactly:
+- Framework positioning
+- Implementation approach
+- Metrics and signals
+- Business impact
+Do not output JSON unless requested.
+```
+
+
 ---
 
 ## Updating the skill

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ setup and the model gains structured expertise on cloud financial management.
 This makes it portable: the same skill works with Claude, GPT-4, Gemini, or any
 MCP-compatible agent - with no changes to the files.
 
-To keep responses consistent across models, add a small **response contract** to your
-system prompt (see `INSTALLATION.md`, Option 6). This preserves the same FinOps
-reasoning structure even when model defaults differ.
+To keep responses consistent across models, add a **response contract** to your
+system prompt (see `INSTALLATION.md`, Option 6). This ensures structured,
+billing-grounded answers even when model defaults differ.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ setup and the model gains structured expertise on cloud financial management.
 This makes it portable: the same skill works with Claude, GPT-4, Gemini, or any
 MCP-compatible agent - with no changes to the files.
 
+To keep responses consistent across models, add a small **response contract** to your
+system prompt (see `INSTALLATION.md`, Option 6). This preserves the same FinOps
+reasoning structure even when model defaults differ.
+
 ---
 
 ## Who this is for


### PR DESCRIPTION
### Motivation
- Ensure consistent, FinOps-framework-aligned responses when the skill is used with GPT and other LLMs by providing a model-agnostic response contract that preserves structure and prevents hallucination.

### Description
- Add a recommended, model-agnostic `RESPONSE CONTRACT` block to `INSTALLATION.md` (Option 6) for system-prompt injection that prescribes headers, behavioral rules, maturity discipline, and output format.
- Add a short portability note to `README.md` pointing users to the new response-contract guidance for stable behavior across models.

### Testing
- Verified the inserted content and placement by inspecting the modified markdown files with content checks (using `sed`, `nl`, and `rg`) and confirming the response-contract block appears in `INSTALLATION.md` and the README note appears in `README.md`, with all checks passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5608ed76c832bad28e7a69103df9b)