### PR TITLE
Add AI dev tools, ITAM references and expand Azure/Snowflake coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ cloud-finops/references/.backups/
 
 # Distribution archive
 cloud-finops.zip
+
+# LinkedIn post drafts
+linkedin-post-*.md

--- a/README.md
+++ b/README.md
@@ -81,10 +81,16 @@ The skill provides accurate, framework-aligned guidance across the following dom
 - **FinOps Framework** - full FinOps Foundation framework, 22 capabilities, maturity model
 - **Databricks** - cluster optimisation, jobs, Spark, Unity Catalog costs
 - **Snowflake** - warehouse optimisation, query tuning, storage, credits
+- **AI coding tools** - Cursor, Claude Code, Copilot, Windsurf, Codex billing models,
+  cost attribution with LiteLLM proxy, seat + usage vs BYOK architecture comparison,
+  optimisation levers, cross-tool spend overlap audit
 - **OCI** - compute, storage, networking optimisation
 - **SaaS asset management (SAM)** - SaaS discovery, license optimization, renewal
   governance, SaaS Management Platforms (SMPs), shadow IT detection, sprawl patterns,
   and the connection to AI transition readiness
+- **ITAM collaboration** - FinOps-ITAM joint operating model, BYOL cost mechanics,
+  marketplace channel governance, Tier 1 vendor co-management, consumption-based SaaS
+  overage monitoring, entitlement integration, and maturity framework
 - **GreenOps and cloud carbon** - carbon measurement tooling, FinOps-to-GreenOps
   integration, carbon-aware workload shifting, region selection, GHG Protocol reporting
 
@@ -236,8 +242,10 @@ cloud-finops-skills/
         ├── finops-framework.md                 ← Full FinOps Foundation framework
         ├── finops-databricks.md                ← Databricks optimisation
         ├── finops-snowflake.md                 ← Snowflake optimisation
+        ├── finops-ai-dev-tools.md             ← AI coding tools (Cursor, Claude Code, etc.)
         ├── finops-oci.md                       ← OCI optimisation
         ├── finops-sam.md                       ← SaaS asset management (SAM)
+        ├── finops-itam.md                     ← ITAM collaboration (BYOL, marketplace, entitlements)
         └── greenops-cloud-carbon.md            ← GreenOps and cloud carbon
 ```
 

--- a/cloud-finops/POWER.md
+++ b/cloud-finops/POWER.md
@@ -51,6 +51,25 @@ keywords:
   - sam
   - smp
   - saas renewal
+  - itam
+  - it asset management
+  - byol
+  - bring your own licence
+  - marketplace governance
+  - licence compliance
+  - entitlement management
+  - vendor negotiation
+  - consumption overage
+  - cursor cost
+  - cursor pricing
+  - copilot cost
+  - windsurf cost
+  - claude code cost
+  - codex cost
+  - ai coding tools
+  - ai dev tools
+  - litellm
+  - developer tool spend
 ---
 
 # Cloud FinOps - Expert Guidance
@@ -90,9 +109,11 @@ philosophy applied to all responses. Then load the domain reference that matches
 | FinOps framework, maturity model, phases, capabilities, personas | `references/finops-framework.md` |
 | Databricks clusters, jobs, Spark optimization, Unity Catalog costs | `references/finops-databricks.md` |
 | Snowflake warehouses, query optimization, storage, credits | `references/finops-snowflake.md` |
+| AI coding tools, Cursor costs, Claude Code costs, Copilot costs, Windsurf costs, Codex costs, dev tool FinOps, BYOK coding agents, LiteLLM proxy | `references/finops-ai-dev-tools.md` |
 | OCI compute, storage, networking optimization | `references/finops-oci.md` |
 | GreenOps, cloud carbon, sustainability, carbon-aware workloads | `references/greenops-cloud-carbon.md` |
 | SaaS management, license optimization, shadow IT, SaaS sprawl, renewal governance, SMP, SAM | `references/finops-sam.md` |
+| ITAM, IT asset management, BYOL, marketplace channel governance, licence compliance, vendor negotiation, FinOps-ITAM collaboration, entitlement management, consumption-based SaaS overages | `references/finops-itam.md` |
 | Multi-domain query | Load all relevant references, synthesize |
 
 ### Reasoning sequence (apply to every response)

--- a/cloud-finops/SKILL.md
+++ b/cloud-finops/SKILL.md
@@ -4,10 +4,11 @@ description: >
   Expert Cloud FinOps guidance covering AI cost management, GenAI capacity planning,
   Anthropic billing, AWS (EC2, Bedrock, Savings Plans, CUR), Azure (reservations,
   OpenAI PTUs, Cost Management), GCP (Vertex AI, Compute Engine, BigQuery), tagging
-  governance, SaaS management (SAM, license optimization, SMPs, shadow IT), Databricks,
-  Snowflake, OCI, GreenOps, and FinOps framework implementation. Use for any query about
-  cloud cost, AI workload economics, commitment discounts, rightsizing, cost allocation,
-  SaaS sprawl, or connecting cloud spend to business value. Built by OptimNow.
+  governance, SaaS management (SAM, license optimization, SMPs, shadow IT), AI coding
+  tools (Cursor, Claude Code, Copilot, Windsurf, Codex), Databricks, Snowflake, OCI,
+  GreenOps, and FinOps framework implementation. Use for any query about cloud cost,
+  AI workload economics, commitment discounts, rightsizing, cost allocation, SaaS sprawl,
+  AI dev tool spend, or connecting cloud spend to business value. Built by OptimNow.
 ---
 
 # Cloud FinOps - Expert Guidance
@@ -40,9 +41,11 @@ domain reference that matches the query.
 | FinOps framework, maturity model, phases, capabilities, personas | `references/finops-framework.md` |
 | Databricks clusters, jobs, Spark optimization, Unity Catalog costs | `references/finops-databricks.md` |
 | Snowflake warehouses, query optimization, storage, credits | `references/finops-snowflake.md` |
+| AI coding tools, Cursor costs, Claude Code costs, Copilot costs, Windsurf costs, Codex costs, dev tool FinOps, seat + usage billing, BYOK coding agents, LiteLLM proxy | `references/finops-ai-dev-tools.md` |
 | OCI compute, storage, networking optimization | `references/finops-oci.md` |
 | GreenOps, cloud carbon, sustainability, carbon-aware workloads | `references/greenops-cloud-carbon.md` |
 | SaaS management, license optimization, shadow IT, SaaS sprawl, renewal governance, SMP, SAM | `references/finops-sam.md` |
+| ITAM, IT asset management, BYOL, marketplace channel governance, licence compliance, vendor negotiation, FinOps-ITAM collaboration, entitlement management, consumption-based SaaS overages | `references/finops-itam.md` |
 | Multi-domain query | Load all relevant references, synthesize |
 
 ### Reasoning sequence (apply to every response)
@@ -128,8 +131,10 @@ premature - they will commit to waste.
 | `finops-framework.md` | Full FinOps Foundation framework: 22 capabilities, personas, domains | ~350 |
 | `finops-databricks.md` | Databricks optimization: 18 patterns for clusters, jobs, Spark, storage | ~180 |
 | `finops-snowflake.md` | Snowflake optimization: 13 patterns for warehouses, queries, storage, credits | ~130 |
+| `finops-ai-dev-tools.md` | AI coding tools: Cursor, Claude Code, Copilot, Windsurf, Codex billing models, cost attribution, optimisation levers | ~400 |
 | `finops-oci.md` | OCI optimization: 6 patterns for compute, storage, networking | ~70 |
 | `finops-sam.md` | SaaS asset management: discovery, license optimization, renewal governance, SMPs, shadow IT, AI transition | ~290 |
+| `finops-itam.md` | FinOps-ITAM collaboration: BYOL mechanics, marketplace channel governance, vendor co-management, consumption monitoring, joint operating model | ~325 |
 | `greenops-cloud-carbon.md` | GreenOps: carbon measurement, carbon-aware workloads, region selection, GHG Protocol | ~150 |
 
 ---

--- a/cloud-finops/references/finops-ai-dev-tools.md
+++ b/cloud-finops/references/finops-ai-dev-tools.md
@@ -1,0 +1,402 @@
+# FinOps for AI Coding Tools
+
+> Cost governance for AI-assisted development tools - covering seat-based IDE assistants
+> (Cursor, GitHub Copilot, Windsurf) and BYOK coding agents (Claude Code, OpenAI Codex).
+> Billing models, cost drivers, attribution patterns, and optimisation levers.
+
+---
+
+## Why AI dev tools need a distinct FinOps approach
+
+AI coding tools do not fit cleanly into existing cost management categories. They are not
+pure SaaS (because variable token costs can exceed the subscription). They are not cloud
+infrastructure (because there are no resources to tag or rightsize). They sit in between,
+and neither your SaaS management playbook nor your cloud FinOps playbook fully covers them.
+
+The adoption pattern is also distinct. A handful of developers try the tool, productivity
+gains spread by word of mouth, and within months the entire engineering organisation is
+using it. Spend follows the same curve, but visibility does not. Finance sees a growing
+invoice with a single number. Engineering cannot explain what is behind it.
+
+This makes AI dev tools a FinOps blind spot in most organisations - growing fast, poorly
+attributed, and governed reactively if at all.
+
+---
+
+## Two billing architectures
+
+The most important structural distinction in this category is who controls the API calls.
+This determines what cost data you can access, what attribution is possible, and which
+optimisation levers are available.
+
+### Seat + usage (vendor-mediated)
+
+Tools like Cursor, GitHub Copilot, and Windsurf manage the API routing. You pay the tool
+vendor, not the model provider. The vendor decides which models are available, how tokens
+are consumed, and what cost data to expose through dashboards or APIs.
+
+**Consequence for FinOps:** your cost visibility is limited to what the vendor chooses to
+surface. You cannot inject metadata at the request level. Attribution depends on the
+vendor's admin tools, which are typically basic - raw data by developer email, no native
+team grouping, no trending, no alerting.
+
+### BYOK / API-direct
+
+Tools like Claude Code and OpenAI Codex (in API key mode) use your own API key to call
+model providers directly. You pay Anthropic or OpenAI, not the tool vendor. The tool is
+a client; the billing relationship is between you and the model provider.
+
+**Consequence for FinOps:** you have full control over the billing pipeline. You can route
+requests through an API gateway (like LiteLLM), inject metadata (team, project, cost
+centre) at the request level, set per-team budgets, and build custom dashboards. But you
+also have no vendor-side cost dashboard unless you build or buy one.
+
+### Architecture comparison
+
+| Dimension | Seat + usage (vendor-mediated) | BYOK / API-direct |
+|---|---|---|
+| Examples | Cursor, Copilot, Windsurf | Claude Code (API key mode), Codex CLI (API key mode) |
+| Who you pay | Tool vendor | Model provider (Anthropic, OpenAI) |
+| Billing model | Subscription + token overage | Direct API token consumption |
+| Cost visibility | Vendor dashboard / Admin API | API provider billing + custom tooling |
+| Attribution control | Limited to vendor-exposed fields | Full (proxy, metadata injection, virtual keys) |
+| Team-level allocation | Manual rollup from developer emails | Native via API gateway team tags |
+| Budget enforcement | Vendor plan caps (if available) | Per-key or per-team budget caps at the gateway |
+
+---
+
+## Cursor (primary deep-dive)
+
+Cursor is the dominant AI coding assistant by adoption. Understanding its cost mechanics
+in detail provides a template for evaluating any seat + usage tool.
+
+### Pricing model
+
+Cursor has two cost layers: a fixed subscription and variable usage-based token charges.
+
+| Plan | Seat cost | Included usage | Overage billing |
+|---|---|---|---|
+| Hobby (free) | $0 | Limited requests and completions | Not available |
+| Pro | $20/month | $20 in usage credits | Per token at model rates |
+| Business | $40/seat/month | $20 in usage credits per seat | Per token at model rates |
+| Enterprise | Custom | Custom | Custom |
+
+Annual billing on Pro reduces the seat cost to ~$16/month.
+
+### Token rate variability
+
+Token rates depend on which model handles the request. This is the highest-leverage cost
+variable. The range is wide:
+
+- **Auto mode** (Cursor's default routing): ~$1.25/MTok input, ~$6.00/MTok output
+- **Budget models** (e.g. Composer 2 Standard): ~$0.50/MTok input
+- **Premium models** (e.g. Claude Opus 4.6): ~$5.00/MTok input, ~$25.00/MTok output
+
+A 10-50x gap exists between the cheapest and most expensive models available in Cursor.
+Even small shifts in model distribution across a team show up on the invoice fast.
+
+### Max mode
+
+Max mode uses the maximum context window for all models, which increases input token
+consumption per request. It is a legitimate feature for working with large codebases, but
+if enabled organisation-wide by default, the token consumption increase may not be
+justified for every use case.
+
+### Cost drivers
+
+Four dimensions explain what is behind a Cursor invoice:
+
+| Dimension | What it reveals | FinOps action |
+|---|---|---|
+| **Model mix** | Which models are consuming tokens | Steer simple completions to cheaper models |
+| **Token type split** (input vs output) | Whether context or generation drives cost | High input = large context windows or max mode; High output = heavy generation tasks |
+| **Per-developer variance** | Outliers in usage patterns | Investigate 5x+ gaps between teams - productivity signal or model mismatch |
+| **Included vs overage ratio** | Whether the plan tier fits actual usage | If most spend is overages, the plan is undersized or usage patterns have shifted |
+
+### Built-in cost tracking and its limits
+
+Cursor's Admin API (Enterprise only) provides structured data by model, token type, and
+developer email. This is useful raw data, but it is not a cost management tool:
+
+- No trending (month-over-month spend changes)
+- No alerting (usage spike detection)
+- No team grouping (developer emails only, no cost-centre rollup)
+- No cross-provider view (Cursor spend is isolated from cloud and direct API spend)
+
+For small teams, pulling Admin API data into a spreadsheet may be sufficient. For
+organisations with dozens or hundreds of developers across multiple teams, you need
+tooling that handles aggregation, team allocation, and alerting. Third-party FinOps
+platforms (Vantage, CloudZero, Finout) support Cursor natively and can provide this
+layer.
+
+---
+
+## Claude Code
+
+Claude Code is a terminal-based coding agent built by Anthropic. It has two access paths,
+each with a different billing model.
+
+### Subscription access
+
+| Plan | Cost | What you get |
+|---|---|---|
+| Pro | $20/month | Claude Code access, Sonnet 4.6 and Opus 4.6, moderate token budget |
+| Max 5x | $100/month | 5x the Pro usage allowance |
+| Max 20x | $200/month | 20x the Pro usage allowance |
+
+On subscription plans, usage is included up to the plan limit. You do not see per-token
+charges, but you hit rate limits when the budget is consumed.
+
+### API key access (BYOK)
+
+When using an API key, Claude Code bills directly against your Anthropic account at
+standard API rates:
+
+| Model | Input ($/MTok) | Output ($/MTok) |
+|---|---|---|
+| Claude Haiku 4.5 | $1.00 | $5.00 |
+| Claude Sonnet 4.6 | $3.00 | $15.00 |
+| Claude Opus 4.6 | $5.00 | $25.00 |
+
+Anthropic's own data indicates the average Claude Code user on API key mode costs ~$6/day,
+with 90% of users staying under $12/day. At sustained full-time usage, expect
+$100-$200/developer/month.
+
+**Important cross-reference:** Claude Code usage on API key mode is subject to the same
+billing mechanics documented in `finops-anthropic.md` - including Fast mode (6x price
+multiplier), long-context pricing cliffs (200K input token threshold), prompt caching
+multipliers, and Batch API discounts. These are not theoretical risks. Fast mode was
+introduced in Claude Code and can silently reprice an entire session.
+
+### Cost tracking for Claude Code
+
+- **ClaudeXray** - dedicated cost tracking tool for Claude Code usage
+- **LiteLLM proxy** - route Claude Code API calls through LiteLLM to inject metadata
+  (team, project, cost centre), enforce per-team budgets, and get usage analytics.
+  LiteLLM auto-detects Claude Code via User-Agent header
+- **Anthropic Console** - basic usage and billing data at the organisation level
+
+---
+
+## OpenAI Codex
+
+Codex is OpenAI's coding agent, available through ChatGPT and as a CLI tool.
+
+### Access paths
+
+**ChatGPT subscription (default):** Codex CLI usage draws from your ChatGPT plan limits
+at no extra per-token charge. ChatGPT Plus at $20/month is the cheapest access path.
+
+**API key mode:** when switched to API key mode, Codex bills per token at standard OpenAI
+API rates:
+
+| Model | Input ($/MTok) | Output ($/MTok) |
+|---|---|---|
+| codex-mini-latest | $1.50 | $6.00 |
+| GPT-5 | $1.25 | $10.00 |
+
+OpenAI claims Codex CLI is approximately 4x more token-efficient than Claude Code, meaning
+the same budget covers more work. This claim should be validated against your own workloads
+before using it for capacity planning. Note that OpenAI's model naming evolves frequently
+(e.g. GPT-5.4, GPT-5.3-Codex, GPT-5.1-Codex-Mini) - verify current model names and rates
+against the OpenAI pricing page.
+
+### Cost tracking
+
+Codex in API key mode is subject to the same attribution options as any OpenAI API usage.
+LiteLLM proxy supports Codex CLI for metadata injection and budget controls, detecting it
+via User-Agent header.
+
+---
+
+## GitHub Copilot and Windsurf (comparison)
+
+These tools are included for reference. Both are seat + usage tools with vendor-mediated
+billing.
+
+### GitHub Copilot
+
+| Plan | Seat cost | Notes |
+|---|---|---|
+| Free | $0 | Limited completions |
+| Pro | $10/month | Individual developers |
+| Pro+ | $39/month | Higher limits, premium models |
+| Business | $19/seat/month | Admin controls, audit logs, IP indemnity |
+| Enterprise | $39/seat/month | Requires GH Enterprise Cloud ($21/seat/month extra) |
+
+Overage charges apply at $0.04 per premium request beyond the monthly allocation.
+
+Enterprise total cost of ownership is $60/seat/month when including the required GitHub
+Enterprise Cloud subscription - a detail that often surprises procurement.
+
+### Windsurf
+
+Windsurf overhauled its pricing in March 2026, replacing variable credits with fixed quota
+tiers:
+
+| Plan | Cost | Credits | Notes |
+|---|---|---|---|
+| Individual tiers | $20 / $40 / $200 per month | Fixed quota per tier | More predictable than token-based |
+| Teams | $40/seat/month | 500 credits/seat | Centralised billing, admin analytics |
+| Enterprise | Custom | Per-seat allocation | SSO, compliance |
+
+Windsurf uses a credit system where each credit costs $0.04 and maps to the underlying
+model provider's API price plus a 20% margin. Add-on credits are available at $10 for 250
+(individual) or $40 for 1,000 (Teams/Enterprise).
+
+---
+
+## Cost attribution patterns
+
+Cost attribution for AI dev tools is harder than for cloud infrastructure. There are no
+resource IDs, no native tagging, and no equivalent of CUR or Cost Management exports. The
+approach depends on the billing architecture.
+
+### For vendor-mediated tools (Cursor, Copilot, Windsurf)
+
+**Vendor Admin API** (where available): pull usage data by developer email, model, and
+token type. Roll up to teams manually or using virtual tagging in a third-party platform.
+Limitations: Enterprise tier often required, no native team grouping, no alerting.
+
+**Third-party FinOps platforms**: tools like Vantage, CloudZero, or Finout support native
+Cursor integrations and can aggregate spend, create virtual team tags from developer
+emails, provide trending and alerting, and show AI dev tool costs alongside cloud
+infrastructure spend.
+
+**Manual spreadsheet**: pull Admin API data periodically, map developer emails to teams,
+build charts. Works for small teams. Does not scale.
+
+### For BYOK tools (Claude Code, Codex in API key mode)
+
+**API gateway / proxy (LiteLLM)**: this is the most powerful option. Route all API calls
+through a self-hosted LiteLLM proxy to:
+
+- Inject metadata at request level (team ID, project, feature, environment)
+- Set per-team or per-project budget caps with automatic enforcement
+- Track usage by any dimension you define
+- Get unified analytics across Claude Code, Codex, and any other tool using the same
+  API keys
+- LiteLLM auto-detects tool type via User-Agent header (Claude Code, Codex CLI, etc.)
+
+**Dedicated tracking tools**: ClaudeXray for Claude Code provides purpose-built cost
+visibility without requiring a proxy setup.
+
+**Provider console**: Anthropic Console and OpenAI Dashboard provide organisation-level
+billing data but limited per-developer or per-team granularity.
+
+### Attribution maturity model
+
+| Maturity | Approach | Granularity |
+|---|---|---|
+| Crawl | Invoice total, headcount-based allocation | Organisation-level |
+| Walk | Admin API or provider console, spreadsheet rollup | Developer-level |
+| Run | API gateway with metadata injection + third-party aggregation | Team / project / feature level |
+
+---
+
+## Optimisation levers
+
+### For seat + usage tools (Cursor, Copilot, Windsurf)
+
+**Model routing governance** - the single highest-impact lever. Ensure expensive reasoning
+models (Opus, GPT-5) are used for tasks that benefit from them, not for routine code
+completions. A team defaulting to the most capable model for every request will spend
+10-50x more than one using the auto-routing or budget models for standard work.
+
+**Max mode / premium mode governance** - make premium modes opt-in per task, not default-on
+organisation-wide. Max mode increases input token consumption on every request by using the
+full context window.
+
+**Plan tier right-sizing** - track the ratio of included usage to overage spend monthly.
+If overages consistently exceed the subscription cost, either upgrade the tier or
+investigate whether usage patterns can be adjusted. If included usage is consistently
+underconsumed, you may be over-provisioned on seats.
+
+**Seat hygiene** - audit active vs licensed seats quarterly. Offboard promptly. Identify
+developers who have not used the tool in 30+ days and reclaim seats.
+
+**Context window policies** - large context windows cost more in input tokens. Not every
+task requires the full codebase as context. Teams that scope context deliberately spend
+less per request.
+
+### For BYOK tools (Claude Code, Codex)
+
+**Model selection** - Sonnet 4.6 at $3/$15 per MTok vs Opus 4.6 at $5/$25 for Claude Code.
+codex-mini at $1.50/$6 vs GPT-5 at $1.25/$10 for Codex. Choose the model that matches the
+task complexity. Default to the more efficient model and escalate only when needed.
+
+**Prompt caching** (Anthropic) - cache reads cost 0.1x the base input price. Cache writes
+cost 1.25x (5-minute TTL) or 2x (1-hour TTL). For repetitive workflows with stable system
+prompts, caching provides significant savings. See `finops-anthropic.md` for the full
+mechanics.
+
+**Batch API** (Anthropic) - 50% discount on all token costs for asynchronous workloads.
+Not applicable to interactive coding sessions, but useful for batch code review, test
+generation, or codebase analysis tasks.
+
+**LiteLLM budget caps** - set hard or soft budget limits per team or project at the proxy
+level. Prevents runaway spend from a single developer or workflow.
+
+**Context window management** - for Anthropic specifically, crossing the 200K input token
+threshold reprices the entire request at premium rates. Monitor input token counts and
+configure alerts before the cliff.
+
+---
+
+## Cross-tool spend overlap
+
+Many engineering organisations use multiple AI coding tools simultaneously - for example,
+Cursor for IDE-based work and Claude Code for terminal-based agentic tasks, with some
+developers also using direct Anthropic or OpenAI API keys for custom scripts.
+
+This is not inherently wasteful. Different tools serve different workflows. But it
+becomes a cost problem when:
+
+- The same developer is paying for Cursor Business ($40/month) and a Claude Max 5x
+  subscription ($100/month) but only actively using one
+- Cursor is routing requests to Claude models while the team also pays for direct
+  Anthropic API usage for the same models
+- Multiple API keys exist across the organisation with no centralised tracking, creating
+  shadow AI spend
+
+### How to audit
+
+1. List all AI dev tool subscriptions (Cursor, Copilot, Windsurf seats) and API accounts
+   (Anthropic, OpenAI)
+2. Map developer overlap - which individuals appear in multiple billing streams
+3. Assess whether the overlap is intentional (different tools for different workflows) or
+   accidental (tool proliferation without governance)
+4. Consolidate API keys where possible and route through a single proxy for unified
+   visibility
+5. Establish a policy on which tools are sanctioned and for which use cases
+
+---
+
+## Pricing comparison (March 2026)
+
+| Tool | Type | Seat cost | Token / usage model | Enterprise option | Proxy-compatible |
+|---|---|---|---|---|---|
+| **Cursor** | Seat + usage | $20 (Pro) / $40 (Business) | $20 included credits + per-token overage | Yes (custom) | No (vendor-mediated) |
+| **Claude Code** | BYOK or subscription | $20 (Pro) / $100 (Max 5x) / $200 (Max 20x) | API key: $3-$25/MTok depending on model | Via Anthropic Enterprise | Yes (API key mode) |
+| **OpenAI Codex** | BYOK or subscription | $20 (ChatGPT Plus) and up | API key: $1.25-$10/MTok depending on model | Via OpenAI Enterprise | Yes (API key mode) |
+| **GitHub Copilot** | Seat + usage | $10 (Pro) / $19 (Business) / $39 (Enterprise) | $0.04/premium request overage | Yes ($60/seat total with GH Enterprise Cloud) | No (vendor-mediated) |
+| **Windsurf** | Seat + usage | $20-$200 (individual) / $40 (Teams) | Credit-based ($0.04/credit, provider cost + 20% margin) | Yes (custom) | No (vendor-mediated) |
+
+---
+
+## Diagnostic questions for a new engagement
+
+1. Which AI coding tools are in use across the organisation, and is adoption sanctioned or shadow IT?
+2. How many seats are active vs licensed? When was the last seat audit?
+3. For seat + usage tools: what is the ratio of included usage to overage spend?
+4. Are developers also using direct API keys (Anthropic, OpenAI) alongside IDE tools?
+5. Is there any cost attribution beyond the total invoice? Can you see spend by team?
+6. Are premium modes (max mode, Fast mode) governed or default-on?
+7. Is an API gateway or proxy in place for BYOK tools?
+8. What is the monthly cost per developer, and how does it compare to the productivity value delivered?
+
+---
+
+---
+
+> *Cloud FinOps Skill by [OptimNow](https://optimnow.io)  - licensed under [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/).*

--- a/cloud-finops/references/finops-azure.md
+++ b/cloud-finops/references/finops-azure.md
@@ -63,19 +63,24 @@ with KQL queries. Use it for:
 
 ### Azure Reservations vs Azure Savings Plans
 
-| Dimension | Azure Reservations | Azure Savings Plans for Compute |
-|---|---|---|
-| Flexibility | Low - locked to specific VM family/region | High - applies across VM families and regions |
-| Discount depth | Higher (up to 72% for some VM families) | Lower but broader coverage |
-| Coverage scope | Specific resource type | Compute (VMs, Dedicated Hosts) |
-| Best for | Stable workloads with known VM types | Variable workloads, mixed VM families |
+| Dimension | Azure Reservations | Azure Savings Plans for Compute | Azure Savings Plans for Databases |
+|---|---|---|---|
+| Flexibility | Low - locked to specific VM family/region | High - applies across VM families and regions | High - applies across database services and regions |
+| Discount depth | Higher (up to 72% for some VM families) | Lower but broader coverage | Up to 35% vs PAYG (varies by service, March 2026 pricing) |
+| Commitment model | Capacity-based (specific SKU) | Spend-based ($/hr) | Spend-based ($/hr) |
+| Coverage scope | Specific resource type | Compute (VMs, Dedicated Hosts) | Database services (SQL DB, PostgreSQL, MySQL, Cosmos DB, SQL MI, MariaDB) |
+| Term options | 1 or 3 years | 1 or 3 years | 1 year only |
+| Best for | Stable workloads with known VM types | Variable workloads, mixed VM families | Evolving database estates, multi-service or multi-region DB workloads |
 
 **Decision framework:**
 1. Analyze 90+ days of historical usage - identify truly steady-state workloads
-2. For workloads with stable VM types: evaluate Reservations (highest discount)
-3. For workloads with variable types or mixed compute: Azure Savings Plans
-4. Layer commitments: Savings Plans first (broadest coverage), then RIs for specific
-   high-stability workloads
+2. For compute with stable VM types: evaluate Reservations (highest discount)
+3. For compute with variable types or mixed families: Savings Plans for Compute
+4. For database workloads across multiple services or regions: Savings Plans for Databases
+5. For stable, single-service database workloads: compare Reservations vs Savings Plans for Databases -
+   Reservations may offer deeper discounts but lock to a specific service and configuration
+6. Layer commitments: Savings Plans first (broadest coverage), then RIs for specific
+   high-stability workloads. For databases, layer DB Savings Plans before service-specific RIs
 
 **Key metrics (same as AWS):**
 - **Utilization:** Target >80%. Below this, you are paying for unused commitment.
@@ -112,6 +117,58 @@ For fault-tolerant, interruptible workloads, Spot offers up to 90% discount over
 
 **Key constraint:** 30-second eviction notice, no SLA guarantees. Start with 20-30% spot
 allocation in non-production, increase based on stability observations.
+
+### Microsoft Azure Consumption Commitment (MACC)
+
+A MACC is a contractual agreement to spend a defined dollar amount on Azure services over
+a set period, typically one to three years. In exchange, Microsoft offers tiered discounts -
+the higher the commitment, the better the terms.
+
+**Critical distinction:** A MACC is a binding obligation, not a forecast. If actual
+consumption falls short of the committed amount by the end of the term, Microsoft issues a
+shortfall invoice. The discount negotiated becomes an additional cost if the target is missed.
+
+**The optimisation paradox**
+
+The MACC is typically sized based on current architecture and projected growth. When a FinOps
+team then rightsizes VMs, decommissions idle resources, and applies Reservations or Savings
+Plans, every dollar saved through optimisation is a dollar that does not draw down against the
+MACC. The burndown rate - how fast actual spend reduces the remaining commitment balance -
+starts to lag. If the gap is significant, the final quarter becomes a scramble to close it.
+
+This is the core tension: the MACC and the FinOps programme can quietly stop working in the
+same direction unless burndown tracking is integrated into optimisation reporting.
+
+**What counts toward MACC drawdown:**
+- Core Azure services consumed under the enrollment
+- Azure Reservations for compute
+- Azure Marketplace purchases carrying the "Azure benefit eligible" badge, transacted through
+  the Azure portal under a subscription tied to the enrollment
+
+**What does not count:**
+- Marketplace purchases made by credit card directly on the Marketplace website (the purchase
+  path matters even for eligible products)
+- Hybrid licensing applied to on-premises workloads
+- Azure Prepayment credits used to fund Marketplace purchases (billing mechanics separate
+  these from MACC consumption, even though it feels like they should count)
+
+**Reporting pitfall:** Azure Cost Management surfaces both actual cost and amortised cost
+views. They produce different burndown numbers. Actual cost reflects when charges are billed.
+Amortised cost spreads upfront Reservation purchases across the coverage term. Without a fixed
+internal standard for which view to use - applied consistently in what gets shared with
+Microsoft - the commitment can appear ahead or behind depending on who pulls the number.
+
+**Operational guidance:**
+- Include MACC burndown rate in FinOps reporting alongside ESR (Effective Savings Rate) and
+  commitment coverage. When burndown slows while ESR improves, that is the signal to act
+- Review required monthly burn rate alongside optimisation metrics in the same session
+- Keep procurement and FinOps in the same cadence review at least quarterly
+- Maintain a forward-looking list of planned software purchases with MACC eligibility confirmed
+  in advance, and pace them to support the burndown trajectory
+- Confirm Marketplace eligibility at planning time, not at purchase time
+- Do not treat Marketplace as a mechanism for spending toward a target - purchases made
+  primarily because they count create vendor relationships, licensing costs, and integration
+  work that were never in the original business case
 
 ---
 
@@ -246,6 +303,40 @@ logical server, region, subscription.
 - Auto-restart after 7 days (PostgreSQL) or 30 days (MySQL) if not manually started
 - HA must be disabled for start/stop to work
 - Ideal for dev/test environments
+
+### Savings Plan for Databases (announced March 2026)
+
+A spend-based commitment discount for eligible database services. Customers commit to a
+fixed hourly spend (e.g. $5/hr) for one year and receive discounted prices - up to 35%
+vs PAYG on select services. The plan applies savings automatically each hour, prioritising
+the usage that delivers the greatest discount first, across services and regions.
+
+**Eligible services:** Azure SQL Database, Azure Database for PostgreSQL, Azure Database
+for MySQL, Azure Cosmos DB, Azure SQL Managed Instance, Azure Database for MariaDB.
+
+**Important caveat:** SQL Server on Azure VMs and SQL Server enabled by Azure Arc also
+consume the plan's hourly commitment, but at normal PAYG rates (no discount). If these
+workloads are in the mix, they reduce the effective savings from the plan. Factor this
+into sizing the hourly commitment.
+
+**Scoping:** Subscription, resource group, management group, or entire billing account.
+
+**Purchase options:** Monthly or upfront payment, optional auto-renewal. Personalised
+recommendations available in Azure Advisor and the Azure portal.
+
+**When to use vs Reservations:**
+- Choose Savings Plan for Databases when the database estate spans multiple services or
+  regions, or when architecture changes (migrations, service swaps) are expected during
+  the commitment period.
+- Choose Reservations when a single database service runs stably in a fixed configuration
+  and the deeper RI discount outweighs the flexibility benefit.
+- Layer both: use the Savings Plan for broad baseline coverage, then add RIs for the
+  most stable, high-spend database workloads.
+
+**Pricing note (March 2026):** The "up to 35%" figure is based on Azure SQL Database
+Serverless over a 1-year term. Actual discounts vary by service and usage pattern. Azure
+Pricing Calculator and pricing pages had not yet been updated at time of announcement -
+verify current rates before purchasing.
 
 ### Database architecture principles
 
@@ -1015,11 +1106,12 @@ In Azure, it’s common for public IP addresses to be created as part of virtual
 **Transactable Vs Non Transactable Confusion In Azure Marketplace**
 Service: Azure Marketplace | Type: Commitment Misalignment
 
-Azure Marketplace offers two types of listings: transactable and non-transactable. Only transactable purchases contribute toward a customer’s MACC commitment.
+Azure Marketplace offers two types of listings: transactable and non-transactable. Only transactable purchases contribute toward a customer’s MACC commitment. See the "Microsoft Azure Consumption Commitment (MACC)" section under Commitment discounts for full drawdown mechanics, including what counts and what does not.
 
 - Prefer transactable listings in Azure Marketplace whenever MACC utilization is a priority
 - Validate SKU eligibility against Microsoft’s Procurement Playbook or MACC eligibility lists
 - Standardize sourcing templates and procurement workflows to explicitly document whether the offer contributes to MACC
+- Confirm that the purchase is transacted through the Azure portal under a subscription tied to the enrollment - credit card purchases on the Marketplace website do not count toward MACC even for eligible products
 
 **Lifecycle Visibility Gaps Inflating Renewal Costs In Azure Marketplace**
 Service: Azure Marketplace | Type: Contract Lifecycle Mismanagement

--- a/cloud-finops/references/finops-itam.md
+++ b/cloud-finops/references/finops-itam.md
@@ -1,0 +1,326 @@
+# FinOps and ITAM - Collaborating Across the Technology Estate
+
+> Where FinOps and ITAM intersect: shared governance, marketplace channel strategy,
+> BYOL cost mechanics, commitment co-ordination, compliance risk, and joint operating
+> models. Covers the collaboration patterns that neither discipline can execute alone.
+> For SaaS-specific management (discovery, sprawl, SMPs), see `finops-sam.md`.
+
+---
+
+## Why FinOps needs ITAM (and vice versa)
+<!-- ref:itam-finops-collab -->
+
+FinOps manages cloud cost through visibility, allocation, and optimisation. ITAM manages
+the broader technology estate through governance, compliance, and contractual accountability.
+Neither discipline covers the full picture on its own, and the gap between them is growing.
+
+The State of FinOps 2026 survey shows FinOps-ITAM collaboration up 20% year over year.
+The driver is practical: modern technology estates blend consumption-based cloud, seat-based
+SaaS, perpetual licenses, BYOL deployments, and marketplace purchases. A single vendor
+relationship (Microsoft, Oracle, SAP) can span all of these billing models simultaneously.
+Managing cost without managing entitlements - or managing entitlements without cost
+telemetry - creates blind spots that lead to overspend, audit exposure, and missed
+negotiation leverage.
+
+**What ITAM brings to FinOps:**
+- Entitlement data: what the organisation owns, what it is allowed to deploy, and under what terms
+- Compliance tracking: whether deployed assets match contractual use rights
+- Vendor audit preparedness: documentation and processes to defend against vendor audits
+- Hardware and software lifecycle management: depreciation schedules, refresh cycles, end-of-support dates
+- Contract intelligence: renewal terms, price escalation clauses, termination notice periods
+
+**What FinOps brings to ITAM:**
+- Real-time usage telemetry: what is actually being consumed, not just what is deployed
+- Cost attribution: linking spend to teams, products, and business outcomes
+- Commitment mechanics: how cloud discounts (RIs, Savings Plans, CUDs) interact with license decisions
+- Forecasting: consumption projections that inform procurement and renewal decisions
+- Anomaly detection: early warning when usage patterns deviate from contracted expectations
+
+---
+
+## ITAM components relevant to FinOps
+
+ITAM traditionally operates as three interdependent components:
+
+**Software Asset Management (SAM)** oversees software licensing, renewals, and audit
+readiness. This is where the overlap with FinOps is strongest - see `finops-sam.md` for
+detailed SaaS management guidance including discovery methods, sprawl patterns, SMP
+landscape, and governance models.
+
+**Hardware Asset Management (HAM)** tracks physical and virtual infrastructure assets.
+Relevant to FinOps during cloud migrations (parallel running costs), hybrid deployments
+(on-premises + cloud), and hardware refresh decisions that trigger cloud workload shifts.
+
+**Service and Cloud Asset Management** manages SaaS, PaaS, and hybrid assets through
+discovery and configuration management databases (CMDBs). This component increasingly
+overlaps with FinOps tooling as cloud billing platforms and ITAM platforms converge.
+
+---
+
+## Tier 1 vendors requiring joint FinOps-ITAM management
+
+These vendors have blended pricing models that cross the FinOps-ITAM boundary. Managing
+them from one discipline alone creates financial or compliance blind spots.
+
+| Vendor | Key products | Billing model | Why both disciplines are needed |
+|---|---|---|---|
+| Microsoft | Microsoft 365, Azure | Seats + cloud consumption | E3/E5 tier optimisation requires usage data (FinOps) and entitlement tracking (ITAM). Azure Hybrid Benefit depends on on-premises licence eligibility |
+| AWS | EC2, S3, RDS, Marketplace | Cloud consumption + marketplace subscriptions | Marketplace purchases consume cloud commitments (EDP). ITAM needs billing data to validate entitlements |
+| Google | GCP, Workspace | Workspace seats + GCP consumption | Workspace licence tiers need usage analysis. GCP CUDs need consumption forecasting |
+| Oracle | Oracle DB, Fusion, OCI | Core-based DB licensing + cloud consumption | BYOL to OCI requires precise entitlement mapping. Processor-based licensing creates audit exposure |
+| Salesforce | Sales Cloud, Data Cloud | CRM seats + data/AI credits | Consumption credits can spike unpredictably. Seat licences accumulate as shelfware |
+| SAP | S/4HANA, BTP | ERP subscriptions + indirect access | Indirect/digital access licensing creates hidden compliance costs |
+| Adobe | Creative Cloud, Experience Cloud | Seat subscriptions + e-sign transactions + AI credits | Named-user vs shared-device licensing affects cost significantly |
+| ServiceNow | Now Platform, ITSM | Subscription entitlements | Entitlement structures are complex and often misaligned with actual usage |
+| Broadcom/VMware | VCF, vSphere, NSX | Core/CPU subscriptions + VCF bundles | Post-acquisition licensing changes require entitlement re-evaluation |
+
+---
+
+## Marketplace channel governance
+
+Cloud marketplace purchasing (AWS Marketplace, Azure Marketplace, GCP Marketplace) is
+growing rapidly and creates new problems that require both FinOps and ITAM co-ordination.
+
+### The problem
+
+Engineering teams buy software through marketplaces without centralised oversight. This
+creates three categories of risk:
+
+**Entitlement fragmentation.** Licences are split between SAM tools, vendor portals, and
+multiple marketplace tenants. ITAM cannot prove compliance or claim BYOL rights when
+marketplace SKUs are not mapped to existing contracts.
+
+**Commitment collision.** Marketplace spend draws down cloud commitments (EDP on AWS, MACC
+on Azure) that FinOps is actively managing. Meanwhile, Procurement may hold separate
+Enterprise Agreements with the same vendor. These competing commitments create risk of
+underutilisation, overcommitment, or duplicated commercial obligations.
+
+**Governance gaps.** Weak policy on who can buy what, through which channel, and under
+which legal entity. Self-service purchasing increases exposure to shadow IT, uncontrolled
+spend, and misaligned commitments.
+
+### Practical steps
+
+1. **Discover and baseline.** Aggregate marketplace invoices and usage records from all
+   clouds. Tag each line item to a vendor, product, and business owner. Reconcile against
+   ITAM entitlement data and existing contracts to identify overlaps and gaps.
+
+2. **Define channel strategy per vendor.** For top vendors, agree on a preferred route to
+   market by scenario - for example, dev/test or short-term projects via marketplace,
+   strategic workloads via EA. Document rules for EA/BYOL vs marketplace, who can approve
+   private offers, and what thresholds trigger Deal Desk involvement.
+
+3. **Integrate processes and tooling.** Implement workflows so marketplace private offers
+   and SaaS subscriptions follow the same approval and tagging standards as direct
+   purchases. Normalise SKUs between the SAM tool, CMDB, and cloud billing.
+
+4. **Operate a joint marketplace review.** Monthly review where FinOps and ITAM assess
+   marketplace pipeline, renewals, and spend trends against commitment targets and
+   entitlement positions.
+
+5. **Optimise and renegotiate.** Use the combined view of marketplace and EA spend to
+   negotiate better discounts, adjust commitment levels, and consolidate vendors where
+   overlapping tools are identified.
+
+### Quick wins
+- Enforce a "no credit card marketplace purchases" rule and move to central accounts
+- Stand up a joint dashboard of marketplace spend by vendor, tagged with owner and channel
+- Reconcile the top 5 marketplace vendors against existing EA entitlements
+
+### Anti-patterns
+- Treating marketplaces as a separate channel owned only by engineering or only by procurement
+- Assuming marketplace always equals better (or worse) pricing without modelling commit impact and entitlement rights
+- Tool-only fixes without governance processes and a joint operating model
+
+---
+
+## BYOL strategy and cost mechanics
+
+Bring Your Own Licence (BYOL) allows organisations to use existing on-premises licences
+in cloud environments. When managed correctly, it avoids paying for the same licence
+twice. When managed poorly, it creates compliance exposure and hidden costs.
+
+### Where BYOL creates FinOps-ITAM dependency
+
+- **Eligibility verification** requires ITAM entitlement data. Not all licences are portable.
+  Microsoft SQL Server, Windows Server, and Oracle DB each have different mobility rules,
+  and these rules change with vendor programme updates.
+- **Cost modelling** requires FinOps consumption data. The financial benefit of BYOL depends
+  on the cloud instance type, region, and commitment discount already in place.
+- **Compliance monitoring** requires both. A licence deployed via BYOL that exceeds its
+  contractual use rights (wrong edition, wrong core count, wrong deployment model) creates
+  audit exposure that neither team can detect alone.
+
+### Common BYOL scenarios
+
+**Azure Hybrid Benefit (AHB):** Windows Server and SQL Server licences with active Software
+Assurance can be applied to Azure VMs, reducing compute costs by up to 40-80%. Requires
+ITAM to confirm SA coverage and FinOps to track which VMs have AHB applied vs which are
+paying full price. See `finops-azure.md` for AHB-specific optimisation patterns.
+
+**AWS Licence Manager:** Tracks licence usage across EC2 instances. Requires ITAM to define
+licence rules and FinOps to monitor consumption against those rules.
+
+**Oracle on cloud:** Oracle's processor-based licensing on cloud is complex and audit-sensitive.
+Deploying Oracle DB on AWS or Azure without precise core-to-licence mapping creates
+significant financial risk. Joint FinOps-ITAM review is essential before any Oracle cloud
+migration.
+
+---
+
+## Joint operating model
+
+### Governance alignment
+
+The most effective FinOps-ITAM collaboration happens through shared forums, not through
+RACI matrices that reinforce boundaries.
+
+| Practice | Purpose | Cadence |
+|---|---|---|
+| Joint cost and compliance review | Review spend trends, licence utilisation, compliance posture, and upcoming renewals | Monthly |
+| Marketplace channel review | Assess marketplace pipeline, spend vs commitment targets, entitlement gaps | Monthly |
+| Pre-renewal checkpoint | Validate usage data, entitlement position, and negotiation strategy before vendor renewals | Pre-renewal (60-90 days before) |
+| Vendor strategy review | Review channel mix, marketplace volume, EA performance, and consolidation opportunities per strategic vendor | Quarterly |
+| Deal Desk engagement | Joint FinOps-ITAM-Procurement review for any commitment above a defined threshold | As needed |
+
+### Shared data requirements
+
+FinOps and ITAM operate from different systems of record. The collaboration only works when
+these systems are connected - not necessarily in a single platform, but with consistent,
+reconcilable data.
+
+| Data domain | Typical FinOps source | Typical ITAM source | Integration requirement |
+|---|---|---|---|
+| Usage and consumption | Cloud billing (CUR, Cost Management, BigQuery export) | N/A | ITAM needs consumption signals for licence right-sizing |
+| Entitlements and contracts | N/A | SAM tool, contract repository, CMDB | FinOps needs entitlement data for BYOL and commitment modelling |
+| Cost allocation | Cloud cost platform, tagging | CMDB, application portfolio | Unified tagging and naming standards across cloud and on-premises |
+| Marketplace purchases | Cloud billing line items | SAM tool (if integrated) | SKU normalisation between cloud billing and SAM inventory |
+| Forecasts | FinOps forecasting models | ITAM renewal calendar | Shared demand signal for procurement and budget planning |
+
+### Bi-directional skills development
+
+Effective collaboration requires both teams to understand each other's domain. Organisations
+that invest in cross-training consistently report better cost avoidance outcomes.
+
+- FinOps teams need: licensing fundamentals (perpetual vs subscription, use rights, audit triggers), contract structure awareness, compliance risk vocabulary
+- ITAM teams need: cloud billing mechanics (consumption models, commitment discounts, reserved pricing), cost allocation principles, FinOps maturity stages
+
+---
+
+## Consumption-based SaaS monitoring
+
+Consumption-based SaaS products (where billing is tied to usage units rather than fixed
+seats) require specific monitoring to prevent overage charges. This is distinct from
+seat-based SaaS sprawl management covered in `finops-sam.md`.
+
+### The risk
+
+A company purchases a consumption-based SaaS application with an agreed number of
+consumption units per SKU. When consumption of one SKU increases significantly beyond
+contracted limits, overage charges apply - often at a premium rate.
+
+### Monitoring framework
+
+1. At contract start, identify all SKUs, their consumption limits, whether overages are
+   charged or consumption stops, and the overage rates.
+2. Ingest consumption data at SKU level into a monitoring platform.
+3. Configure anomaly detection or threshold-based alerting at meaningful levels before
+   overages occur (e.g., 70%, 85%, 95% of limit).
+4. When anomalies are detected, FinOps, ITAM, and Engineering collaborate to determine
+   root cause: configuration issue, new use case, or genuine growth.
+5. Maintain a baseline forecast and use forward-looking models to project consumption
+   against contract limits.
+
+### Key metrics
+- % consumed / total contracted units (per SKU)
+- Total overage charges (currency)
+- Forecast accuracy: projected vs actual consumption at renewal
+- Number of SKUs with no monitoring in place
+
+### Anti-patterns
+- Paying overages without investigating root cause
+- Renewing at the same commitment level without reviewing actual usage data
+- Planning to monitor "later" - even manual tracking is better than no tracking
+
+---
+
+## Application onboarding checklist
+
+When new SaaS or cloud-hosted applications are introduced, cost allocation and licence
+compliance gaps created at onboarding compound over time. Both FinOps and ITAM should be
+involved before the application goes live.
+
+1. **Pre-onboarding assessment**
+   - Validate licensing model and subscription tiers
+   - Check for duplicate SaaS to avoid sprawl (ideally resolved at procurement stage)
+   - Identify any burstable or consumption-based charges within hyperscaler accounts
+   - Align enterprise tagging standards for cost allocation
+
+2. **Contract and commitment alignment**
+   - Review cloud commitments against vendor licensing models
+   - Set up budget notifications and approval gates for consumption spending
+
+3. **Integration and tooling**
+   - Connect ITAM/SAM and FinOps tooling
+   - Add a complete record to the software asset inventory
+
+4. **Operational governance**
+   - Define cadence for usage reviews and renewal checkpoints
+   - Implement alerting for non-compliance and cost anomalies
+
+5. **Recurring optimisation**
+   - Benchmark performance and cost trends
+   - Review licence reclamation and rightsizing opportunities on a defined schedule
+
+---
+
+## Automated governance (advanced)
+
+At Run maturity, organisations deploy automated agents or agentless connectors across
+hybrid environments for continuous inventory, compliance, and cost governance.
+
+### What automated governance delivers
+- Unified inventory trusted by FinOps, ITAM, Security, and Procurement
+- Real-time actions: tag corrections, resource shutdowns, licence re-harvesting
+- Reduced manual audit effort
+- Waste reduction from orphaned resources and unused licences
+
+### Prerequisites
+- Established and consistent tagging strategy
+- Strong data quality and attribution across reporting systems
+- Agreed governance policies with defined thresholds and remediation actions
+
+### Key metrics
+- Compliance status of deployed resources
+- % of resources with accurate allocation metadata
+- Cost reduction from automated licence re-harvesting or resource shutdowns
+
+### Anti-patterns
+- Attempting inventory tracking without a unified data source
+- Deploying BYOL without implementing compliance monitoring within 30 days
+- Automating governance rules without cross-team agreement on thresholds and actions
+
+---
+
+## Crawl / Walk / Run maturity for FinOps-ITAM collaboration
+
+| Indicator | Crawl | Walk | Run |
+|---|---|---|---|
+| Organisational alignment | Separate teams, no co-ordination | Regular collaboration meetings, shared KPIs emerging | Integrated practice or unified leadership, shared data and goals |
+| Data integration | Siloed systems, no shared data | Key systems linked (billing + SAM), manual reconciliation | Automated data pipelines, unified schemas, single source of truth |
+| Marketplace governance | No visibility into marketplace purchases | Channel strategy defined for top vendors, monthly reviews | Automated checks, Deal Desk integration, commitment-aware purchasing |
+| BYOL management | No tracking of licence use in cloud | Key licences tracked (SQL Server, Windows), periodic review | Automated eligibility verification, continuous compliance monitoring |
+| Vendor negotiation | FinOps and ITAM negotiate separately | Joint preparation for major renewals | Combined volume leverage, channel mix optimisation, unified vendor strategy |
+| Consumption monitoring | No SKU-level visibility | Top applications monitored, manual threshold alerts | Automated anomaly detection, forward-looking forecasting, proactive optimisation |
+
+Always assess maturity before recommending changes. An organisation where FinOps and ITAM
+have never co-ordinated should start with a shared monthly review of the top 5 vendors -
+not with an automated governance platform.
+
+---
+
+> Sources: FinOps Foundation (FinOps & ITAM: Collaborating to Optimize Cost, Risk, and
+> Value, March 2026; Practical Scenarios: Planning & Procurement, March 2026; Practical
+> Scenarios: Deliver & Govern, March 2026; State of FinOps 2026).
+
+> *Cloud FinOps Skill by [OptimNow](https://optimnow.io) - licensed under [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/).*

--- a/cloud-finops/references/finops-snowflake.md
+++ b/cloud-finops/references/finops-snowflake.md
@@ -5,6 +5,71 @@
 
 ---
 
+## Snowflake FinOps fundamentals
+
+Snowflake differs from IaaS providers (AWS, Azure, GCP) in ways that require a distinct FinOps approach. Understanding the model before optimizing it is essential.
+
+### The credit abstraction
+
+Snowflake does not bill for vCPUs or instance-hours directly. It bills in **Snowflake credits**, which are an abstraction layer over actual compute. The dollar value of a credit depends on your edition (Standard, Enterprise, Business Critical) and cloud region. This indirection complicates cost attribution: you cannot map spend directly to infrastructure resources the way you would with EC2 or Compute Engine.
+
+### Compute and storage are architecturally separated
+
+Multiple virtual warehouses (VWH) can read the same storage simultaneously. This is a core Snowflake design principle, not a configuration option. The FinOps consequence: warehouse proliferation is structurally incentivized — teams create dedicated warehouses to simplify chargebacks, which produces a fleet of chronically underutilized warehouses. On AWS you oversize one instance; on Snowflake you oversize per warehouse, per team, per workload.
+
+### 60-second billing minimum
+
+Warehouses bill per second, but with a 60-second minimum on every cold start. A warehouse that suspends and restarts frequently for short queries can cost more than one that runs continuously. This is counter-intuitive and has no direct equivalent in IaaS billing models (except AWS Lambda to a limited extent).
+
+### Hidden cost categories specific to Snowflake
+
+These cost drivers do not appear in warehouse credit consumption and are frequently overlooked:
+
+| Category | Trigger | Risk |
+|---|---|---|
+| **Time Travel storage** | High-churn tables (INSERT/UPDATE/DELETE) | Historical snapshots accumulate silently |
+| **Auto-Clustering** | Enabled on tables that change frequently | Continuous background recluster consumes credits outside warehouse billing |
+| **Snowpipe** | High-frequency ingestion of small files | Per-file overhead charge regardless of file size; 10,000 small files >> 10 equivalent large files |
+| **Search Optimization Service** | Enabled and forgotten | Ongoing storage and maintenance cost with no query benefit if access patterns change |
+| **Materialized Views** | Stale or low-usage MVs left active | Refresh costs persist even when the MV is rarely queried |
+
+### Commitment model vs. IaaS reserved capacity
+
+AWS Savings Plans and Reserved Instances commit to a compute capacity type and apply automatically against usage. Snowflake's equivalent is **pre-purchased credits** — you buy a credit pool at a volume discount. If you over-estimate consumption, unused credits are lost. There is no equivalent to a Compute Savings Plan that flexibly covers all compute workloads. Commitment sizing must be based on realistic historical consumption, not aspirational usage.
+
+### Cost attribution: roles and query logs, not tags
+
+On AWS, cost allocation relies primarily on resource tags feeding into CUR. Snowflake supports Object Tagging, but the practical attribution model is different:
+
+- **Virtual warehouses** are the primary cost boundary — who uses which warehouse defines the cost center split
+- **ACCOUNT_USAGE.QUERY_HISTORY** is the primary data source for tracing which user, role, or BI tool consumed what
+- **Resource Monitors** are the governance mechanism for setting credit budgets per warehouse
+
+FinOps practitioners coming from AWS instinctively look for tags. On Snowflake, the answer is in the access model and query logs. Tagging governance is still relevant for storage objects, but it is not the primary attribution mechanism.
+
+### IaaS vs. Snowflake FinOps comparison
+
+| Dimension | AWS IaaS | Snowflake |
+|---|---|---|
+| Cost unit | $ / resource | Snowflake credits |
+| Compute model | Always provisioned | Elastic, billed on activity |
+| Hidden costs | Networking, EBS snapshots | Time Travel, Auto-Clustering, Snowpipe, MV refresh |
+| Commitment mechanism | RIs / Savings Plans | Pre-purchased credit pools |
+| Cost attribution | Tags on resources → CUR | Warehouses + roles + QUERY_HISTORY |
+| Budget governance | AWS Budgets + tag policies | Resource Monitors per warehouse |
+
+### Key diagnostic questions for a new Snowflake account
+
+1. How many virtual warehouses exist, and what is the average utilization of each?
+2. What is the auto-suspend setting per warehouse, and is it appropriate for the workload type?
+3. Which tables have Auto-Clustering enabled, and what is their churn rate?
+4. What is the Time Travel retention period per table or schema?
+5. Is Snowpipe ingesting small files at high frequency?
+6. Are there pre-purchased credits, and what is the burn rate vs. the commitment expiry?
+7. How is cost attributed today — by warehouse, by role, or not at all?
+
+---
+
 ## Compute Optimization Patterns (5)
 
 **Inefficient Execution Of Repeated Queries**


### PR DESCRIPTION
## Summary
- **New:** `finops-ai-dev-tools.md` - covers Cursor, Claude Code, OpenAI Codex, GitHub Copilot, and Windsurf billing models, cost attribution patterns, and optimisation levers
- **New:** `finops-itam.md` - FinOps-ITAM collaboration including Tier 1 vendor governance, marketplace channel strategy, BYOL mechanics, and maturity model
- **Updated:** `finops-azure.md` - Azure Savings Plans for Databases, MACC burndown mechanics, database optimisation patterns
- **Updated:** `finops-snowflake.md` - Snowflake credit abstraction model, hidden cost categories (Time Travel, Auto-Clustering, Snowpipe, Search Optimization)
- Routing tables updated in SKILL.md and POWER.md, README coverage expanded
- LinkedIn post drafts added to .gitignore

## Test plan
- [ ] Ask an AI dev tools cost question and verify finops-ai-dev-tools.md is loaded
- [ ] Ask an ITAM/vendor governance question and verify finops-itam.md is loaded
- [ ] Ask about Azure database savings plans and verify expanded Azure content is used
- [ ] Ask about Snowflake hidden costs and verify new fundamentals section is referenced
- [ ] Verify SKILL.md description is under 1024 characters

🤖 Generated with [Claude Code](https://claude.com/claude-code)