### PR TITLE
Add commitment strategy frameworks, decision trees, and portfolio liquidity for AWS and Azure

### DIFF
--- a/cloud-finops/SKILL.md
+++ b/cloud-finops/SKILL.md
@@ -120,9 +120,9 @@ premature - they will commit to waste.
 | `finops-for-ai.md` | AI cost management, LLM economics, agentic patterns, ROI framework | ~400 |
 | `finops-ai-value-management.md` | AI investment governance: AI Investment Council, stage gates, incremental funding, practice operations, value metrics | ~265 |
 | `finops-genai-capacity.md` | GenAI capacity models: provisioned vs shared, traffic shape, spillover, waste types, cross-provider comparison | ~220 |
-| `finops-aws.md` | AWS FinOps + 128 optimization patterns: CUR, Cost Explorer, EC2, RIs, Savings Plans, EDP negotiation, RDS strategy, waste detection | ~1730 |
+| `finops-aws.md` | AWS FinOps + 128 optimization patterns: CUR, Cost Explorer, EC2, RIs, Savings Plans, EDP negotiation, RDS strategy, database commitment decision tree, waste detection | ~1860 |
 | `finops-bedrock.md` | AWS Bedrock billing: model pricing, provisioned throughput, batch inference, CloudWatch metrics, cost allocation | ~200 |
-| `finops-azure.md` | Azure FinOps + 48 optimization patterns: reservations, Advisor, AHB, EA-to-MCA transition, waste detection | ~1070 |
+| `finops-azure.md` | Azure FinOps + 48 optimization patterns: reservations, Savings Plans, AHB, compute/database commitment decision trees, portfolio liquidity, EA-to-MCA transition, waste detection | ~1530 |
 | `finops-azure-openai.md` | Azure OpenAI Service: PTU reservations, spillover, GPT model pricing, prompt caching, fine-tuning costs | ~260 |
 | `finops-anthropic.md` | Anthropic billing: Claude Opus/Sonnet/Haiku pricing, Fast mode, long-context cliffs, prompt caching, Batch API, governance | ~175 |
 | `finops-gcp.md` | GCP optimization: 26 patterns across Compute Engine, Cloud SQL, GCS, networking | ~260 |

--- a/cloud-finops/references/finops-aws.md
+++ b/cloud-finops/references/finops-aws.md
@@ -363,23 +363,46 @@ a natural rebalancing rhythm.
 
 ### Phased purchasing
 
-Never buy the full commitment in a single transaction. Purchase in blocks of 10-25%
-of the target commitment to create a portfolio of overlapping terms with staggered
-expiry dates.
+Never buy the full commitment in a single transaction. Purchase in blocks to create
+a portfolio of overlapping terms with staggered expiry dates. The cadence and block
+size should match your consumption profile - not a fixed rule.
 
 **Why phased purchasing matters:**
 - **Reduces lock-in risk:** if architecture changes mid-term, only the current block
   is at risk - not the entire commitment
 - **Creates natural re-evaluation points:** each purchase cycle forces a review of
   utilisation, workload stability, and architecture direction
-- **Smooths cash flow:** Upfront payments are spread across quarters instead of
-  concentrated in a single month
+- **Smooths cash flow:** Upfront payments are spread over time instead of concentrated
+  in a single month
 - **Enables course correction:** if utilisation drops on existing commitments, you
   can pause or reduce the next block instead of over-committing further
 - **Captures pricing improvements:** newer instance families and Graviton adoption
   can be reflected in subsequent blocks
 
-**Phased purchasing framework:**
+**Cadence and block size by consumption profile:**
+
+The purchasing cadence should follow consumption volatility. The more variable the
+workload, the shorter the purchase cycle and the smaller each block. The principle:
+your commitment refresh rate should be faster than your workload change rate.
+
+| Consumption profile | Examples | Cadence | Block size | Rationale |
+|---|---|---|---|---|
+| Steady, predictable | Enterprise ERP, internal tools, back-office systems | Quarterly | 20-25% | Workloads barely move quarter to quarter. Larger blocks capture deeper coverage faster. |
+| Moderate growth or gradual shifts | SaaS platforms, B2B applications, steady API services | Monthly to bi-monthly | 10-15% | Growth adds new capacity regularly. Smaller blocks incorporate new workloads without over-committing to the old baseline. |
+| Seasonal or event-driven | Retail (holiday peaks), media (live events), gaming (launches) | Monthly to weekly | 5-10% | Demand swings mean the baseline shifts frequently. Small blocks commit only to the proven floor; peaks stay on On-Demand/Spot. |
+| Highly volatile or early-stage | Startups, experimental workloads, pre-product-market-fit | Weekly or do not commit | 5% or less | If you cannot predict next month, do not lock in for a year. Stay on On-Demand with Spot until patterns stabilise. |
+
+**The cadence can shift over time for the same company.** A retail company might buy
+quarterly in Q1-Q3 (steady baseline) and switch to weekly in Q4 (holiday ramp) to
+avoid committing to peak capacity that evaporates in January. A SaaS company might
+start with monthly cadence during a growth phase and shift to quarterly once the
+growth rate stabilises.
+
+**Block size and cadence are inversely related:** higher frequency = smaller blocks.
+This keeps the total portfolio size similar but distributes the risk across more,
+smaller decisions.
+
+**Phased purchasing framework (quarterly example for steady consumption):**
 
 ```
 Quarter 1: Buy 20-25% of target commitment (the floor you are certain about)
@@ -400,7 +423,21 @@ Quarter 4: Evaluate whether to buy more or hold
   → Begin planning the next cycle
 ```
 
-**Portfolio view - staggered expiry example (1-year terms):**
+**Phased purchasing framework (monthly example for moderate growth):**
+
+```
+Month 1: Buy 10-12% of target (proven steady-state floor)
+  → Monitor utilisation for 2 weeks
+Month 2: Buy next 10-12% block
+  → Incorporate any new workloads that stabilised last month
+Month 3: Buy next 10-12% block
+  → Review: are earlier blocks still >80% utilised?
+Months 4-8: Continue at 10-12% per month, pausing if utilisation drops
+Month 9+: Evaluate - early blocks approaching renewal
+  → Shift to maintenance mode: renew justified blocks, drop the rest
+```
+
+**Portfolio view - staggered expiry example (1-year terms, quarterly cadence):**
 
 | Block | Purchased | Expires | % of total | Instrument |
 |---|---|---|---|---|
@@ -421,14 +458,16 @@ term, the smaller each block should be - because the risk of architecture change
 over 3 years is substantially higher than over 1 year.
 
 **Portfolio management cadence:**
-- **Monthly:** review SP/RI utilisation dashboard. Flag any commitment below 80%.
-- **Quarterly:** evaluate whether to purchase the next block, adjust the instrument
-  mix, and review upcoming expiries.
+- **At each purchase cycle** (weekly/monthly/quarterly depending on profile): review
+  SP/RI utilisation dashboard. Flag any commitment below 80%. Decide whether to buy
+  the next block, adjust the instrument mix, or pause.
 - **At each expiry:** do not auto-renew. Re-evaluate the workload: has it grown,
   shrunk, migrated to a different service, or been decommissioned? Renew only what
   is still justified.
+- **Quarterly (regardless of purchase cadence):** strategic review of commitment
+  coverage ratio, instrument mix, and upcoming expiries.
 - **Annually:** review the overall commitment strategy against the organisation's
-  cloud roadmap. Adjust the target coverage ratio and instrument mix.
+  cloud roadmap. Adjust the target coverage ratio, cadence, and instrument mix.
 
 **Common commitment mistakes:**
 - Buying commitments before right-sizing (committing to waste)

--- a/cloud-finops/references/finops-aws.md
+++ b/cloud-finops/references/finops-aws.md
@@ -85,59 +85,401 @@ unexpected spending increases and sends alerts via SNS or email.
 
 ## Commitment discounts
 
-### Reserved Instances vs Savings Plans
+### Compute commitment instruments
 
-The single most common commitment discount question. The answer depends on workload
-characteristics, not a general preference.
+AWS provides five distinct instruments for reducing compute costs. Each has different
+flexibility, discount depth, and risk profile. The most common mistake is treating
+them as alternatives when they are designed to be layered.
 
-| Dimension | Reserved Instances | Savings Plans |
+**Instrument comparison:**
+
+| Instrument | Discount depth | Flexibility | Commitment type | Term | Covers |
+|---|---|---|---|---|---|
+| EC2 Standard RI | Up to 72% | Lowest - locked to instance type, region, OS, tenancy | Capacity reservation + rate | 1yr or 3yr | EC2 only |
+| EC2 Convertible RI | Up to 66% | Medium - can change instance family, OS, tenancy | Rate only (no capacity) | 3yr only | EC2 only |
+| EC2 Instance Savings Plan | Up to 72% | Medium - locked to instance family and region | Spend-based ($/hr) | 1yr or 3yr | EC2 only |
+| Compute Savings Plan | Up to 66% | Highest - any instance family, region, OS | Spend-based ($/hr) | 1yr or 3yr | EC2, Fargate, Lambda, SageMaker |
+| Spot Instances | Up to 90% | Variable - can be interrupted with 2 min notice | None (market-priced) | None | EC2, EKS nodes, EMR, SageMaker Training |
+
+**Critical distinctions most teams miss:**
+
+1. **EC2 Instance Savings Plans match Standard RI discount depth** (up to 72%) but
+   are spend-based, not capacity-based. They offer the same discount with more
+   flexibility (any size within the instance family). For most teams, EC2 Instance
+   SPs have replaced Standard RIs as the default choice.
+
+2. **Compute Savings Plans are shallower** (up to 66%) but cover EC2, Fargate,
+   Lambda, and SageMaker. The flexibility premium costs ~6% discount depth vs
+   EC2 Instance SPs.
+
+3. **Standard RIs are the only instrument that reserves capacity.** If you need
+   guaranteed capacity in a specific AZ (e.g. GPU instances, high-demand regions),
+   Standard RIs with capacity reservation are the only option.
+
+4. **Convertible RIs provide mid-term liquidity.** EC2 Instance Savings Plans offer
+   similar flexibility at equal or better discount depth, but they are locked for
+   the full term - no modifications allowed once purchased. Convertible RIs can be
+   exchanged mid-term for a different configuration (instance family, OS, tenancy),
+   which means you can reshape the commitment as workloads evolve without waiting
+   for expiry. This mid-term exchange capability is one of three commitment
+   liquidity mechanisms (see "Commitment portfolio liquidity" below). Note:
+   Convertible RIs cannot be sold on the RI Marketplace - only Standard RIs can -
+   so the liquidity trade-off is mid-term exchange flexibility vs secondary market
+   resale.
+
+5. **Standard RI marketplace liquidity is limited for EDP customers.** As of January
+   2024, EDP customers cannot sell discounted RIs on the AWS Marketplace. This
+   removes the secondary market resale option for EDP organisations, making
+   Standard RIs a less liquid instrument. Non-EDP organisations retain the ability
+   to sell unused Standard RIs to recover value from over-commitment. For EDP
+   customers, phased purchasing with staggered expiry dates becomes the primary
+   liquidity strategy (see "Commitment portfolio liquidity" below).
+
+6. **Spot is not a commitment** - it is a market mechanism. It belongs in the compute
+   cost strategy but should not be compared directly against commitment instruments.
+
+### Compute commitment decision tree
+
+```
+START: What compute service runs the workload?
+│
+├── EC2 (including self-managed databases, custom AMIs, GPU workloads)
+│   │
+│   ├── Is the workload fault-tolerant and interruptible?
+│   │   ├── YES → Use Spot Instances (up to 90% discount)
+│   │   │         - Diversify across 6+ instance types and 3+ AZs
+│   │   │         - Implement interruption handling (2-min warning)
+│   │   │         - Use ASG mixed instances policy for On-Demand fallback
+│   │   │         - Good for: batch, ML training, CI/CD, stateless web tiers
+│   │   │
+│   │   └── NO → Is the workload stable and predictable (90+ days)?
+│   │       ├── NO → Stay On-Demand. Re-evaluate quarterly.
+│   │       │
+│   │       └── YES → Has it been right-sized?
+│   │           ├── NO → Right-size first (see Compute rightsizing below)
+│   │           │
+│   │           └── YES → Do you need guaranteed capacity in a specific AZ?
+│   │               ├── YES → EC2 Standard RI with capacity reservation
+│   │               │         (only instrument that reserves capacity)
+│   │               │
+│   │               └── NO → Will it stay in the same instance family + region?
+│   │                   ├── YES → EC2 Instance Savings Plan (up to 72%)
+│   │                   │         Best default choice. Same discount as
+│   │                   │         Standard RI, but flexible on size within
+│   │                   │         the family. Spend-based, no capacity lock.
+│   │                   │
+│   │                   └── NO / UNSURE → Compute Savings Plan (up to 66%)
+│   │                         Covers any instance family and region.
+│   │                         ~6% discount penalty vs Instance SP, but
+│   │                         protects against architecture changes.
+│   │
+│   └── Special case: GPU / accelerated compute (P, G, Inf, Trn families)
+│       - Capacity scarcity is the primary risk, not just cost
+│       - Standard RIs with capacity reservation may be necessary
+│       - EC2 Instance SPs work if capacity is available on-demand
+│       - Spot is viable for ML training with checkpointing
+│       - For SageMaker-based ML: see SageMaker section below
+│
+├── Fargate (ECS or EKS on Fargate)
+│   │
+│   ├── Is usage stable and predictable?
+│   │   ├── NO → Stay On-Demand. Fargate scales to zero, so idle cost
+│   │   │         is already low. Focus on task right-sizing instead.
+│   │   │
+│   │   └── YES → Compute Savings Plan (only instrument that covers Fargate)
+│   │             - Fargate Spot available for fault-tolerant ECS tasks
+│   │               (up to 70% discount, but can be interrupted)
+│   │             - EC2 Instance SPs and Standard RIs do NOT cover Fargate
+│   │
+│   └── Consider: would ECS/EKS on EC2 be cheaper?
+│       At sustained high utilisation, EC2-backed containers with
+│       Savings Plans or RIs can be 30-50% cheaper than Fargate.
+│       Trade-off is cluster management overhead.
+│
+├── Lambda
+│   │
+│   ├── Is monthly Lambda spend significant (>$5K/month)?
+│   │   ├── NO → Lambda cost is likely immaterial. Optimise duration
+│   │   │         and memory allocation, but commitment is not worth
+│   │   │         the management overhead.
+│   │   │
+│   │   └── YES → Compute Savings Plan (only instrument for Lambda)
+│   │             - Discount applies to Lambda duration charges
+│   │             - Does NOT apply to Lambda requests (invocations)
+│   │             - Also consider: is the workload better suited to
+│   │               Fargate or EC2? High-volume, long-running Lambda
+│   │               functions often cost less on Fargate.
+│   │
+│   └── Lambda Provisioned Concurrency:
+│       Charges for allocated concurrency even when idle. Treat this
+│       as a form of capacity commitment - only use for latency-critical
+│       functions where cold starts are unacceptable.
+│
+├── SageMaker (ML inference and training)
+│   │
+│   ├── Training jobs → Spot via SageMaker Managed Spot Training
+│   │   (up to 90% discount; requires checkpoint support)
+│   │
+│   └── Inference endpoints
+│       ├── Stable, predictable → SageMaker Savings Plan (dedicated)
+│       │   OR Compute Savings Plan (if mixed with EC2/Fargate/Lambda)
+│       ├── Variable → SageMaker Serverless Inference (no commitment)
+│       └── Real-time with auto-scaling → evaluate Inference Components
+│           for multi-model packing before committing
+│
+└── EKS (Kubernetes)
+    │
+    ├── EKS on EC2 → commitment applies to the EC2 node group
+    │   (use EC2 decision tree above for the underlying instances)
+    │   - Karpenter can shift node types dynamically; favour Compute
+    │     Savings Plans over Instance SPs if Karpenter is active
+    │   - Spot nodes work well for stateless pods with proper
+    │     disruption budgets and node affinity rules
+    │
+    └── EKS on Fargate → use Fargate decision tree above
+```
+
+### Savings Plan types - detailed comparison
+
+| Dimension | Compute Savings Plan | EC2 Instance Savings Plan |
 |---|---|---|
-| Flexibility | Low - locked to instance family, region, OS | High - applies across instance families and services |
-| Discount depth | Up to 72% (Standard RI, full upfront) | Up to 66% (Compute Savings Plan) |
-| Coverage scope | Specific EC2 instance type | EC2, Fargate, Lambda (Compute SP) |
-| Convertibility | Convertible RIs allow instance family changes | N/A - flexible by design |
-| Best for | Stable, predictable workloads with known instance types | Variable workloads or mixed instance families |
+| Commitment | $/hr spend for 1yr or 3yr | $/hr spend for 1yr or 3yr |
+| Discount depth | Up to 66% | Up to 72% |
+| Instance family | Any | Locked to one family (e.g. m6i) |
+| Region | Any | Locked to one region |
+| OS | Any | Any |
+| Tenancy | Any | Any |
+| Size | Any | Any (flexible within family) |
+| Covers Fargate | Yes | No |
+| Covers Lambda | Yes | No |
+| Covers SageMaker | Yes | No |
+| Payment options | No Upfront, Partial Upfront, All Upfront | No Upfront, Partial Upfront, All Upfront |
+| Discount by payment | All Upfront > Partial > No Upfront | All Upfront > Partial > No Upfront |
 
-**Decision framework:**
-
-1. Analyze 90+ days of historical usage - identify truly steady-state workloads
-2. For workloads with stable instance types: evaluate Standard RIs (highest discount)
-3. For workloads with variable instance types or mixed EC2/Fargate/Lambda: Compute Savings Plans
-4. For EC2 with some flexibility needs: Compute Savings Plans or Convertible RIs
-5. Layer commitments: buy Savings Plans first (broadest coverage), then RIs for specific
-   high-stability workloads
-
-**Key metrics:**
-- **RI/SP Utilization:** Target >80%. Below this, you are paying for unused commitment.
-- **RI/SP Coverage:** Target 70% (Walk), 80%+ (Run). Remaining on-demand is acceptable buffer.
-- **Break-even period:** Should be <9 months for the commitment to be worth the risk.
-
-**Before purchasing any commitment:**
-- [ ] Confirm the workload has run stably for 90+ days
-- [ ] Confirm no planned architecture changes in the commitment period
-- [ ] Confirm the workload is tagged and attributable to an owner
-- [ ] Verify utilization will sustain through the commitment term
-- [ ] Do not commit to waste - rightsize first, commit second
+**Payment option guidance:**
+- **No Upfront** - lowest risk, lowest discount. Best starting point for organisations
+  new to commitments or with cash flow constraints.
+- **Partial Upfront** - moderate risk, ~2-4% deeper discount. Good for steady-state
+  workloads with 6+ months of stable history.
+- **All Upfront** - highest discount (~5-8% deeper than No Upfront) but full capital
+  outlay. Only justified for workloads with multi-year stability AND when the discount
+  delta exceeds your cost of capital.
 
 ### Spot Instances
 
-For fault-tolerant, interruptible workloads, Spot offers up to 90% discount over on-demand.
+For fault-tolerant, interruptible workloads, Spot offers up to 90% discount over On-Demand.
 
 **Appropriate workloads for Spot:**
 - Batch processing, data pipelines, ML training jobs
 - CI/CD build environments
 - Stateless web tier behind a load balancer (with proper drain handling)
 - Development and test environments
+- EKS worker nodes for stateless pods (with pod disruption budgets)
 
 **Not appropriate for Spot:**
 - Stateful applications without checkpoint/resume logic
 - Production databases
 - Workloads with strict latency or availability SLAs
+- Single-instance workloads with no failover
 
 **Spot best practices:**
-- Use Spot Instance pools (multiple instance types and AZs) to reduce interruption risk
-- Implement interruption handling (2-minute warning via EC2 metadata service)
-- Use EC2 Auto Scaling mixed instances policy for automatic on-demand fallback
+- Use Spot Instance pools across 6+ instance types and 3+ AZs to reduce interruption risk
+- Implement interruption handling (2-minute warning via EC2 metadata or EventBridge)
+- Use EC2 Auto Scaling mixed instances policy for automatic On-Demand fallback
+- Set maximum price at On-Demand rate (never bid above OD - you lose the cost advantage)
+- For containers: use Karpenter (EKS) or Fargate Spot (ECS) for managed Spot lifecycle
+- Monitor Spot interruption frequency by instance type - some types are more stable
+
+**Spot savings estimation:**
+Spot discounts vary by instance type, region, and AZ. The Spot Placement Score API
+indicates how likely a Spot request will be fulfilled. Use the EC2 Spot Advisor for
+historical interruption rates. Typical realised savings are 60-80% (not the theoretical
+90% maximum).
+
+### Compute commitment layering strategy
+
+The instruments are designed to be stacked, not chosen in isolation. The layering
+order matters because AWS applies discounts in a specific sequence.
+
+**Discount application order (AWS-defined):**
+1. Spot pricing (market rate, applied first)
+2. Reserved Instances (capacity + rate, applied to matching On-Demand usage)
+3. Savings Plans (spend-based, applied to remaining eligible On-Demand usage)
+4. EDP (portfolio discount, applied last to remaining spend)
+
+**Recommended layering approach:**
+
+```
+Layer 1: Spot (for interruptible workloads)
+  ↓ removes 15-40% of compute from the commitment equation entirely
+Layer 2: Compute Savings Plans (broad baseline)
+  ↓ covers the predictable floor across EC2/Fargate/Lambda/SageMaker
+Layer 3: EC2 Instance Savings Plans (high-stability EC2 workloads)
+  ↓ captures the extra ~6% discount for workloads locked to a family+region
+Layer 4: Standard RIs (capacity reservation needs only)
+  ↓ only where guaranteed AZ capacity is required (GPU, scarce types)
+Layer 5: EDP (portfolio-wide, if eligible)
+  ↓ applies on top of everything above for remaining On-Demand spend
+Layer 6: On-Demand (variable / new workloads)
+  ↓ buffer for growth, experimentation, and workloads under evaluation
+```
+
+**Sizing the commitment - the 70/20/10 guideline:**
+- **70% of steady-state compute:** covered by Savings Plans and/or RIs. This is the
+  floor that will not change during the commitment term.
+- **20% variable buffer:** On-Demand capacity for scaling, new workloads, and seasonal
+  variation. This is deliberately uncommitted.
+- **10% Spot opportunity:** workloads that can tolerate interruption, running on Spot
+  to capture the deepest discounts.
+
+These ratios are starting points, not targets. Mature organisations (Run maturity) may
+push committed coverage to 80%+ while maintaining Spot at 10-15%.
+
+### Commitment portfolio liquidity
+
+The deepest discount means nothing if you cannot adapt when workloads change.
+Commitment liquidity - the ability to reshape, rebalance, or exit your commitment
+portfolio without wasting money - is as important as discount depth. Every commitment
+purchase decision should be evaluated on two axes: how much does it save, and how
+much flexibility does it preserve?
+
+AWS commitment instruments offer three forms of liquidity:
+
+| Liquidity mechanism | How it works | Available on |
+|---|---|---|
+| **Secondary market resale** | Sell unused Standard RIs on the RI Marketplace to recover value | Standard RIs only (not available to EDP customers since Jan 2024) |
+| **Mid-term exchange** | Exchange a Convertible RI for a different configuration (family, OS, tenancy) without losing the commitment value | Convertible RIs only |
+| **Staggered expiry** | Purchase commitments in phased blocks so that only a fraction of the portfolio expires in any given quarter | All instruments (SPs, RIs) |
+
+The first two are instrument-specific. The third - staggered expiry through phased
+purchasing - is a portfolio management discipline that works with any instrument and
+is the most reliable way to maintain liquidity.
+
+Organisations that buy their full commitment in a single transaction have zero
+liquidity until the term expires. If workloads shift, they pay for unused commitment
+with no recourse. Organisations that build a diversified portfolio with staggered
+expiry dates always have a portion of their commitment approaching renewal, creating
+a natural rebalancing rhythm.
+
+### Phased purchasing
+
+Never buy the full commitment in a single transaction. Purchase in blocks of 10-25%
+of the target commitment to create a portfolio of overlapping terms with staggered
+expiry dates.
+
+**Why phased purchasing matters:**
+- **Reduces lock-in risk:** if architecture changes mid-term, only the current block
+  is at risk - not the entire commitment
+- **Creates natural re-evaluation points:** each purchase cycle forces a review of
+  utilisation, workload stability, and architecture direction
+- **Smooths cash flow:** Upfront payments are spread across quarters instead of
+  concentrated in a single month
+- **Enables course correction:** if utilisation drops on existing commitments, you
+  can pause or reduce the next block instead of over-committing further
+- **Captures pricing improvements:** newer instance families and Graviton adoption
+  can be reflected in subsequent blocks
+
+**Phased purchasing framework:**
+
+```
+Quarter 1: Buy 20-25% of target commitment (the floor you are certain about)
+  → Monitor utilisation for 30 days
+  → If utilisation >80%: proceed to next block
+  → If utilisation <80%: investigate before buying more
+
+Quarter 2: Buy next 15-20% block
+  → Reassess workload stability and architecture plans
+  → Adjust instrument mix if workload profile has shifted
+
+Quarter 3: Buy next 15-20% block
+  → By now you have 50-65% of target covered
+  → Remaining gap is intentional On-Demand buffer
+
+Quarter 4: Evaluate whether to buy more or hold
+  → Early blocks from Q1 of previous year start approaching renewal
+  → Begin planning the next cycle
+```
+
+**Portfolio view - staggered expiry example (1-year terms):**
+
+| Block | Purchased | Expires | % of total | Instrument |
+|---|---|---|---|---|
+| Block 1 | Jan 2026 | Jan 2027 | 25% | Compute SP (broad baseline) |
+| Block 2 | Apr 2026 | Apr 2027 | 20% | EC2 Instance SP (stable m6i workloads) |
+| Block 3 | Jul 2026 | Jul 2027 | 15% | EC2 Instance SP (stable r6g workloads) |
+| Block 4 | Oct 2026 | Oct 2027 | 10% | Compute SP (new Fargate workloads) |
+| On-Demand | - | - | 30% | Buffer for variable / new workloads |
+
+With staggered expiry, no more than 25% of your commitment portfolio expires in any
+single quarter. This means you are never forced into a large, rushed repurchase
+decision.
+
+**3-year term phasing:**
+For 3-year commitments (deeper discounts), phasing is even more critical. Buy in
+smaller blocks (10-15% each) and stagger across 6-month intervals. The longer the
+term, the smaller each block should be - because the risk of architecture change
+over 3 years is substantially higher than over 1 year.
+
+**Portfolio management cadence:**
+- **Monthly:** review SP/RI utilisation dashboard. Flag any commitment below 80%.
+- **Quarterly:** evaluate whether to purchase the next block, adjust the instrument
+  mix, and review upcoming expiries.
+- **At each expiry:** do not auto-renew. Re-evaluate the workload: has it grown,
+  shrunk, migrated to a different service, or been decommissioned? Renew only what
+  is still justified.
+- **Annually:** review the overall commitment strategy against the organisation's
+  cloud roadmap. Adjust the target coverage ratio and instrument mix.
+
+**Common commitment mistakes:**
+- Buying commitments before right-sizing (committing to waste)
+- Over-committing: purchasing for peak usage instead of steady-state floor
+- Ignoring architecture changes: migrating from EC2 to Fargate mid-term while holding
+  EC2 Instance SPs that no longer apply
+- Treating Spot savings as guaranteed in financial forecasts (Spot availability fluctuates)
+- Purchasing All Upfront without comparing the discount delta to the organisation's
+  cost of capital
+- Buying 3-year terms for workloads that may be re-architected within 18 months
+- Not monitoring utilisation: an SP or RI below 80% utilisation means you are paying
+  for unused commitment and should adjust the next purchase
+
+**Key metrics:**
+- **SP/RI Utilisation:** Target >80%. Below this, the commitment is oversized.
+- **SP/RI Coverage:** Target 70% (Walk maturity), 80%+ (Run maturity).
+- **Effective Savings Rate:** actual savings / theoretical maximum savings. Measures
+  how well commitments are matched to real usage.
+- **Break-even period:** should be <9 months for 1-year terms, <15 months for 3-year.
+- **Commitment waste:** hours where committed capacity had no matching usage.
+
+**Pre-purchase checklist:**
+- [ ] Workload has run stably for 90+ days
+- [ ] Workload has been right-sized (do not commit to waste)
+- [ ] No planned architecture changes during the commitment term
+- [ ] All resources are tagged and attributable to an owner
+- [ ] Utilisation will sustain through the full term
+- [ ] Finance has approved the capital outlay (for Upfront payments)
+- [ ] Break-even period is acceptable given the workload risk profile
+- [ ] Existing SP/RI utilisation is >80% before purchasing more
+
+**Diagnostic questions:**
+- What is your current SP/RI utilisation rate? If below 80%, do not buy more - fix
+  the mismatch first.
+- What percentage of EC2 spend is On-Demand vs committed vs Spot? The goal is to
+  minimise On-Demand for steady-state workloads.
+- Are any Compute Savings Plans covering workloads that could be on cheaper EC2
+  Instance Savings Plans instead? (leaving ~6% on the table)
+- Do you have Convertible RIs? If so, are you actively exchanging them as workloads
+  shift, or should they be allowed to expire and replaced with EC2 Instance SPs?
+- Are engineering teams launching new instance families (Graviton, AMD) that might
+  invalidate existing EC2 Instance SP commitments?
+- Is Karpenter or Cluster Autoscaler shifting EKS node types dynamically? If yes,
+  Compute SPs are safer than Instance SPs for the underlying EC2.
+- Are there workloads on Fargate or Lambda that appear small individually but add
+  up to significant monthly spend when aggregated?
+- Are you buying commitments in phased blocks (10-25%) with staggered expiry dates,
+  or purchasing the full amount in a single transaction? Single-purchase strategies
+  concentrate renewal risk and reduce flexibility.
+- What percentage of your commitment portfolio expires in any single quarter? If
+  more than 30%, the portfolio is insufficiently diversified.
 
 ### Enterprise Discount Program (EDP)
 <!-- src:optimnow-edp-guide -->
@@ -1125,6 +1467,140 @@ Effective implementation requires collaboration across roles:
 - Product/business teams confirm which databases support which products and approve
   changes
 - Procurement manages Reserved Instance purchasing strategy
+
+### Database commitment discount decision tree
+
+AWS offers different commitment instruments depending on the database service. Unlike
+Azure (which introduced a unified Savings Plan for Databases in March 2026), AWS
+commitment discounts remain service-specific. Choosing the wrong instrument - or
+committing too early - is the most common database FinOps mistake.
+
+**Instrument availability by service:**
+
+| Service | Reserved Instances | Compute Savings Plans | On-Demand only | Notes |
+|---|---|---|---|---|
+| RDS (MySQL, PostgreSQL, MariaDB) | Yes - size-flexible within family | No | - | RI size flexibility means right-sizing does not invalidate the commitment |
+| RDS (Oracle, SQL Server) | Yes - locked to instance type | No | - | No size flexibility for commercial engines; must match instance exactly |
+| Aurora (MySQL, PostgreSQL) | Yes - size-flexible within family | No | - | Same RI pool as RDS open-source engines |
+| DynamoDB | Yes - Reserved Capacity | No | - | Commit to read/write capacity units; only viable for Provisioned mode |
+| ElastiCache (Redis, Memcached) | Yes - node-type specific | No | - | Locked to node type, no size flexibility |
+| MemoryDB | Yes - node-type specific | No | - | Same mechanics as ElastiCache RIs |
+| Neptune | Yes - instance-type specific | No | - | Low discount depth compared to RDS RIs |
+| OpenSearch | Yes - instance-type specific | No | - | Also covers legacy Elasticsearch domains |
+| Redshift | Yes - node-type specific | No | - | Consider Redshift Serverless for variable workloads (no RI available) |
+| DocumentDB | Yes - instance-type specific | No | - | Same RI mechanics as RDS commercial engines |
+
+**Key insight:** Compute Savings Plans do NOT cover any managed database service.
+Savings Plans only apply to EC2, Fargate, Lambda, and SageMaker. If a database
+runs on EC2 (self-managed), Compute Savings Plans apply to the EC2 instance - but
+the database layer itself has no Savings Plan instrument.
+
+**Decision tree:**
+
+```
+Is the database workload stable and predictable (90+ days of consistent usage)?
+├── NO → Stay on On-Demand. Re-evaluate quarterly.
+│         For DynamoDB: use On-Demand capacity mode.
+│         For Redshift: evaluate Serverless for variable workloads.
+│
+└── YES → Has the workload been right-sized? (steps 1-8 of RDS framework above)
+    ├── NO → Right-size first, commit second. Do not lock in waste.
+    │
+    └── YES → What database service?
+        │
+        ├── RDS or Aurora (open-source engine: MySQL, PostgreSQL, MariaDB)
+        │   → RDS Reserved Instances with size flexibility
+        │     - Start with 1-year No Upfront (~34% discount, zero risk)
+        │     - Upgrade to 1-year Partial Upfront (~37%) once confident
+        │     - Consider 3-year Partial Upfront (~57%) only for workloads
+        │       with 3+ year horizon AND no planned migration
+        │     - Size flexibility means you can right-size within the
+        │       instance family without losing the RI benefit
+        │
+        ├── RDS (commercial engine: Oracle, SQL Server)
+        │   → RDS Reserved Instances (instance-type locked)
+        │     - No size flexibility - must match exact instance type
+        │     - Higher risk: right-size thoroughly before committing
+        │     - Evaluate BYOL vs License Included cost difference
+        │     - Consider migration to open-source engine to unlock
+        │       size flexibility and reduce licensing costs
+        │
+        ├── DynamoDB
+        │   → First: switch from On-Demand to Provisioned + Auto Scaling
+        │     if usage is predictable (this alone saves 50-80%)
+        │   → Then: Reserved Capacity for baseline read/write units
+        │     - 1-year or 3-year terms available
+        │     - Only commit the steady-state baseline; let Auto Scaling
+        │       handle peaks above the reserved floor
+        │
+        ├── ElastiCache / MemoryDB
+        │   → Reserved Nodes (node-type specific)
+        │     - No size flexibility - must match exact node type
+        │     - For MemoryDB: migrate to Valkey engine first (lower
+        │       base cost), then evaluate RI on the new node type
+        │
+        ├── Redshift
+        │   → Reserved Nodes for stable provisioned clusters
+        │   → For variable workloads: Redshift Serverless (no RI, pay
+        │     per RPU-hour) may be cheaper than committed idle capacity
+        │
+        └── Neptune / OpenSearch / DocumentDB
+            → Reserved Instances (instance-type specific)
+              - Evaluate usage carefully; these services often have
+                bursty patterns that make commitment risky
+              - Start with 1-year No Upfront if committing
+```
+
+**Self-managed databases on EC2 vs managed (RDS/Aurora):**
+
+Running databases on EC2 instead of RDS trades management overhead for pricing
+flexibility. The decision is rarely purely financial.
+
+| Factor | Self-managed on EC2 | RDS / Aurora |
+|---|---|---|
+| Instance cost | EC2 On-Demand (cheaper base) | 40-70% premium over equivalent EC2 |
+| Commitment options | Compute Savings Plans + EC2 RIs | RDS RIs only (no Savings Plans) |
+| Maximum discount | Up to 72% (Standard RI) + EDP | Up to 57% (3yr Partial Upfront RI) + EDP |
+| Operational cost | DBA time, patching, backups, HA setup | Managed by AWS |
+| BYOL | Full control over licensing | Limited BYOL options (Oracle, SQL Server) |
+| Flexibility | Any database engine, any version | AWS-supported engines and versions only |
+
+**When self-managed makes financial sense:**
+- Large-scale deployments where the 40-70% RDS premium exceeds the cost of a DBA team
+- Commercial engines (Oracle, SQL Server) where BYOL on EC2 is significantly cheaper
+  than RDS License Included pricing
+- Workloads requiring database versions or configurations not supported by RDS
+- Organisations with existing DBA capacity and mature operational practices
+
+**When managed (RDS/Aurora) wins:**
+- Teams without dedicated DBA capacity
+- Workloads where high availability, automated backups, and patching are critical
+- Aurora Serverless v2 for highly variable workloads (no EC2 equivalent)
+- When the total cost of ownership (including operational burden) favours managed
+
+**Layering strategy for database commitments:**
+
+1. **EDP as base** - if eligible, the portfolio-wide EDP discount applies to both
+   EC2 and RDS, reducing the effective rate before any RI is applied
+2. **Right-size and optimise** - complete the 9-step RDS framework before committing
+3. **Reserve the steady-state floor** - commit RIs for the baseline that will not
+   change during the term. Leave headroom for scaling
+4. **On-Demand for the variable layer** - peaks, new workloads, and workloads under
+   evaluation stay on On-Demand until they stabilise
+5. **Review quarterly** - commitment coverage should increase as workloads mature,
+   not as a one-time purchasing event
+
+**Diagnostic questions:**
+- What percentage of your database spend is covered by Reserved Instances today?
+- Are any RDS RIs sitting below 80% utilisation? (indicates over-commitment or
+  workload changes)
+- Do you have commercial-engine RDS instances that could migrate to open-source
+  (unlocking size flexibility and reducing licence costs)?
+- Are DynamoDB tables on On-Demand mode despite having predictable, steady throughput?
+- Is anyone running self-managed databases on EC2 without Compute Savings Plans
+  covering those instances?
+- Have you evaluated Aurora Serverless v2 for workloads with unpredictable traffic
+  before committing to provisioned Aurora RIs?
 
 ---
 

--- a/cloud-finops/references/finops-azure.md
+++ b/cloud-finops/references/finops-azure.md
@@ -61,62 +61,428 @@ with KQL queries. Use it for:
 
 ## Commitment discounts
 
-### Azure Reservations vs Azure Savings Plans
+### Compute commitment instruments
 
-| Dimension | Azure Reservations | Azure Savings Plans for Compute | Azure Savings Plans for Databases |
-|---|---|---|---|
-| Flexibility | Low - locked to specific VM family/region | High - applies across VM families and regions | High - applies across database services and regions |
-| Discount depth | Higher (up to 72% for some VM families) | Lower but broader coverage | Up to 35% vs PAYG (varies by service, March 2026 pricing) |
-| Commitment model | Capacity-based (specific SKU) | Spend-based ($/hr) | Spend-based ($/hr) |
-| Coverage scope | Specific resource type | Compute (VMs, Dedicated Hosts) | Database services (SQL DB, PostgreSQL, MySQL, Cosmos DB, SQL MI, MariaDB) |
-| Term options | 1 or 3 years | 1 or 3 years | 1 year only |
-| Best for | Stable workloads with known VM types | Variable workloads, mixed VM families | Evolving database estates, multi-service or multi-region DB workloads |
+Azure provides four distinct instruments for reducing compute costs, plus Azure Hybrid
+Benefit which acts as a licensing overlay. As with AWS, these instruments are designed
+to be layered, not chosen in isolation.
 
-**Decision framework:**
-1. Analyze 90+ days of historical usage - identify truly steady-state workloads
-2. For compute with stable VM types: evaluate Reservations (highest discount)
-3. For compute with variable types or mixed families: Savings Plans for Compute
-4. For database workloads across multiple services or regions: Savings Plans for Databases
-5. For stable, single-service database workloads: compare Reservations vs Savings Plans for Databases -
-   Reservations may offer deeper discounts but lock to a specific service and configuration
-6. Layer commitments: Savings Plans first (broadest coverage), then RIs for specific
-   high-stability workloads. For databases, layer DB Savings Plans before service-specific RIs
+**Instrument comparison:**
 
-**Key metrics (same as AWS):**
-- **Utilization:** Target >80%. Below this, you are paying for unused commitment.
-- **Coverage:** Target 70% (Walk), 80%+ (Run). Remaining on-demand is acceptable buffer.
+| Instrument | Discount depth | Flexibility | Commitment type | Term | Covers |
+|---|---|---|---|---|---|
+| Azure Reservation | Up to 72% | Lowest - locked to VM family, region, size | Capacity-based (specific SKU) | 1yr or 3yr | VMs, Dedicated Hosts, App Service (Isolated), specific services |
+| Azure Savings Plan for Compute | Up to 65% | High - any VM family, region, size | Spend-based ($/hr) | 1yr or 3yr | VMs, Dedicated Hosts, Container Instances, App Service (Premium v3 / Isolated v2) |
+| Azure Hybrid Benefit (AHB) | Up to 40% (Windows), 55% (SQL) | Highest - no commitment, no lock-in | Licensing overlay | None | VMs, SQL Database, SQL MI, Red Hat/SUSE Linux |
+| Spot Virtual Machines | Up to 90% | Variable - can be evicted with 30s notice | None (market-priced) | None | VMs, VMSS, AKS node pools |
 
-**Before purchasing any commitment:**
-- [ ] Confirm the workload has run stably for 90+ days
-- [ ] Confirm no planned architecture changes in the commitment period
-- [ ] Confirm the workload is tagged and attributable to an owner
-- [ ] **Do not commit to waste** - rightsize and shut down idle resources first, commit second
+**Critical distinctions:**
 
-### Azure Hybrid Benefit (AHB)
+1. **Azure Hybrid Benefit is not a commitment - it is free money.** If you have Windows
+   Server or SQL Server licenses with Software Assurance, AHB eliminates the license
+   component from VM pricing. No contract, no lock-in, no restart needed. This should
+   be enabled on all eligible VMs before any other commitment decision. Windows licence
+   costs can account for 44% of a Windows VM price (e.g. D4_v5 Windows at ~0.35/hr =
+   ~0.19 compute + ~0.15 licence). Use the AHB Workbook from FinOps Toolkit for
+   compliance tracking across the fleet.
 
-Organizations with existing Windows Server or SQL Server licenses (with Software Assurance)
-can apply them to Azure VMs, eliminating the license premium.
+2. **Savings Plans for Compute cover more than VMs.** Unlike Reservations (which are
+   resource-specific), Compute Savings Plans also cover Container Instances and App
+   Service Premium v3 / Isolated v2. If you run a mix of VMs, containers, and App
+   Service, a Compute Savings Plan is the only instrument that covers all three.
 
-**Why this matters:** Windows license costs can account for 44% of a Windows VM price.
-Example: D4_v5 Windows at ~0.35/hr = ~0.19 (compute) + ~0.15 (Windows license). Without
-AHB, you double-pay for licenses you already own.
+3. **Reservations offer deeper discounts but less flexibility.** A Reservation locks to
+   a specific VM family and region. If you change instance family or region mid-term, the
+   Reservation does not follow. A Savings Plan is spend-based and applies wherever it
+   finds eligible usage - but the discount is ~7% shallower than a Reservation.
 
-**AHB details:**
-- Up to 40% savings on Windows VMs, up to 55% on SQL Database
-- No architectural change, no restart needed - single CLI command per VM
-- Also applies to SQL Managed Instance and Red Hat/SUSE Linux
-- Use the AHB Workbook from FinOps Toolkit for compliance tracking across the fleet
-- **Priority: #1 quick win** - enable on all eligible VMs immediately
+4. **Azure allows Reservation exchanges and refunds - but with limits.** You can exchange
+   a Reservation for a different SKU (same or higher value) or request a pro-rated refund
+   up to $50,000 per rolling 12 months. This is significantly more liquidity than AWS
+   offers (where Savings Plans cannot be modified and Standard RIs can only be sold on
+   the marketplace). However, Microsoft has been tightening these policies - verify
+   current exchange and refund terms before relying on them for liquidity.
+
+5. **Savings Plans cannot be exchanged, cancelled, or refunded** once purchased. The
+   commitment runs for the full term. This makes phased purchasing and portfolio
+   diversification critical for Savings Plans (see "Commitment portfolio liquidity" below).
+
+6. **Spot is not a commitment** - it is a market mechanism with a 30-second eviction
+   notice and no SLA. It belongs in the compute cost strategy but should not be compared
+   directly against commitment instruments.
+
+### Compute commitment decision tree
+
+```
+START: What Azure compute service runs the workload?
+│
+├── Virtual Machines (including VMSS)
+│   │
+│   ├── Does the VM run Windows Server or SQL Server with SA licenses?
+│   │   └── YES → Enable Azure Hybrid Benefit immediately (up to 40-55%
+│   │             savings, no commitment, no restart). Then continue below
+│   │             for additional commitment discounts on top of AHB.
+│   │
+│   ├── Is the workload fault-tolerant and interruptible?
+│   │   ├── YES → Use Spot VMs (up to 90% discount)
+│   │   │         - Start with 20-30% Spot allocation in non-production
+│   │   │         - Use VMSS with Spot priority for auto-scaling pools
+│   │   │         - Implement eviction handling (30-second notice)
+│   │   │         - Good for: batch, dev/test, CI/CD, stateless tiers
+│   │   │
+│   │   └── NO → Is the workload stable and predictable (90+ days)?
+│   │       ├── NO → Stay on PAYG. Re-evaluate quarterly.
+│   │       │
+│   │       └── YES → Has it been right-sized? (see Compute rightsizing below)
+│   │           ├── NO → Right-size first. Do not commit to waste.
+│   │           │
+│   │           └── YES → Will it stay on the same VM family + region?
+│   │               ├── YES → Azure Reservation (up to 72%)
+│   │               │         Deepest discount. Can be exchanged for a
+│   │               │         different SKU if workload changes (subject
+│   │               │         to exchange policy limits).
+│   │               │
+│   │               └── NO / UNSURE → Savings Plan for Compute (up to 65%)
+│   │                     Covers any VM family and region. ~7% shallower
+│   │                     than Reservations but protects against family
+│   │                     or region changes. Cannot be exchanged or
+│   │                     refunded once purchased.
+│   │
+│   └── Special case: GPU / N-series VMs
+│       - Capacity scarcity is a primary concern (NC, ND, NV families)
+│       - Reservations may be necessary to secure capacity in constrained regions
+│       - Savings Plans do not reserve capacity - only provide pricing benefit
+│       - For ML training: consider Spot VMs with checkpointing
+│
+├── Azure Kubernetes Service (AKS)
+│   │
+│   ├── AKS node pools run on VMs → commitment applies to underlying VMs
+│   │   (use VM decision tree above for node pool instances)
+│   │
+│   ├── Spot node pools → use Spot priority for fault-tolerant pods
+│   │   - Configure pod disruption budgets for graceful eviction
+│   │   - Use taints/tolerations to isolate Spot-eligible workloads
+│   │   - Can save 60-90% on non-critical node pools
+│   │
+│   └── Consider: cluster autoscaler + right-sized node pools before committing
+│       Pod rightsizing (VPA) saves 20-40%; node pool rightsizing saves 15-30%.
+│       Commit after these optimisations are stable, not before.
+│
+├── App Service
+│   │
+│   ├── Consumption Plan → no commitment needed (pay per execution)
+│   │
+│   ├── Premium v3 / Isolated v2 → Savings Plan for Compute applies
+│   │   - Only relevant if App Service spend is significant (>$2K/month)
+│   │   - Reservations also available for Isolated tier
+│   │
+│   └── Legacy plans (V2) → migrate to V3 first for better price-performance,
+│       then evaluate commitment on the new tier
+│
+├── Azure Functions
+│   │
+│   ├── Consumption Plan → pay per execution, no commitment available
+│   │   - Focus on optimising execution duration and memory allocation
+│   │
+│   ├── Premium Plan → runs on App Service infrastructure
+│   │   Savings Plan for Compute applies. But first: does the workload
+│   │   actually need Premium? Move non-critical functions to Consumption
+│   │   Plan before committing to Premium.
+│   │
+│   └── Dedicated (App Service Plan) → same as App Service above
+│
+├── Container Instances
+│   │
+│   └── Savings Plan for Compute covers Container Instances
+│       - Only worth committing if usage is sustained and predictable
+│       - For short-lived or burst containers, PAYG is usually cheaper
+│
+└── Azure Databricks
+    │
+    └── Databricks has its own commitment model (DBCU pre-purchase)
+        - Separate from Azure Reservations and Savings Plans
+        - See finops-databricks.md for Databricks-specific guidance
+```
+
+### Savings Plan vs Reservation - detailed comparison
+
+| Dimension | Azure Reservation | Azure Savings Plan for Compute |
+|---|---|---|
+| Commitment | Specific SKU for 1yr or 3yr | $/hr spend for 1yr or 3yr |
+| Discount depth | Up to 72% | Up to 65% |
+| VM family | Locked to one family | Any family |
+| Region | Locked to one region | Any region |
+| Size | Flexible within family (instance size flexibility) | Any size |
+| Covers App Service | Isolated tier only | Premium v3 + Isolated v2 |
+| Covers Container Instances | No | Yes |
+| Exchangeable | Yes (for equal or greater value, $50K/12mo refund cap) | No |
+| Refundable | Pro-rated, up to $50K per 12 months | No |
+| Cancellable | Yes (with early termination fee) | No |
+| Payment options | Monthly or Upfront | Monthly or Upfront |
+| Scoping | Subscription, resource group, management group, shared | Subscription, resource group, management group, shared |
+
+**Key takeaway:** Reservations offer deeper discounts AND more liquidity (exchanges,
+refunds). Savings Plans offer broader coverage but zero liquidity once purchased. This
+inverts the common assumption that "flexibility = Savings Plans." For Azure specifically,
+Reservations are often the better choice when workloads are moderately stable, because
+you retain the ability to exchange if things change.
 
 ### Spot Virtual Machines
 
 For fault-tolerant, interruptible workloads, Spot offers up to 90% discount over PAYG.
 
-**Appropriate for Spot:** Batch processing, dev/test, CI/CD, stateless pods in AKS
-**Not appropriate:** Stateful databases, workloads with strict SLA requirements
+**Appropriate for Spot:** Batch processing, dev/test, CI/CD, stateless pods in AKS,
+ML training with checkpointing, scale-out processing with VMSS.
 
-**Key constraint:** 30-second eviction notice, no SLA guarantees. Start with 20-30% spot
-allocation in non-production, increase based on stability observations.
+**Not appropriate:** Stateful databases, workloads with strict SLA requirements,
+single-instance workloads with no failover.
+
+**Key constraint:** 30-second eviction notice (vs 2 minutes on AWS), no SLA guarantees.
+
+**Spot best practices:**
+- Start with 20-30% Spot allocation in non-production, increase based on stability
+- Use VMSS with Spot priority for auto-scaling pools with automatic fallback
+- Configure eviction policy: Deallocate (preserves disk) or Delete (lowest cost)
+- Set max price at PAYG rate - never bid above PAYG
+- For AKS: use Spot node pools with taints/tolerations for workload isolation
+- Monitor eviction rates by VM family and region - some combinations are more stable
+
+### Azure Hybrid Benefit (AHB)
+
+Organisations with existing Windows Server or SQL Server licenses (with Software
+Assurance) can apply them to Azure resources, eliminating the licence premium.
+
+**Why AHB is the #1 quick win:**
+- Up to 40% savings on Windows VMs, up to 55% on SQL Database
+- No architectural change, no restart needed - single CLI command per VM
+- Also applies to SQL Managed Instance and Red Hat/SUSE Linux
+- Zero commitment, zero risk, immediate effect
+- Use the AHB Workbook from FinOps Toolkit for compliance tracking across the fleet
+- **Enable on all eligible VMs before evaluating any other commitment**
+
+### Compute commitment layering strategy
+
+Azure applies discounts in a specific order. The layering sequence matters.
+
+**Discount application order (Azure-defined):**
+1. Azure Hybrid Benefit (licence overlay, applied first to eligible VMs)
+2. Spot pricing (market rate, for Spot-eligible workloads)
+3. Reservations (capacity-based, applied to matching PAYG usage)
+4. Savings Plans (spend-based, applied to remaining eligible PAYG usage)
+5. MACC discount (portfolio-wide, applied last to remaining spend)
+
+**Recommended layering approach:**
+
+```
+Layer 0: Azure Hybrid Benefit (free - no commitment, immediate)
+  ↓ eliminates licence cost on all eligible Windows/SQL VMs
+Layer 1: Spot (for interruptible workloads)
+  ↓ removes 15-40% of compute from the commitment equation
+Layer 2: Savings Plans for Compute (broad baseline)
+  ↓ covers predictable floor across VMs/App Service/Container Instances
+Layer 3: Reservations (high-stability VM workloads)
+  ↓ captures the extra ~7% discount for workloads locked to a family+region
+  ↓ retains exchange/refund liquidity if workload changes
+Layer 4: MACC (portfolio-wide, if applicable)
+  ↓ applies on top of everything above for remaining PAYG spend
+Layer 5: PAYG (variable / new workloads)
+  ↓ buffer for growth, experimentation, and workloads under evaluation
+```
+
+**Sizing the commitment - the 70/20/10 guideline:**
+- **70% of steady-state compute:** covered by Savings Plans and/or Reservations
+- **20% variable buffer:** PAYG capacity for scaling, new workloads, seasonal variation
+- **10% Spot opportunity:** fault-tolerant workloads on Spot pricing
+
+### Database commitment decision tree
+
+Azure offers two commitment instruments for database services, plus operational
+optimisations that should be applied before any commitment purchase.
+
+**Pre-commitment optimisation (do these first):**
+1. Enable Azure Hybrid Benefit on all eligible SQL Database and SQL MI instances
+2. Switch dev/test databases to SQL Serverless (auto-pause) - saves 70-90% on idle DBs
+3. Stop PostgreSQL/MySQL Flexible Servers outside business hours
+4. Consolidate small databases into Elastic Pools (20-40% savings)
+5. Review DTU vs vCore: migrate to vCore if AHB-eligible for licence savings
+6. Right-size overprovisioned compute and storage tiers
+
+**Decision tree:**
+
+```
+Is the database workload stable and predictable (90+ days)?
+├── NO → Stay on PAYG or use Serverless (auto-pause for intermittent use).
+│         Re-evaluate quarterly.
+│
+└── YES → Has the database been right-sized and optimised? (steps 1-6 above)
+    ├── NO → Optimise first, commit second. Do not lock in waste.
+    │
+    └── YES → What is the database estate profile?
+        │
+        ├── Single service, single region, stable configuration
+        │   → Azure Reservation (deeper discount than Savings Plan)
+        │     - Available for: SQL Database, Cosmos DB, PostgreSQL,
+        │       MySQL, MariaDB, SQL MI
+        │     - Exchangeable for different SKU if workload changes
+        │     - Pro-rated refund available (up to $50K/12 months)
+        │
+        ├── Multiple database services or regions
+        │   → Savings Plan for Databases (up to 35%, March 2026)
+        │     - Covers: SQL Database, PostgreSQL, MySQL, Cosmos DB,
+        │       SQL MI, MariaDB
+        │     - Applies savings across services and regions automatically
+        │     - Cannot be exchanged or refunded once purchased
+        │     - CAUTION: SQL Server on Azure VMs and Azure Arc consume
+        │       the commitment at PAYG rates (no discount) - factor
+        │       this into sizing the hourly commitment
+        │
+        ├── Mix of stable and evolving workloads
+        │   → Layer both: Savings Plan for Databases as broad baseline,
+        │     then add Reservations for the most stable, high-spend
+        │     database instances to capture deeper discounts
+        │
+        └── Cosmos DB (special case)
+            → Cosmos DB Reserved Capacity available separately
+              - 1yr or 3yr terms, significant discounts on RU/s
+              - Requires predictable throughput baseline
+              - For variable throughput: use autoscale (no commitment)
+              - Evaluate serverless for low/intermittent usage first
+```
+
+**Database commitment diagnostic questions:**
+- What percentage of your database spend is PAYG vs committed?
+- Are Azure Hybrid Benefit licences applied to all eligible SQL instances?
+- Are dev/test databases on Serverless (auto-pause) or still running 24/7?
+- Do you have SQL Server on Azure VMs that would consume a Database Savings Plan
+  at PAYG rates? If so, how much of the plan's hourly commitment would they absorb?
+- Are overprovisioned tiers (Business Critical on non-prod, RA-GRS backup storage
+  on non-critical DBs) inflating the baseline you would commit to?
+
+### Commitment portfolio liquidity
+
+Commitment liquidity - the ability to reshape, rebalance, or exit your commitment
+portfolio without wasting money - is as important as discount depth. Azure offers
+more built-in liquidity mechanisms than AWS, but each has limits.
+
+**Azure liquidity mechanisms:**
+
+| Mechanism | How it works | Applies to | Limits |
+|---|---|---|---|
+| **Reservation exchange** | Swap a Reservation for a different SKU of equal or greater value | Reservations only | Must be equal or greater value; exchanges count toward $50K refund cap |
+| **Reservation refund** | Cancel a Reservation and receive a pro-rated refund | Reservations only | $50,000 rolling 12-month cap across all refunds and exchanges |
+| **Reservation instance size flexibility** | A Reservation on one VM size covers other sizes in the same family at a normalised ratio | VM Reservations | Same VM family and region only |
+| **Staggered expiry** | Purchase commitments in phased blocks so only a fraction expires each quarter | All instruments (Reservations, Savings Plans) | Requires purchasing discipline |
+
+**Key insight:** Reservations are more liquid than Savings Plans on Azure. This is the
+opposite of the common assumption. Savings Plans offer usage flexibility (any family,
+any region) but zero financial liquidity (no exchange, no refund, no cancellation).
+Reservations lock to a specific SKU but allow exchanges, refunds, and instance size
+flexibility. When choosing between the two, factor liquidity into the decision - not
+just discount depth and coverage breadth.
+
+**The $50,000 refund cap:**
+Microsoft imposes a rolling 12-month cap of $50,000 across all Reservation refunds
+and exchanges that result in a decrease in value. For organisations with large
+Reservation portfolios, this cap can be a binding constraint. If you need to reshape
+more than $50,000 in Reservations within a year, you will hit the ceiling. Plan
+exchanges early and spread them across the 12-month window.
+
+### Phased purchasing
+
+Never buy the full commitment in a single transaction. Purchase in blocks of 10-25%
+of the target commitment to create a portfolio with staggered expiry dates.
+
+**Why phased purchasing matters on Azure:**
+- **Reduces lock-in risk:** if workloads migrate or are re-architected, only the
+  current block is at risk
+- **Creates natural re-evaluation points:** each purchase cycle forces a review of
+  utilisation, Advisor recommendations, and architecture direction
+- **Preserves refund/exchange headroom:** spreading purchases means smaller individual
+  Reservations, making it easier to stay within the $50K refund cap if changes are needed
+- **Aligns with MACC cadence:** phased purchasing can be timed to support MACC burndown
+  trajectory, avoiding end-of-period scrambles
+- **Captures pricing improvements:** newer VM generations (v5, v6) and architecture
+  shifts (ARM-based Dps/Eps families) can be reflected in subsequent blocks
+
+**Phased purchasing framework:**
+
+```
+Quarter 1: Buy 20-25% of target commitment (the floor you are certain about)
+  → Monitor utilisation for 30 days via Azure Advisor and Cost Management
+  → If utilisation >80%: proceed to next block
+  → If utilisation <80%: investigate before buying more
+
+Quarter 2: Buy next 15-20% block
+  → Reassess workload stability and architecture plans
+  → Review Reservation exchange opportunities on earlier blocks if workloads shifted
+
+Quarter 3: Buy next 15-20% block
+  → By now 50-65% of target is covered
+  → Remaining gap is intentional PAYG buffer
+
+Quarter 4: Evaluate whether to buy more or hold
+  → Factor MACC burndown position into the decision
+  → Early blocks from previous year start approaching renewal
+```
+
+**Portfolio view - staggered expiry example (1-year terms):**
+
+| Block | Purchased | Expires | % of total | Instrument | Rationale |
+|---|---|---|---|---|---|
+| Block 1 | Jan 2026 | Jan 2027 | 25% | Compute Savings Plan | Broad baseline across VMs + App Service |
+| Block 2 | Apr 2026 | Apr 2027 | 20% | VM Reservations (D-series) | Stable production VMs, deepest discount |
+| Block 3 | Jul 2026 | Jul 2027 | 15% | VM Reservations (E-series) | Memory-optimised database VMs |
+| Block 4 | Oct 2026 | Oct 2027 | 10% | DB Savings Plan | Database baseline across SQL + PostgreSQL |
+| PAYG | - | - | 30% | None | Buffer for variable / new workloads |
+
+**3-year term phasing:**
+For 3-year commitments (deeper discounts), purchase in smaller blocks (10-15%) at
+6-month intervals. The longer the term, the smaller each block should be.
+
+**Portfolio management cadence:**
+- **Monthly:** review Reservation and Savings Plan utilisation in Azure Cost Management.
+  Flag any commitment below 80% utilisation.
+- **Quarterly:** evaluate whether to purchase the next block, review Reservation
+  exchange opportunities, and check MACC burndown trajectory.
+- **At each expiry:** do not auto-renew blindly. Re-evaluate the workload: has it
+  grown, shrunk, migrated, or been decommissioned? Renew only what is still justified.
+  Azure Advisor provides renewal recommendations - use them as input, not as the decision.
+- **Annually:** review the overall commitment strategy against the organisation's Azure
+  roadmap. Adjust coverage ratio, instrument mix, and MACC alignment.
+
+**Commitment portfolio diagnostic questions:**
+- What percentage of your commitment portfolio expires in any single quarter? If more
+  than 30%, the portfolio is insufficiently diversified.
+- Are you buying commitments in phased blocks with staggered expiry, or purchasing the
+  full amount in a single transaction?
+- How much of your $50,000 Reservation refund/exchange cap have you used in the last
+  12 months? If you are close to the cap, you have less room to reshape the portfolio.
+- Are Savings Plans covering workloads that are stable enough for Reservations (leaving
+  ~7% discount on the table)?
+- Is MACC burndown tracking integrated into the same review cadence as commitment
+  purchasing? If not, optimisation gains may create a MACC shortfall risk.
+- Are engineering teams planning VM family migrations (e.g. to ARM-based Dps/Eps) that
+  would strand existing Reservations? If so, favour Savings Plans for those workloads
+  or plan Reservation exchanges in advance.
+
+**Key metrics:**
+- **Reservation/SP Utilisation:** Target >80%. Below this, the commitment is oversized.
+- **Reservation/SP Coverage:** Target 70% (Walk maturity), 80%+ (Run maturity).
+- **Effective Savings Rate:** actual savings / theoretical maximum. Measures how well
+  commitments are matched to real usage.
+- **Break-even period:** should be <9 months for 1-year terms, <15 months for 3-year.
+- **Commitment waste:** hours where committed capacity had no matching usage.
+- **Exchange headroom:** remaining $ available under the $50K/12-month refund cap.
+
+**Pre-purchase checklist:**
+- [ ] Azure Hybrid Benefit enabled on all eligible VMs and SQL instances
+- [ ] Workload has run stably for 90+ days
+- [ ] Workload has been right-sized (do not commit to waste)
+- [ ] No planned architecture changes during the commitment term
+- [ ] All resources are tagged and attributable to an owner
+- [ ] Existing commitment utilisation is >80% before purchasing more
+- [ ] MACC burndown trajectory reviewed - commitment purchase aligns with drawdown
+- [ ] Finance has approved the capital outlay (for Upfront payments)
 
 ### Microsoft Azure Consumption Commitment (MACC)
 

--- a/cloud-finops/references/finops-azure.md
+++ b/cloud-finops/references/finops-azure.md
@@ -389,8 +389,9 @@ exchanges early and spread them across the 12-month window.
 
 ### Phased purchasing
 
-Never buy the full commitment in a single transaction. Purchase in blocks of 10-25%
-of the target commitment to create a portfolio with staggered expiry dates.
+Never buy the full commitment in a single transaction. Purchase in blocks to create
+a portfolio with staggered expiry dates. The cadence and block size should match your
+consumption profile - not a fixed rule.
 
 **Why phased purchasing matters on Azure:**
 - **Reduces lock-in risk:** if workloads migrate or are re-architected, only the
@@ -404,7 +405,37 @@ of the target commitment to create a portfolio with staggered expiry dates.
 - **Captures pricing improvements:** newer VM generations (v5, v6) and architecture
   shifts (ARM-based Dps/Eps families) can be reflected in subsequent blocks
 
-**Phased purchasing framework:**
+**Cadence and block size by consumption profile:**
+
+The purchasing cadence should follow consumption volatility. The more variable the
+workload, the shorter the purchase cycle and the smaller each block. Your commitment
+refresh rate should be faster than your workload change rate.
+
+| Consumption profile | Examples | Cadence | Block size | Rationale |
+|---|---|---|---|---|
+| Steady, predictable | Enterprise ERP, internal tools, back-office systems | Quarterly | 20-25% | Workloads barely move quarter to quarter. Larger blocks capture deeper coverage faster. |
+| Moderate growth or gradual shifts | SaaS platforms, B2B applications, steady API services | Monthly to bi-monthly | 10-15% | Growth adds new capacity regularly. Smaller blocks incorporate new workloads without over-committing to the old baseline. |
+| Seasonal or event-driven | Retail (holiday peaks), media (live events), gaming (launches) | Monthly to weekly | 5-10% | Demand swings mean the baseline shifts frequently. Small blocks commit only to the proven floor; peaks stay on PAYG/Spot. |
+| Highly volatile or early-stage | Startups, experimental workloads, pre-product-market-fit | Weekly or do not commit | 5% or less | If you cannot predict next month, do not lock in for a year. Stay on PAYG with Spot until patterns stabilise. |
+
+**The cadence can shift over time for the same company.** A retail company might buy
+quarterly in Q1-Q3 (steady baseline) and switch to weekly in Q4 (holiday ramp) to
+avoid committing to peak capacity that evaporates in January. A SaaS company might
+start with monthly cadence during a growth phase and shift to quarterly once the
+growth rate stabilises.
+
+**Block size and cadence are inversely related:** higher frequency = smaller blocks.
+This keeps the total portfolio size similar but distributes the risk across more,
+smaller decisions.
+
+**Azure-specific consideration:** on Azure, Reservations can be exchanged mid-term,
+so organisations with moderate-frequency cadence (monthly/bi-monthly) can favour
+Reservations over Savings Plans - the exchange mechanism provides an additional
+liquidity layer on top of the staggered expiry approach. Organisations buying weekly
+may prefer Savings Plans to avoid the administrative overhead of frequent Reservation
+management.
+
+**Phased purchasing framework (quarterly example for steady consumption):**
 
 ```
 Quarter 1: Buy 20-25% of target commitment (the floor you are certain about)
@@ -425,7 +456,7 @@ Quarter 4: Evaluate whether to buy more or hold
   → Early blocks from previous year start approaching renewal
 ```
 
-**Portfolio view - staggered expiry example (1-year terms):**
+**Portfolio view - staggered expiry example (1-year terms, quarterly cadence):**
 
 | Block | Purchased | Expires | % of total | Instrument | Rationale |
 |---|---|---|---|---|---|
@@ -440,15 +471,17 @@ For 3-year commitments (deeper discounts), purchase in smaller blocks (10-15%) a
 6-month intervals. The longer the term, the smaller each block should be.
 
 **Portfolio management cadence:**
-- **Monthly:** review Reservation and Savings Plan utilisation in Azure Cost Management.
-  Flag any commitment below 80% utilisation.
-- **Quarterly:** evaluate whether to purchase the next block, review Reservation
-  exchange opportunities, and check MACC burndown trajectory.
+- **At each purchase cycle** (weekly/monthly/quarterly depending on profile): review
+  Reservation and Savings Plan utilisation in Azure Cost Management. Flag any commitment
+  below 80%. Decide whether to buy the next block, adjust the mix, or pause. Review
+  Reservation exchange opportunities on earlier blocks if workloads have shifted.
 - **At each expiry:** do not auto-renew blindly. Re-evaluate the workload: has it
   grown, shrunk, migrated, or been decommissioned? Renew only what is still justified.
   Azure Advisor provides renewal recommendations - use them as input, not as the decision.
+- **Quarterly (regardless of purchase cadence):** strategic review of commitment
+  coverage ratio, instrument mix, MACC burndown trajectory, and upcoming expiries.
 - **Annually:** review the overall commitment strategy against the organisation's Azure
-  roadmap. Adjust coverage ratio, instrument mix, and MACC alignment.
+  roadmap. Adjust coverage ratio, cadence, instrument mix, and MACC alignment.
 
 **Commitment portfolio diagnostic questions:**
 - What percentage of your commitment portfolio expires in any single quarter? If more


### PR DESCRIPTION
## Summary
- **AWS compute commitments:** decision tree covering EC2, Fargate, Lambda, SageMaker, EKS with instrument comparison (Standard RI, Convertible RI, EC2 Instance SP, Compute SP, Spot), layering strategy, and detailed SP vs RI comparison
- **AWS database commitments:** decision tree with instrument availability by service, self-managed vs RDS/Aurora comparison, layering strategy
- **Azure compute commitments:** decision tree covering VMs, AKS, App Service, Functions, Container Instances, Databricks with instrument comparison (Reservations, Savings Plans, AHB, Spot)
- **Azure database commitments:** decision tree with 6-step pre-commitment optimisation, Reservations vs DB Savings Plans vs layering
- **Commitment portfolio liquidity:** strategic framework for both clouds - AWS (marketplace resale, Convertible RI exchange, staggered expiry) and Azure (Reservation exchange/refund, instance size flexibility, staggered expiry, $50K refund cap)
- **Phased purchasing:** volatility-based cadence (weekly to quarterly) with block sizes adapted to consumption profile (steady, moderate growth, seasonal, volatile)

Key insights:
- Azure Reservations are more liquid than Savings Plans (exchanges + refunds), inverting the common assumption
- AWS Compute Savings Plans do NOT cover any managed database service
- Purchase cadence should follow consumption volatility, not a fixed schedule
- Convertible RIs provide mid-term exchange liquidity that Savings Plans lack

## Test plan
- [ ] Ask about EC2 commitment strategy - verify compute decision tree is loaded
- [ ] Ask about RDS vs Aurora commitment options - verify database decision tree
- [ ] Ask about Azure VM commitment strategy - verify Azure compute decision tree
- [ ] Ask about commitment portfolio management - verify liquidity and phased purchasing
- [ ] Ask "should I use Savings Plans or Reservations on Azure?" - verify the liquidity insight surfaces
- [ ] Verify SKILL.md line counts are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)