### PR TITLE
Tighten live-pricing discipline (AI dev tools) and source caveats (Anthropic)

### DIFF
--- a/cloud-finops/references/finops-ai-dev-tools.md
+++ b/cloud-finops/references/finops-ai-dev-tools.md
@@ -354,9 +354,13 @@ less per request.
 
 ### For BYOK tools (Claude Code, Codex)
 
-**Model selection** - Sonnet 4.6 at $3/$15 per MTok vs Opus 4.6 at $5/$25 for Claude Code.
-codex-mini at $1.50/$6 vs GPT-5 at $1.25/$10 for Codex. Choose the model that matches the
-task complexity. Default to the more efficient model and escalate only when needed.
+**Model selection** - Anthropic and OpenAI models span a wide rate range (Haiku /
+Sonnet / Opus on Anthropic, codex-mini / GPT-5 / GPT-5.5 on OpenAI). The typical
+spread is roughly 5x between cheapest and most capable model in each provider's
+line-up. Choose the model that matches the task complexity; default to the more
+efficient model and escalate only when needed. **Verify current per-token rates
+on the Anthropic and OpenAI pricing pages before using them in capacity planning -
+both providers re-price model lines on a multi-month cadence.**
 
 **Prompt caching** (Anthropic) - cache reads cost 0.1x the base input price. Cache writes
 cost 1.25x (5-minute TTL) or 2x (1-hour TTL). For repetitive workflows with stable system

--- a/cloud-finops/references/finops-anthropic.md
+++ b/cloud-finops/references/finops-anthropic.md
@@ -85,6 +85,13 @@ Total cost is now shaped by a combination of variables that FinOps must track ex
 
 ## Claude Managed Agents: new cost dimension
 
+> **Source quality flag.** The Managed Agents mechanics described in this section are
+> distilled primarily from Finout commentary and early community reporting, not from
+> Anthropic's primary pricing documentation. Treat the specifics (cost drivers,
+> always-on session billing, resource tiers) as **emerging assumptions** to validate
+> against official Anthropic docs before quoting in a customer engagement. Update this
+> section when Anthropic publishes settled pricing detail.
+
 ### What Managed Agents are
 
 Claude Managed Agents provide a fully managed runtime for autonomous AI agents with:
@@ -115,6 +122,14 @@ Unlike token-based API calls, Managed Agents introduce new cost drivers:
 ---
 
 ## Fast mode: key FinOps risks
+
+> **Source quality flag.** Fast mode pricing specifics in this section (6× premium
+> multiplier, sticky routing, retroactive context repricing) are sourced primarily
+> from Finout reporting and community observation, not from Anthropic's primary
+> pricing documentation. Treat as **emerging assumptions** - the qualitative shape
+> (Fast mode is a premium-priced channel, governance matters) is reliable; specific
+> multipliers and behaviours need verification against Anthropic docs before being
+> quoted as policy in customer engagements.
 
 ### What Fast mode is
 


### PR DESCRIPTION
Replaces hard-coded Anthropic and OpenAI per-token rates in the AI dev tools BYOK section with the 'verify live pricing' framing already used elsewhere in the file. Adds emerging-assumption source-quality flags to the Anthropic Managed Agents and Fast mode sections (Finout-sourced, validate against Anthropic primary docs before quoting in engagements).