### PR TITLE
Sync routing metadata across SKILL.md and POWER.md

### DIFF
--- a/cloud-finops/POWER.md
+++ b/cloud-finops/POWER.md
@@ -98,17 +98,17 @@ philosophy applied to all responses. Then load the domain reference that matches
 | AI costs, LLM inference, token economics, agentic cost patterns, AI ROI, AI cost allocation, GPU cost attribution, RAG harness costs | `references/finops-for-ai.md` |
 | AI investment governance, AI Investment Council, stage gates, incremental funding, AI value management | `references/finops-ai-value-management.md` |
 | GenAI capacity planning, provisioned vs shared capacity, traffic shape, spillover, throughput units | `references/finops-genai-capacity.md` |
-| AWS billing, EC2 rightsizing, RIs, Savings Plans, CUR, Cost Explorer | `references/finops-aws.md` |
-| AWS Bedrock billing, provisioned throughput, model unit pricing, batch inference | `references/finops-bedrock.md` |
-| Azure cost management, reservations, Azure Advisor, Cost Management, EA-to-MCA transition | `references/finops-azure.md` |
-| Azure OpenAI Service, PTU reservations, GPT pricing, AOAI spillover, fine-tuning costs | `references/finops-azure-openai.md` |
-| Anthropic billing, Claude API costs, Claude Code costs, pricing, Fast mode, prompt caching, Batch API | `references/finops-anthropic.md` |
-| GCP billing, Compute Engine, Cloud SQL, GCS, BigQuery optimization | `references/finops-gcp.md` |
-| GCP Vertex AI billing, Gemini pricing, provisioned throughput, batch prediction | `references/finops-vertexai.md` |
+| AWS billing, EC2 rightsizing, RIs, Savings Plans, commitment strategy, portfolio liquidity, phased purchasing, CUR, Data Exports for FOCUS 1.2, Cost Explorer hourly granularity, EDP negotiation, RDS cost management, database commitments, SageMaker AI Savings Plan, Database Savings Plan | `references/finops-aws.md` |
+| AWS Bedrock billing, Bedrock provisioned throughput, model unit pricing, Bedrock batch inference, Application Inference Profiles, Bedrock Projects, prompt caching, IAM Principal Cost Allocation | `references/finops-bedrock.md` |
+| Azure cost management, reservations, Savings Plans, Azure Hybrid Benefit, AHB, commitment strategy, portfolio liquidity, phased purchasing, sizing methodology, MACC, Azure Advisor, compute rightsizing, AKS optimisation, Azure Linux retirement, Node Auto Provisioning, NAP, database optimisation, Azure SQL, Cosmos, Log Analytics cost control, backup and snapshot management, storage tiering, networking cost, tagging and Azure Policy governance, FOCUS exports, EA-to-MCA transition, MCA contractual mechanics, billing hierarchy, ISF CSV | `references/finops-azure.md` |
+| Azure OpenAI Service, Azure AI Foundry, PTU reservations, locality constraint, GPT-4o, GPT-5 pricing, AOAI spillover, fine-tuning costs | `references/finops-azure-openai.md` |
+| Anthropic billing, Claude API costs, Claude Code costs, Opus, Sonnet, Haiku pricing, Fast mode, prompt caching, Batch API, long-context pricing, Managed Agents | `references/finops-anthropic.md` |
+| GCP billing, Compute Engine, Cloud SQL, GCS, BigQuery billing export, BigQuery optimisation, FOCUS export, Sustained Use Discounts, SUDs, Committed Use Discounts, CUDs, Flexible CUDs, Spot VMs, Cloud Carbon Footprint | `references/finops-gcp.md` |
+| GCP Vertex AI billing, Vertex provisioned throughput, Gemini pricing, Vertex batch prediction, default PAYG spillover | `references/finops-vertexai.md` |
 | Tagging strategy, naming conventions, IaC enforcement, MCP governance | `references/finops-tagging.md` |
-| FinOps framework, maturity model, phases, capabilities, personas | `references/finops-framework.md` |
-| Databricks clusters, jobs, Spark optimization, Unity Catalog costs | `references/finops-databricks.md` |
-| Snowflake warehouses, query optimization, storage, credits | `references/finops-snowflake.md` |
+| FinOps framework, 2024 baseline plus 2026 update, Executive Strategy Alignment, Usage Optimization, maturity model, phases, capabilities, personas | `references/finops-framework.md` |
+| Databricks clusters, jobs, Spark optimisation, Unity Catalog costs | `references/finops-databricks.md` |
+| Snowflake warehouses, query optimisation, storage, credits | `references/finops-snowflake.md` |
 | AI coding tools, Cursor costs, Claude Code costs, Copilot costs, Windsurf costs, Codex costs, dev tool FinOps, BYOK coding agents, LiteLLM proxy | `references/finops-ai-dev-tools.md` |
 | OCI compute, storage, networking optimization | `references/finops-oci.md` |
 | GreenOps, cloud carbon, sustainability, carbon-aware workloads | `references/greenops-cloud-carbon.md` |

--- a/cloud-finops/SKILL.md
+++ b/cloud-finops/SKILL.md
@@ -117,24 +117,24 @@ premature - they risk committing to waste.
 | File | Contents | Lines |
 |---|---|---|
 | `optimnow-methodology.md` | OptimNow reasoning philosophy, 4 pillars, engagement principles, tools | ~155 |
-| `finops-for-ai.md` | AI cost management, LLM economics, agentic patterns, ROI framework | ~490 |
+| `finops-for-ai.md` | AI cost management, LLM economics, agentic patterns, ROI framework | ~330 |
 | `finops-ai-value-management.md` | AI investment governance: AI Investment Council, stage gates, incremental funding, practice operations, value metrics | ~275 |
-| `finops-genai-capacity.md` | GenAI capacity models: provisioned vs shared, traffic shape, spillover, waste types, cross-provider comparison | ~225 |
-| `finops-aws.md` | AWS FinOps: CUR, Cost Explorer, EC2, compute/database commitment decision trees, portfolio liquidity, phased purchasing, EDP negotiation, RDS strategy, 128 optimisation patterns | ~2240 |
-| `finops-bedrock.md` | AWS Bedrock billing: model pricing, provisioned throughput, batch inference, CloudWatch metrics, cost allocation | ~225 |
-| `finops-azure.md` | Azure FinOps: reservations, Savings Plans, AHB, compute/database commitment decision trees, portfolio liquidity, MACC, EA-to-MCA transition, Advisor rightsizing, AKS optimisation, database patterns, Log Analytics cost control, backup/snapshot management, storage tiering, networking cost, tagging and Azure Policy governance, FOCUS exports | ~1500 |
-| `finops-azure-openai.md` | Azure OpenAI Service: PTU reservations, spillover, GPT model pricing, prompt caching, fine-tuning costs | ~390 |
-| `finops-anthropic.md` | Anthropic billing: Claude Opus/Sonnet/Haiku pricing, Fast mode, long-context cliffs, prompt caching, Batch API, governance | ~180 |
-| `finops-gcp.md` | GCP optimisation: 26 patterns across Compute Engine, Cloud SQL, GCS, networking | ~265 |
-| `finops-vertexai.md` | GCP Vertex AI billing: Gemini pricing, provisioned throughput, batch prediction, Cloud Monitoring metrics | ~235 |
+| `finops-genai-capacity.md` | GenAI capacity models: provisioned vs shared, traffic shape, spillover (incl. Vertex AI default-PAYG), waste types, cross-provider comparison | ~225 |
+| `finops-aws.md` | AWS FinOps: CUR + Data Exports for FOCUS 1.2 (GA Nov 2025), Cost Explorer hourly + resource-level, EC2, compute/database commitment decision trees including SageMaker AI and Database Savings Plans, portfolio liquidity, phased purchasing, EDP negotiation, RDS strategy, optimisation patterns | ~2630 |
+| `finops-bedrock.md` | AWS Bedrock: model pricing, provisioned throughput, Application Inference Profiles, Bedrock Projects, prompt caching with 1-hour TTL, IAM Principal Cost Allocation, CloudWatch metrics, cost allocation | ~350 |
+| `finops-azure.md` | Azure FinOps: reservations, Savings Plans, AHB, compute/database commitment decision trees, sizing methodology (granularity, Advisor calibration, tooling), portfolio liquidity, MACC, EA-to-MCA contractual mechanics (three MCA flavours, billing hierarchy with role-per-level), reservation chargeback trap, ISF CSV deprecation 9 May 2026, Advisor rightsizing, AKS in depth (NAP, Azure Linux 2 retirement), database patterns, Log Analytics 5-lever cost control, backup/snapshot management, storage tiering, networking cost, tagging and Azure Policy governance, FOCUS exports, 48-pattern catalogue | ~2980 |
+| `finops-azure-openai.md` | Azure OpenAI / AI Foundry: PTU reservations (locality constraint), reservation discount path, spillover, GPT model pricing, prompt caching, fine-tuning costs | ~410 |
+| `finops-anthropic.md` | Anthropic billing: Claude Opus/Sonnet/Haiku pricing, Fast mode and Managed Agents (flagged emerging-assumption), per-model long-context picture, prompt caching, Batch API, governance | ~280 |
+| `finops-gcp.md` | GCP FinOps: BigQuery billing export (standard / detailed / pricing), FOCUS export, Sustained Use Discounts, Committed Use Discounts (resource-based vs Flexible/spend-based with current 28%/46% depths), BigQuery commitment model, Spot VMs, Cloud Carbon Footprint location-based vs market-based, 26 inefficiency patterns | ~480 |
+| `finops-vertexai.md` | GCP Vertex AI billing: Gemini pricing, provisioned throughput (default-PAYG spillover), batch prediction, Cloud Monitoring metrics | ~245 |
 | `finops-tagging.md` | Tagging strategy, IaC enforcement, virtual tagging, MCP automation | ~250 |
-| `finops-framework.md` | Full FinOps Foundation framework: 22 capabilities, personas, domains | ~280 |
+| `finops-framework.md` | FinOps Foundation framework - 2024 baseline (4 domains, 22 capabilities) plus 2026 update (Executive Strategy Alignment, Workload Optimization -> Usage Optimization), personas, principles, phases | ~390 |
 | `finops-databricks.md` | Databricks optimisation: 18 patterns for clusters, jobs, Spark, storage | ~185 |
 | `finops-snowflake.md` | Snowflake FinOps: credit model, hidden cost categories, 13 optimisation patterns for warehouses, queries, storage | ~200 |
-| `finops-ai-dev-tools.md` | AI coding tools: Cursor, Claude Code, Copilot, Windsurf, Codex billing models, cost attribution, optimisation levers | ~400 |
+| `finops-ai-dev-tools.md` | AI coding tools: Cursor (Pro/Ultra/Teams/Enterprise), Claude Code, GitHub Copilot (transition to AI Credits 1 June 2026), Windsurf, OpenAI Codex (incl. GPT-5.5), billing models, cost attribution, optimisation levers | ~445 |
 | `finops-oci.md` | OCI optimisation: 6 patterns for compute, storage, networking | ~75 |
-| `finops-sam.md` | SaaS asset management: discovery, licence optimisation, renewal governance, SMPs, shadow IT, AI transition | ~290 |
-| `finops-itam.md` | FinOps-ITAM collaboration: BYOL mechanics, marketplace channel governance, vendor co-management, consumption monitoring, joint operating model | ~325 |
+| `finops-sam.md` | SaaS asset management: discovery, licence optimisation, renewal governance, SMPs, shadow IT, AI transition | ~210 |
+| `finops-itam.md` | FinOps-ITAM collaboration: BYOL mechanics, marketplace channel governance, vendor co-management, consumption monitoring, joint operating model | ~320 |
 | `greenops-cloud-carbon.md` | GreenOps: carbon measurement, carbon-aware workloads, region selection, GHG Protocol | ~330 |
 
 ---


### PR DESCRIPTION
Refreshes the SKILL.md reference table with current line counts and content descriptions reflecting the recent extensions (Azure ~2980, AWS ~2630, GCP ~480, etc.), and expands the POWER.md routing keywords to match SKILL.md depth so both entry points route equivalently. Also re-labels the framework reference as '2024 baseline plus 2026 update' rather than anchoring on the older 4-domain framing.