### PR TITLE
Expand Databricks, Snowflake, OCI references with modern cost-management primitives

### DIFF
--- a/cloud-finops/references/finops-databricks.md
+++ b/cloud-finops/references/finops-databricks.md
@@ -1,7 +1,103 @@
 # FinOps on Databricks
 
-> Databricks-specific optimization patterns covering compute clusters, jobs, storage, and configuration. 18 inefficiency patterns for diagnosing waste and building optimization roadmaps.
-> Source: PointFive Cloud Efficiency Hub.
+> Databricks-specific FinOps guidance covering cost data foundations (system tables,
+> budget policies, serverless and model-serving attribution) and 18 inefficiency
+> patterns for diagnosing waste and building optimisation roadmaps.
+
+---
+
+## Cost data foundations on Databricks
+
+Databricks cost data lives primarily in **system tables** in Unity Catalog. Account-
+admin queries against these tables are the canonical FinOps source of truth - cluster
+UI snapshots, dashboards, and per-workspace reports all derive from the same data.
+Skip the UI for serious analytics; query the system tables directly.
+
+### `system.billing.usage` - the canonical billing table
+
+The single most important table for Databricks FinOps. One row per usage record
+(typically 1-hour granularity), with fields covering account, workspace, SKU, DBUs
+consumed, list-price USD, and identifiers for the workload that consumed the DBUs
+(`usage_metadata` includes job_id, cluster_id, warehouse_id, endpoint_id depending
+on workload type).
+
+**Practical usage patterns:**
+- Daily allocation by team / tag / project: join `usage_metadata.tags` to a team
+  mapping; aggregate `usage_quantity` (DBUs) and `usage_quantity * list_price` (USD).
+- Job-level cost trending: filter by `billing_origin_product = 'JOBS'` and join to
+  `system.lakeflow.jobs` for job names.
+- Anomaly detection: month-over-month delta per workspace per SKU, flagged at >20%.
+
+**Important nuances:**
+- Data is account-level (not workspace-level) - all workspaces under one account
+  show up in the same table, controlled by `account_id`.
+- List-price USD is the published price, not the customer's negotiated rate. For
+  effective cost, multiply by your contract discount or join to `system.billing.list_prices`
+  for historical price rate-card.
+- Usage records appear with a typical 24-48 hour lag; do not use this for real-time
+  alerting (use cluster-level metrics for that).
+
+Source: https://docs.databricks.com/aws/en/admin/system-tables/billing
+
+### Budget policies - programmatic spend governance
+
+Budget policies are Databricks' first-class spend-control primitive (GA 2025). Define
+a policy that attaches to compute (cluster, job, warehouse, serverless endpoint) and
+enforces a spend cap with alert and/or hard-stop modes.
+
+**What budget policies enable:**
+- **Serverless serverless cost attribution before the fact** - tag the workload with
+  the policy ID, and all serverless DBU consumption rolls up to that policy in
+  billing reports (this is the canonical way to attribute serverless spend, since
+  serverless workloads don't expose node-level visibility).
+- **Spend caps with alerts** at configurable thresholds (e.g. 50%, 80%, 100%).
+- **Hard-stop enforcement** for non-production policies - workload terminates when
+  the cap is reached.
+- **Workspace or account scope** - policies can be enforced org-wide or per-workspace.
+
+**FinOps integration pattern:** create one budget policy per team or per cost-centre,
+require all serverless workloads to declare a policy at submission time, and
+reconcile against `system.billing.usage` monthly. This converts serverless from an
+attribution-blind cost into a per-team accountable line item.
+
+Source: https://docs.databricks.com/aws/en/admin/usage/budget-policies
+
+### Serverless attribution - what changes vs classic compute
+
+Serverless compute (SQL Warehouses serverless, Jobs serverless, Model Serving)
+differs from classic compute in two FinOps-relevant ways:
+
+1. **No node-level visibility.** You don't see the underlying VMs - Databricks
+   manages capacity and charges per DBU consumed. Cluster-level monitoring
+   patterns (autoscaler tuning, node pool selection) don't apply.
+2. **Attribution flows through workload IDs and budget policies, not cluster tags.**
+   Tag the *workload* (job, warehouse, endpoint) or attach a budget policy; the tag
+   propagates to `system.billing.usage` via `usage_metadata`.
+
+The serverless billing system table - `system.billing.usage` filtered to serverless
+SKUs, plus the more detailed serverless-specific tables - is the right starting
+point for serverless cost analysis. Don't try to back-derive cost from query
+duration; let the billing system tell you what it cost.
+
+Source: https://docs.databricks.com/aws/en/admin/system-tables/serverless-billing
+
+### Model serving attribution
+
+Databricks Model Serving (foundation model APIs and custom-deployed models) bills
+through dedicated meters that show up in `system.billing.usage` with
+`billing_origin_product = 'MODEL_SERVING'` and per-endpoint identifiers in
+`usage_metadata`.
+
+**Two distinct cost categories within model serving:**
+- **Provisioned throughput** - dedicated capacity for production endpoints, billed
+  per DBU-hour regardless of request volume. Right-size against P95 throughput.
+- **Pay-per-token** - token-based billing for foundation model APIs (Llama, Mixtral,
+  etc. served by Databricks). Billed per 1k input/output tokens.
+
+**Per-endpoint attribution pattern:** require all model-serving endpoints to carry
+a `cost_centre` and `application` tag at deployment. Aggregate from
+`system.billing.usage` weekly to surface high-cost endpoints and re-evaluate
+provisioned-throughput sizing for ones consistently below 50% utilisation.
 
 ---
 

--- a/cloud-finops/references/finops-oci.md
+++ b/cloud-finops/references/finops-oci.md
@@ -1,7 +1,102 @@
 # FinOps on OCI
 
-> Oracle Cloud Infrastructure optimization patterns covering compute, storage, and networking. 6 inefficiency patterns for diagnosing waste and building optimization roadmaps.
-> Source: PointFive Cloud Efficiency Hub.
+> Oracle Cloud Infrastructure FinOps guidance covering cost data foundations
+> (Cost Reports, FOCUS, cost-tracking tags, Budgets, Universal Credits) and 6
+> inefficiency patterns for diagnosing waste and building optimisation roadmaps.
+
+---
+
+## OCI cost data foundations
+
+OCI's billing and cost-management primitives differ from AWS / Azure / GCP in
+naming and structure but cover the same conceptual ground. The five primitives
+below are the FinOps practitioner's starting kit on any OCI engagement.
+
+### Cost Reports (legacy CSV exports)
+
+OCI's billing data export. Cost Reports are CSVs delivered daily to a tenancy-
+owned Object Storage bucket, with one row per usage record. The schema covers
+service, SKU, compartment, tags, region, usage quantity, list rate, discounted
+rate, and effective cost.
+
+**Practical setup:**
+- Cost Reports are auto-generated daily once enabled at the tenancy root.
+- Files land in a dedicated Oracle-managed Object Storage bucket; access requires
+  a policy granting your tenancy read on `bling-bucket` (the canonical name).
+- Retention: typically 365 days of historical reports retained, but verify per
+  tenancy as Oracle has changed retention policy historically.
+- Daily granularity (no hourly), which is similar to Azure Cost Management
+  exports - the same daily-vs-hourly capacity-sizing nuance applies for OCI as
+  documented for Azure.
+
+Source: https://docs.oracle.com/iaas/Content/Billing/Concepts/costusagereportsoverview.htm
+
+### FOCUS Reports - the cross-cloud-conformant export
+
+OCI publishes a **FOCUS-conformant cost export** alongside the legacy Cost Reports.
+This is the path for multi-cloud customers who want OCI cost data in the same
+schema as AWS Data Exports for FOCUS 1.2 and Azure Cost Management's FOCUS 1.2
+preview. Coexistence pattern: enable both - FOCUS for multi-cloud normalisation
+into a unified warehouse, legacy Cost Reports for OCI-native columns the FOCUS
+schema doesn't surface.
+
+### Cost-tracking tags - first-class billing-attribution primitive
+
+OCI distinguishes three tag types, and only one of them flows into cost reports:
+
+| Tag type | Scope | Surfaces in Cost Reports? |
+|---|---|---|
+| **Freeform tags** | User-applied key/value | Limited - not native cost-allocation primitive |
+| **Defined tags** | Schema-enforced via tag namespaces | Yes, but verbose in cost data |
+| **Cost-tracking tags** | Subset of defined tags explicitly marked for billing | **Yes - the canonical cost-allocation tag** |
+
+**Practical implication:** mark the tags you want to allocate cost by - typically
+`cost_centre`, `team`, `application`, `environment` - as cost-tracking tags
+(maximum 10 per tenancy as of 2026, verify current limit). They then propagate
+to Cost Reports and become the primary cost-allocation grouping dimension. Tags
+not marked as cost-tracking still apply to resources but require manual joins to
+attribute spend.
+
+Day-1 audit on any OCI engagement: list cost-tracking tags via the Tagging
+console, verify against the customer's intended allocation dimensions, and add
+missing ones before the next billing cycle (the cap forces deliberate choice).
+
+### OCI Budgets
+
+OCI Budgets provide spend caps with email and event-grid alerts at the
+**compartment** or **cost-tracking tag** scope. Budgets are alert-only by default
+- they do not enforce hard stops the way Azure Budgets or Snowflake Budgets can.
+
+**Practical setup:**
+- One budget per top-level cost-allocation boundary (compartment for org-by-
+  project tenancies; cost-tracking tag for org-by-team tenancies).
+- Alert thresholds at 50%, 80%, 100% of forecast.
+- Route alerts to both FinOps and engineering team leads (FinOps-only alerts
+  create a bottleneck).
+
+Source: https://docs.oracle.com/iaas/Content/Billing/Concepts/budgetsoverview.htm
+
+### Universal Credits - Oracle's commercial commitment construct
+
+Universal Credits are Oracle's multi-year spend commitment, analogous to AWS EDP
+and Azure MACC. The customer commits to a defined dollar amount over 1-3 years;
+eligible OCI consumption draws down against that commitment.
+
+**FinOps responsibility under Universal Credits:**
+- **Burndown alignment** - track actual spend vs commitment trajectory monthly.
+  An optimisation programme that succeeds in reducing OCI spend can leave the
+  customer with an unspent Universal Credit balance at term end (the same
+  optimisation paradox documented for Azure MACC).
+- **Coverage** - most native OCI services count toward Universal Credit burndown,
+  but third-party Marketplace listings and certain Oracle SaaS products may not.
+  Verify product eligibility at procurement, not at burn-time.
+- **Annual commitment vs three-year commitment** - longer term gives deeper
+  discount but compounds the optimisation-vs-burndown tension. Evaluate
+  consumption stability before committing for three years.
+
+The Universal Credits / FinOps interaction mirrors the MACC framing in
+`finops-azure.md` - read that section for the full optimisation-paradox and
+operational-cadence guidance, then apply OCI-specific coverage rules.
 
 ---
 

--- a/cloud-finops/references/finops-snowflake.md
+++ b/cloud-finops/references/finops-snowflake.md
@@ -70,6 +70,111 @@ FinOps practitioners coming from AWS instinctively look for tags. On Snowflake, 
 
 ---
 
+## Modern cost-management primitives
+
+Snowflake's cost-attribution surface improved materially in 2025-2026. The FinOps
+practitioner's toolbox is no longer just `WAREHOUSE_METERING_HISTORY` and resource
+monitors - there are now per-query attribution views, programmable budgets, and AI
+feature governance.
+
+### `QUERY_ATTRIBUTION_HISTORY` - per-query credit attribution
+
+The right starting point for "which query consumed which credit" analysis.
+`SNOWFLAKE.ACCOUNT_USAGE.QUERY_ATTRIBUTION_HISTORY` exposes credit consumption per
+query with finer attribution than `QUERY_HISTORY`:
+
+| Column | What it gives |
+|---|---|
+| `QUERY_ID` | Joins to `QUERY_HISTORY` for query text and timing |
+| `CREDITS_ATTRIBUTED_COMPUTE` | Compute credits attributed to the specific query |
+| `CREDITS_USED_QUERY_ACCELERATION` | Query Acceleration Service credits per query |
+| `WAREHOUSE_ID`, `USER_NAME`, `ROLE_NAME` | Standard attribution dimensions |
+| `PARENT_QUERY_ID` | For procedures and nested queries |
+
+**Coverage spans virtual warehouses, serverless tasks, and Cortex AI** - this is the
+single view that ties all three to a credit number per query.
+
+**How it differs from `QUERY_HISTORY`:** `QUERY_HISTORY` shows execution metadata
+(duration, bytes scanned, rows returned). `QUERY_ATTRIBUTION_HISTORY` shows the
+actual credit cost, calculated by Snowflake based on warehouse utilisation during
+the query window. Two queries with similar execution times can have very different
+credit attributions if one ran on a busy warehouse and the other had the warehouse
+to itself.
+
+**Retention:** 365 days in `ACCOUNT_USAGE`, 14 days in `INFORMATION_SCHEMA.QUERY_ATTRIBUTION_HISTORY`.
+
+**Practical FinOps query:** top 50 queries by credits last 30 days, joined to
+`QUERY_HISTORY` for the SQL text - this surfaces the actual heavy hitters that
+warehouse-level metering hides.
+
+Source: https://docs.snowflake.com/en/sql-reference/account-usage/query_attribution_history
+
+### Snowflake Budgets - programmable spend governance
+
+Snowflake Budgets (GA 2024, AI feature budgets GA April 2026) provide spend caps
+with alerts at the account, database, schema, or feature level. The mechanic:
+define a budget object, attach it to a scope, set spend limits and notification
+recipients, and Snowflake enforces or alerts based on cumulative consumption.
+
+**Three useful patterns:**
+- **Account-level safety net** - one budget at the account level with alert at 80%
+  of monthly target, hard limit at 100%. This is the floor - every customer should
+  have it.
+- **Per-database or per-schema budgets** - aligns spend with logical workload
+  boundaries, useful where database = team or database = product.
+- **AI feature budgets** (GA April 2026) - a dedicated budget type that caps
+  Cortex AI consumption (LLM functions, vector search, document AI, etc.)
+  separately from warehouse compute. Important: Cortex spend is otherwise
+  invisible to resource monitors (see below) - AI feature budgets are the only
+  built-in mechanism to cap it.
+
+Sources: https://docs.snowflake.com/en/user-guide/budgets, https://docs.snowflake.com/en/release-notes/2026/other/2026-04-10-budgets-ai-features-ga
+
+### Resource monitors - the warehouse-only constraint
+
+Snowflake Resource Monitors are the older spend-control primitive and still useful,
+but they have a **critical scope limit**: resource monitors **only monitor virtual
+warehouses**. They do not cover:
+
+- **Cortex AI consumption** (LLM functions, document AI, etc.)
+- **Serverless tasks**
+- **Snowpipe ingest credits**
+- **Materialized view auto-refresh**
+- **Search optimisation service**
+- **Replication and failover**
+
+A resource monitor with "100 credits/month, suspend warehouse" enforcement does
+nothing if the credit burn is on Cortex or Snowpipe. **The common cost-control
+posture gap:** customer has resource monitors on every warehouse and assumes
+spend is capped, when serverless / Cortex / Snowpipe are unbounded. Fix: pair
+resource monitors with Snowflake Budgets at higher scopes, and use AI feature
+budgets specifically for Cortex.
+
+Source: https://docs.snowflake.com/en/user-guide/resource-monitors
+
+### Cortex AI cost governance
+
+Cortex AI consumption (Cortex LLM functions, Cortex Search, Cortex Analyst,
+Document AI) bills in credits like everything else, but with three FinOps-relevant
+differences from warehouse compute:
+
+1. **Per-function token-equivalent pricing.** Each Cortex function has a credit-
+   per-token (or credit-per-call) rate that varies by function and underlying
+   model. Cortex LLM functions in particular have a wide credit range across
+   models (e.g. cheaper Llama-class models vs Anthropic Claude-class models).
+2. **No node-level rightsizing.** Cortex is fully managed - no warehouse to size,
+   no autoscaler to tune. The optimisation lever is **prompt design and model
+   selection**, not infrastructure.
+3. **Resource monitors do not cover Cortex.** Use AI feature budgets (above) for
+   spend caps.
+
+Surface Cortex consumption via `QUERY_ATTRIBUTION_HISTORY` filtered to Cortex-
+related warehouses or via the dedicated Cortex usage views. Tag Cortex calls with
+session metadata (`SET QUERY_TAG = 'team:ds, app:rag-pipeline'`) so credit
+attribution carries the application context into `QUERY_HISTORY`.
+
+---
+
 ## Compute Optimization Patterns (5)
 
 **Inefficient Execution Of Repeated Queries**


### PR DESCRIPTION
Adds dedicated cost-data foundation sections above the existing pattern catalogues in three reference files.

**Databricks:** `system.billing.usage` system table, budget policies (with serverless attribution implications), serverless attribution mechanics (no node-level visibility, workload-tag propagation), model serving attribution (provisioned throughput vs pay-per-token).

**Snowflake:** `QUERY_ATTRIBUTION_HISTORY` per-query credit attribution (covering warehouses, serverless, and Cortex AI), Snowflake Budgets including AI feature budgets GA April 2026, the resource-monitor scope limit (warehouses only - does not cover Cortex, Snowpipe, or serverless tasks), Cortex AI cost governance.

**OCI:** Cost Reports (legacy CSV), FOCUS Reports (cross-cloud-conformant), cost-tracking tags (the canonical billing-attribution primitive distinct from defined and freeform tags), OCI Budgets, Universal Credits (Oracle's commercial commitment construct, with cross-reference to the Azure MACC optimisation paradox).

Existing pattern catalogues preserved verbatim. Sources cited inline.