### PR TITLE
Framework 2024-baseline reframing + finops-for-ai Managed Agents source flag

### DIFF
--- a/cloud-finops/references/finops-for-ai.md
+++ b/cloud-finops/references/finops-for-ai.md
@@ -120,6 +120,14 @@ beyond token-based inference. Managed agents run in provider-controlled sandboxe
 environments with persistent sessions and autonomous execution capabilities. Cost drivers
 differ fundamentally from standard API calls:
 
+> **Source quality flag.** The Managed Agents cost-driver bullets below are sourced
+> primarily from Finout commentary and early community reporting, not from
+> Anthropic's primary pricing documentation. Treat as **emerging assumptions** to
+> validate against official Anthropic docs before quoting in customer engagements.
+> See `finops-anthropic.md` for the same caveat applied to the dedicated Anthropic
+> reference.
+
+
 - **Session-based billing** - charged per active session hour, not per token
 - **Compute resource allocation** - dedicated CPU/memory for agent execution
 - **Tool invocation costs** - each external API call or database query adds cost

--- a/cloud-finops/references/finops-framework.md
+++ b/cloud-finops/references/finops-framework.md
@@ -130,7 +130,15 @@ become difficult to reverse.
 
 ---
 
-## The 4 Domains and 22 Capabilities
+## The 4 Domains and 22 Capabilities (2024 baseline)
+
+> The structure documented in this section is the **2024 framework baseline**. The
+> FinOps Foundation published a **2026 framework update** (Executive Strategy
+> Alignment dimension; Workload Optimization renamed to Usage Optimization;
+> capability list refreshed) - see "2026 framework update" further down for the
+> changes. In customer engagements as of 2026, use the 2026 capability names; the
+> 2024 baseline below remains useful for mapping legacy artefacts (older
+> assessments, vendor proposals, procurement decks) to current terminology.
 
 ### Domain 1: Understand Usage and Cost
 


### PR DESCRIPTION
Two surgical edits.

**finops-framework.md:** the heading `## The 4 Domains and 22 Capabilities` is renamed `## The 4 Domains and 22 Capabilities (2024 baseline)` and prefaced with a one-paragraph explainer that this is the 2024 structure, the 2026 update (Executive Strategy Alignment, Workload Optimization -> Usage Optimization) is documented further down, and customers in 2026+ engagements should use the 2026 capability names with the 2024 baseline as historical context.

**finops-for-ai.md:** the Managed Agents passage near line 117 now carries the same `Source quality flag` callout as the dedicated Anthropic file, marking the cost-driver bullets as emerging assumptions sourced from Finout reporting rather than Anthropic primary pricing docs.