### PR TITLE
Add Microsoft Fabric reference and Databricks allocation/governance content

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,9 @@ The skill provides accurate, framework-aligned guidance across the following dom
 - **Tagging governance** - tag taxonomy design, naming conventions, IaC enforcement,
   virtual tagging, MCP-based automation, and compliance monitoring
 - **FinOps Framework** - full FinOps Foundation framework, 22 capabilities, maturity model
-- **Databricks** - cluster optimisation, jobs, Spark, Unity Catalog costs
-- **Snowflake** - warehouse optimisation, query tuning, storage, credits
+- **Databricks** - cost data foundations (system.billing.usage, budget policies, serverless and model-serving attribution), allocation and governance (DBU executor patterns, DBCU commitments, Photon and serverless multipliers, amortised vs PAYG split, Azure VM RI vs DBU clarification), cluster optimisation, jobs, Spark, Unity Catalog costs
+- **Microsoft Fabric** - capacity FinOps (F-SKU model, Capacity Units, 24-hour CU smoothing, throttling), pause / resume, Reserved Capacity, the Pro/PPU to Fabric migration governance trap, shared-capacity allocation models, Capacity Metrics app
+- **Snowflake** - warehouse optimisation, query tuning, storage, credits, QUERY_ATTRIBUTION_HISTORY, Budgets including AI feature budgets, Cortex governance, resource monitor scope limit
 - **AI coding tools** - Cursor, Claude Code, Copilot, Windsurf, Codex billing models,
   cost attribution with LiteLLM proxy, seat + usage vs BYOK architecture comparison,
   optimisation levers, cross-tool spend overlap audit
@@ -240,7 +241,8 @@ cloud-finops-skills/
         ├── finops-vertexai.md                  ← GCP Vertex AI billing
         ├── finops-tagging.md                   ← Tagging and naming governance
         ├── finops-framework.md                 ← Full FinOps Foundation framework
-        ├── finops-databricks.md                ← Databricks optimisation
+        ├── finops-databricks.md                ← Databricks allocation, governance, and optimisation
+        ├── finops-fabric.md                    ← Microsoft Fabric capacity FinOps
         ├── finops-snowflake.md                 ← Snowflake optimisation
         ├── finops-ai-dev-tools.md             ← AI coding tools (Cursor, Claude Code, etc.)
         ├── finops-oci.md                       ← OCI optimisation

--- a/cloud-finops/POWER.md
+++ b/cloud-finops/POWER.md
@@ -39,6 +39,13 @@ keywords:
   - cost explorer
   - cur
   - databricks cost
+  - dbu
+  - dbcu
+  - microsoft fabric
+  - fabric capacity
+  - f-sku
+  - capacity unit
+  - power bi premium
   - snowflake cost
   - oci cost
   - greenops
@@ -107,7 +114,8 @@ philosophy applied to all responses. Then load the domain reference that matches
 | GCP Vertex AI billing, Vertex provisioned throughput, Gemini pricing, Vertex batch prediction, default PAYG spillover | `references/finops-vertexai.md` |
 | Tagging strategy, naming conventions, IaC enforcement, MCP governance | `references/finops-tagging.md` |
 | FinOps framework, 2024 baseline plus 2026 update, Executive Strategy Alignment, Usage Optimization, maturity model, phases, capabilities, personas | `references/finops-framework.md` |
-| Databricks clusters, jobs, Spark optimisation, Unity Catalog costs | `references/finops-databricks.md` |
+| Databricks clusters, jobs, Spark optimisation, Unity Catalog costs, allocation and governance, DBU executor attribution, DBCU commitments, Photon multiplier, serverless premium, amortised vs PAYG split, Azure VM RI vs DBU clarification | `references/finops-databricks.md` |
+| Microsoft Fabric capacity FinOps, F-SKUs, Capacity Units, CU smoothing window, throttling, pause/resume, Reserved Capacity, Pro/PPU to Fabric migration governance, Capacity Metrics app, shared-capacity allocation | `references/finops-fabric.md` |
 | Snowflake warehouses, query optimisation, storage, credits | `references/finops-snowflake.md` |
 | AI coding tools, Cursor costs, Claude Code costs, Copilot costs, Windsurf costs, Codex costs, dev tool FinOps, BYOK coding agents, LiteLLM proxy | `references/finops-ai-dev-tools.md` |
 | OCI compute, storage, networking optimization | `references/finops-oci.md` |

--- a/cloud-finops/SKILL.md
+++ b/cloud-finops/SKILL.md
@@ -6,7 +6,9 @@ description: >
   CUR, commitment strategy), Azure (reservations, Savings Plans, AHB, OpenAI PTUs, portfolio
   liquidity), GCP (Vertex AI, Compute Engine, BigQuery), tagging governance, SaaS management
   (SAM, licence optimisation, SMPs, shadow IT), AI coding tools (Cursor, Claude Code,
-  Copilot, Windsurf, Codex), ITAM, Databricks, Snowflake, OCI, and GreenOps. Use for any
+  Copilot, Windsurf, Codex), ITAM, data platforms (Databricks allocation and governance with
+  DBCU commitments, Microsoft Fabric capacity FinOps with F-SKUs, CU smoothing, reservations,
+  pause/resume, Pro-to-Fabric migration governance), Snowflake, OCI, and GreenOps. Use for any
   query about technology cost, commitment portfolio management, rightsizing, cost allocation,
   SaaS sprawl, AI dev tool spend, or connecting spend to business value. Built by OptimNow.
 ---
@@ -39,7 +41,8 @@ philosophy applied to all responses. Then load the domain reference that matches
 | GCP Vertex AI billing, Vertex provisioned throughput, Gemini pricing, Vertex batch prediction | `references/finops-vertexai.md` |
 | Tagging strategy, naming conventions, IaC enforcement, MCP governance | `references/finops-tagging.md` |
 | FinOps framework, maturity model, phases, capabilities, personas | `references/finops-framework.md` |
-| Databricks clusters, jobs, Spark optimisation, Unity Catalog costs | `references/finops-databricks.md` |
+| Databricks clusters, jobs, Spark optimisation, Unity Catalog costs, allocation and governance, DBU executor attribution, DBCU commitments, Photon multiplier, serverless premium, amortised vs PAYG split, Azure VM RI vs DBU clarification | `references/finops-databricks.md` |
+| Microsoft Fabric capacity FinOps, F-SKUs, Capacity Units, CU smoothing window, throttling, pause/resume, Reserved Capacity, Pro/PPU to Fabric migration governance, Capacity Metrics app, shared-capacity allocation | `references/finops-fabric.md` |
 | Snowflake warehouses, query optimisation, storage, credits | `references/finops-snowflake.md` |
 | AI coding tools, Cursor costs, Claude Code costs, Copilot costs, Windsurf costs, Codex costs, dev tool FinOps, seat + usage billing, BYOK coding agents, LiteLLM proxy | `references/finops-ai-dev-tools.md` |
 | OCI compute, storage, networking optimisation | `references/finops-oci.md` |
@@ -129,7 +132,8 @@ premature - they risk committing to waste.
 | `finops-vertexai.md` | GCP Vertex AI billing: Gemini pricing, provisioned throughput (default-PAYG spillover), batch prediction, Cloud Monitoring metrics | ~245 |
 | `finops-tagging.md` | Tagging strategy, IaC enforcement, virtual tagging, MCP automation | ~250 |
 | `finops-framework.md` | FinOps Foundation framework - 2024 baseline (4 domains, 22 capabilities) plus 2026 update (Executive Strategy Alignment, Workload Optimization -> Usage Optimization), personas, principles, phases | ~390 |
-| `finops-databricks.md` | Databricks optimisation: 18 patterns for clusters, jobs, Spark, storage | ~185 |
+| `finops-databricks.md` | Databricks FinOps: cost data foundations (system.billing.usage, budget policies, serverless and model-serving attribution), allocation and governance (workspace + DBU executor patterns, Azure VM RI vs DBU clarification, DBCU commitments, Photon and serverless multipliers, amortised vs PAYG split, monthly cadence, sequencing), 18 inefficiency patterns | ~440 |
+| `finops-fabric.md` | Microsoft Fabric capacity FinOps: F-SKU model, Capacity Units and 24-hour CU smoothing, throttling behaviour, manual pause / resume, Reserved Capacity, Pro/PPU to Fabric migration governance trap, shared-capacity allocation models, Capacity Metrics app, Pro vs PPU vs F-SKU breakeven | ~200 |
 | `finops-snowflake.md` | Snowflake FinOps: credit model, hidden cost categories, 13 optimisation patterns for warehouses, queries, storage | ~200 |
 | `finops-ai-dev-tools.md` | AI coding tools: Cursor (Pro/Ultra/Teams/Enterprise), Claude Code, GitHub Copilot (transition to AI Credits 1 June 2026), Windsurf, OpenAI Codex (incl. GPT-5.5), billing models, cost attribution, optimisation levers | ~445 |
 | `finops-oci.md` | OCI optimisation: 6 patterns for compute, storage, networking | ~75 |

--- a/cloud-finops/references/finops-databricks.md
+++ b/cloud-finops/references/finops-databricks.md
@@ -1,8 +1,26 @@
 # FinOps on Databricks
 
 > Databricks-specific FinOps guidance covering cost data foundations (system tables,
-> budget policies, serverless and model-serving attribution) and 18 inefficiency
-> patterns for diagnosing waste and building optimisation roadmaps.
+> budget policies, serverless and model-serving attribution), allocation and
+> governance, commitment instruments, and 18 inefficiency patterns for diagnosing
+> waste and building optimisation roadmaps.
+
+---
+
+## The data-platform FinOps problem
+
+For Databricks (and Microsoft Fabric, see `finops-fabric.md` for the parallel
+treatment), the cost object the platform reports - workspace, capacity, DBU hours,
+query execution, capacity unit consumption - is rarely the same as the business
+object Finance wants to allocate against (application, product, team, business unit,
+data domain, use case). A shared workspace or shared Fabric capacity does not
+naturally tell Finance who consumed what. The FinOps model needs a translation
+layer between platform telemetry and business ownership. **Build the model around
+the consumption driver, then reconcile it back to the invoice - not the other way
+around.**
+
+This framing is shared with `finops-fabric.md`. The mechanics differ between the two
+platforms; the allocation problem is the same.
 
 ---
 
@@ -274,6 +292,151 @@ Databricks cost optimization begins with visibility. Unlike traditional IaaS ser
 - Storage: Align S3/ADLS/GCS usage with lifecycle policies and avoid excessive churn
 
 ---
+
+## Allocation and Governance
+
+The optimisation patterns above answer "where is the waste?" This section answers
+"who pays?" - the harder problem on a shared data platform.
+
+### Workspace-level reporting is necessary but not sufficient
+
+Workspace cost alone is too coarse. A single workspace is shared across teams, jobs,
+notebooks, pipelines, and experiments. Allocating only by workspace owner risks
+charging the platform owner or default business unit, not the actual consumer.
+
+A useful Databricks allocation model layers signals:
+
+| Layer | Allocation signal | Why it matters |
+|---|---|---|
+| Workspace | name, owner, business mapping | First-level showback |
+| Compute | cluster, job, pool usage | Identifies major technical cost drivers |
+| Execution | query executor, job owner, notebook owner | Links cost to users or teams |
+| Consumption | DBU hours | Core usage metric |
+| Financial view | amortised vs PAYG cost | Shows savings from commitments |
+
+The strongest single allocation pattern: **DBU hours by executor or workload,
+translated into amortised cost.**
+
+```sql
+-- DBU hours by executor / job, joined to workspace metadata, last 30 days
+-- Adjust to your account's system table location and tag conventions.
+WITH usage_by_executor AS (
+  SELECT
+    workspace_id,
+    coalesce(usage_metadata.job_id,
+             usage_metadata.cluster_id,
+             usage_metadata.warehouse_id,
+             usage_metadata.endpoint_id) AS workload_id,
+    coalesce(identity_metadata.run_as,
+             usage_metadata.created_by) AS executor,
+    sku_name,
+    sum(usage_quantity) AS dbu_hours,
+    sum(usage_quantity * list_price) AS list_usd
+  FROM system.billing.usage
+  LEFT JOIN system.billing.list_prices USING (sku_name, currency_code, usage_unit)
+  WHERE usage_date >= current_date() - INTERVAL 30 DAY
+  GROUP BY ALL
+)
+SELECT
+  workspace_id,
+  executor,
+  workload_id,
+  sku_name,
+  round(sum(dbu_hours), 2) AS dbu_hours,
+  round(sum(list_usd), 2) AS list_usd_30d
+FROM usage_by_executor
+GROUP BY ALL
+ORDER BY list_usd_30d DESC
+LIMIT 50;
+```
+
+The query is illustrative - your `system.billing.list_prices` schema and
+identity-metadata fields may differ; adapt column names to your account.
+
+### The Azure VM Reservation vs DBU clarification
+
+**Common trap.** Databricks compute runs on Azure VMs, so **Azure VM Reservations
+apply to the underlying VM compute layer**. But Databricks also charges a separate
+**DBU meter** for the Databricks platform layer, billed independently. **Azure VM
+RIs do not cover the DBU meter.**
+
+- Azure VM RI -> covers the VM hourly charge.
+- DBU meter -> covered by Databricks-specific commitments (DBCU, see below) or
+  paid PAYG.
+
+Customers coming from VM-only commitment thinking often assume an Azure RI on the
+underlying VM family covers their Databricks bill. It covers half of it. Surface
+both meters separately when modelling Databricks commitment economics.
+
+### Databricks commitment instruments
+
+- **DBCU (Databricks Commit Units)** - annual prepaid commitment to a $ amount of
+  DBUs. Separate from Azure RIs and Savings Plans; negotiated with Databricks /
+  Microsoft directly. Discount depth depends on commitment size and tier.
+- **Photon multiplier** - Photon-enabled clusters consume DBUs at roughly 2x the
+  base rate but execute 2-3x faster on supported workloads (vectorised SQL,
+  certain DataFrame ops). Net cost can go down despite the multiplier; depends on
+  workload. Validate per workload before defaulting Photon on or off org-wide.
+- **Serverless premium** - Serverless SQL Warehouses, jobs, and notebooks consume
+  DBUs at a higher rate (roughly 1.5-2x) than classic compute. Trade-off: no
+  cluster management overhead, near-instant start, no idle cost. Worth it for
+  spiky interactive work; not always worth it for steady-state heavy jobs.
+- **DBU rates differ by workload type** - Jobs Compute is the cheapest tier,
+  All-Purpose is the most expensive, SQL Warehouse sits between with tier-
+  dependent rates. Migrating a scheduled job from All-Purpose to Jobs Compute is
+  often a 30-40% saving with zero functional change. **Verify current rates
+  against the Databricks Azure pricing page; do not hard-code.**
+
+### Amortised vs PAYG visibility - splitting the conversation
+
+A useful Databricks cost report shows **both amortised cost and PAYG-equivalent
+cost.** This separates two distinct conversations:
+
+- **Consumption conversation** - "Who used the platform, and how much?" - driven
+  by DBU hours and PAYG-equivalent cost. The right view for showback to teams,
+  capacity planning, and unit-economics work.
+- **Commercial effectiveness conversation** - "How much did reservations or DBCU
+  commitments reduce the effective rate?" - driven by amortised vs PAYG delta.
+  The right view for finance to assess commitment ROI and for FinOps to track ESR
+  (Effective Savings Rate).
+
+Without this split, teams may believe their behaviour generated savings when the
+savings actually came from centralised commitment purchasing, or the reverse - a
+team that genuinely reduced consumption sees no impact in their amortised number
+because the contractual amortisation is fixed.
+
+### Monthly review cadence - Databricks side
+
+| Review item | Source signal |
+|---|---|
+| Top cost drivers | DBU hours by workspace, job, user (from `system.billing.usage` joined to `system.lakeflow.jobs`) |
+| Waste | Idle clusters, unused jobs, oversized clusters (cluster events + utilisation metrics) |
+| Allocation gaps | Unmapped workspaces, missing executor labels, untagged workloads |
+| Commitment status | DBCU utilisation, RI utilisation on underlying VMs, PAYG-equivalent vs amortised delta |
+| Anomalies | DBU hour spikes, query activity spikes (>20% week-over-week threshold) |
+| Actions | Tune jobs, remove clusters, fix labels, scope new commitments |
+
+This feeds Finance, platform engineering, and data owners simultaneously - the
+review is not three separate meetings.
+
+### Sequencing - clean up before committing
+
+Standard FinOps sequencing applies to Databricks specifically. Each step is a
+prerequisite for the next:
+
+1. Remove idle clusters and abandoned workspaces.
+2. Right-size clusters that survive cleanup.
+3. Migrate jobs from All-Purpose to Jobs Compute where appropriate (cheapest tier).
+4. Establish baseline consumption over 60-90 days post-cleanup.
+5. **Then** commit via DBCU and / or Azure VM RIs on the underlying compute.
+
+**Reserving before cleanup turns waste into a contractual baseline.** This is the
+single most expensive ordering mistake on Databricks engagements - DBCU commitments
+are non-trivial and a year-long commitment to over-provisioned clusters is hard to
+unwind.
+
+Source for the data-platform allocation framing: FinOps Foundation webinar -
+practitioner conversation on data-platform allocation (Databricks + Fabric).
 
 ---
 

--- a/cloud-finops/references/finops-fabric.md
+++ b/cloud-finops/references/finops-fabric.md
@@ -1,0 +1,309 @@
+# FinOps on Microsoft Fabric
+
+> Microsoft Fabric capacity FinOps: F-SKU model, Capacity Units (CU) and the 24-hour
+> smoothing window, pause / resume, Reserved Capacity, the Power BI Pro to Fabric
+> migration governance trap, allocation models for shared capacity, and monitoring
+> via the Fabric Capacity Metrics app.
+
+---
+
+## What Fabric is, in FinOps terms
+
+Microsoft Fabric is the unified analytics platform Microsoft positions as the
+successor to Power BI Premium and as a peer to Databricks / Snowflake for
+non-engineer-led analytics. It bundles Power BI, Data Factory, Synapse-style data
+engineering, real-time analytics, and Copilot under one **capacity-based** licence,
+billed in **Capacity Units (CU)** delivered through **F-SKUs**.
+
+The FinOps consequence: spend moves from per-user Power BI Pro / PPU licences to
+shared compute capacity. The economic unit changes - and so does the governance
+problem.
+
+For the shared-data-platform allocation framing (cost object reported by the
+platform vs business object Finance wants to allocate against), see the "data-
+platform FinOps problem" callout in `finops-databricks.md`. The mechanics differ
+between Databricks and Fabric; the allocation problem is the same.
+
+---
+
+## The capacity model - F-SKUs, Capacity Units, and the 24-hour smoothing window
+
+### F-SKU range and the CU mapping
+
+Fabric capacity is sold as F-SKUs in 11 sizes:
+
+```
+F2 / F4 / F8 / F16 / F32 / F64 / F128 / F256 / F512 / F1024 / F2048
+```
+
+The number after `F` is the **Capacity Unit (CU)** count. F2 = 2 CU, F64 = 64 CU,
+F2048 = 2048 CU. CUs are the unit of compute throughput Fabric measures and bills
+against.
+
+**Verify current pricing against the Microsoft Fabric pricing page** -
+https://azure.microsoft.com/en-us/pricing/details/microsoft-fabric/ - before
+quoting dollar amounts. Fabric pricing has shipped multiple changes since GA;
+hard-coded numbers age out fast.
+
+### CU smoothing - the most counterintuitive Fabric mechanic
+
+Fabric **smooths CU usage over a 24-hour rolling window** before applying
+throttling decisions. Short spikes are absorbed by the smoothing; sustained
+over-consumption triggers throttling. This is the single most counterintuitive
+behaviour in Fabric capacity sizing and customers regularly mis-size F-SKUs
+because they reason about peak instead of smoothed load.
+
+**Practical implication:** a 5-minute spike at 200% of capacity does not throttle
+anything if the rest of the 24-hour window runs below capacity. Capacity sizing
+should target the **smoothed** P95-P99 load, not raw peak load. This is closer
+to AWS's Lambda burst-capacity behaviour than to per-second autoscaling.
+
+**Throttling behaviour when smoothed CU usage exceeds capacity:**
+- **Interactive operations** (Power BI queries, Direct Lake reads, ad-hoc Spark
+  notebooks) are delayed - users see slower response, not failures.
+- **Background operations** (scheduled refreshes, pipelines, data warehouse
+  loads) are queued and may eventually be rejected if the queue depth exceeds
+  service limits.
+
+Source: https://learn.microsoft.com/en-us/fabric/enterprise/throttling
+
+### Autoscale - limited, not general-purpose
+
+Fabric does not have a general-purpose autoscale across all workload types.
+**Fabric Autoscale Billing for Spark** exists for Spark-specific overage - Spark
+jobs that would otherwise throttle can be billed as autoscale CU consumption above
+the F-SKU's base capacity. This is opt-in per workspace and bills separately on
+the Azure invoice. Outside Spark, the capacity ceiling is the F-SKU; over-runs
+throttle, they do not auto-scale.
+
+Source: https://learn.microsoft.com/en-us/fabric/data-engineering/autoscale-billing-for-spark-overview
+
+---
+
+## Pause / Resume - the most underused cost lever
+
+Fabric capacities support **manual pause and resume**. While paused, **compute
+charges stop**; storage and metadata continue to accrue. Resume takes a few
+minutes. This is functionally equivalent to Azure SQL Serverless auto-pause but
+**not automatic** - you have to schedule it.
+
+**Use cases:**
+- Non-production / dev / departmental capacities only needed during business
+  hours.
+- Capacity used for monthly or quarterly reporting workloads with long idle
+  windows between cycles.
+
+**Saving math:** an F-SKU running 168 hours/week (24x7) vs 50 hours/week
+(business hours) is a ~70% saving on capacity compute, with no functional change
+beyond accepting the resume delay at the start of each working day.
+
+**Implementation:**
+- Fabric REST API: `POST /capacities/{capacityId}/suspend` and `/resume`. Source:
+  https://learn.microsoft.com/en-us/rest/api/microsoftfabric/fabric-capacities
+- Azure Logic Apps or Function on a schedule, calling the REST endpoints with a
+  service principal that has Fabric admin rights.
+- Avoid: manual portal-driven pause / resume - it does not survive operator
+  attrition.
+
+**Common trap.** Pause / resume is **incompatible with capacities currently
+serving Power BI Premium workloads with active datasets** - active datasets
+prevent suspend. Plan a workspace migration off the capacity (or schedule the
+pause for windows where datasets are not in use) before scheduling pause cycles.
+Customers regularly hit this on day 1 of a pause-schedule rollout because they
+did not audit the active-dataset list first.
+
+---
+
+## Fabric Reserved Capacity
+
+- 1-year commitment, applied at the F-SKU level (e.g. one reservation per F64).
+- **Saving: roughly 40-50% vs PAYG capacity** - verify current rate against the
+  Microsoft Fabric reserved capacity page before quoting.
+- Scope and exchange rules: similar to Azure VM Reservations but capacity-
+  specific. Exchanges allowed within the F-SKU family with the standard Azure
+  reservation mechanics (see `finops-azure.md` for exchange / refund / cap
+  details, which apply identically here).
+- **No 3-year option as of April 2026.** Fabric Reserved Capacity is 1-year only.
+- **Sequencing:** only commit after cleanup and capacity sizing have stabilised.
+  Reserving before cleanup locks the wrong F-SKU into a 1-year contract - the
+  same mistake as committing to over-provisioned Databricks compute, with the
+  same recovery cost.
+
+Source: https://azure.microsoft.com/en-us/pricing/details/microsoft-fabric/
+
+---
+
+## The Power BI Pro to Fabric capacity migration - the governance failure pattern
+
+The single most common Fabric FinOps failure pattern is the **post-migration
+governance gap** in customers transitioning from per-user Power BI Pro licensing
+to shared Fabric capacities. Document this as a specific repeatable engagement
+scenario.
+
+When an organisation moves from Pro / PPU to Fabric:
+
+- The economic unit changes from **per-user licence** to **shared capacity
+  consumption**.
+- User behaviour does not adjust automatically. Users keep creating workspaces
+  and treating them as effectively free, because under Pro they were - the
+  marginal cost of a new workspace was zero.
+- Costs spike weeks after migration because the operating model lagged the
+  licensing model.
+
+**Specific failures to watch for:**
+- Users do not understand that workspace activity consumes shared capacity. A
+  poorly-written Direct Query can consume meaningful CU on every page render.
+- Workspace creation is not controlled - anyone can create one with default
+  governance.
+- Idle workspaces accumulate; nothing flags them because no per-user licence is
+  expiring.
+- Capacity sizing is not reviewed early enough. The F-SKU bought at migration is
+  often wrong by month 2 - either over-sized (waste) or under-sized (throttling
+  events the business owner blames on platform engineering).
+- Business demand grows faster than cost governance maturity.
+
+**Day 1 question on any post-migration engagement:** "When did you migrate from
+Pro / PPU to Fabric, and what governance did you put in place at the same time?"
+If the answer to "what governance" is vague, governance is the engagement -
+capacity sizing and reservations are downstream.
+
+---
+
+## Capacity governance controls
+
+| Control area | Practical control |
+|---|---|
+| Workspace creation | Approval workflow or Azure-Policy-based creation control; do not leave open to all users post-migration |
+| Workspace ownership | Mandatory owner, cost centre, business purpose tags at creation |
+| Idle cleanup | Recurring (monthly) review of inactive workspaces - delete or archive |
+| Capacity sizing | Utilisation review and right-sizing every quarter for the first year, then annually |
+| Reservation decision | Only after usage baseline is stable for 60-90 days post-cleanup |
+| Monitoring | Capacity utilisation, spikes, throttling events, trend - all surfaced via the Fabric Capacity Metrics app |
+| Escalation | Finance + platform owner + workspace owner in the same review cadence; do not silo by function |
+
+---
+
+## Allocation models for shared capacity
+
+When several workspaces share a Fabric capacity, who pays? There is no canonical
+right answer; the allocation model has to match the customer's maturity and
+political reality.
+
+| Model | When it works | Weakness |
+|---|---|---|
+| Equal split by workspace | Early-stage, low maturity, "we just need to start somewhere" | Unfair if usage differs materially - high consumers pay the same as light ones |
+| Split by department / business-unit ownership | Broad showback, easy to administer | Weak for shared analytics teams that serve multiple BUs |
+| Split by capacity consumption (CU-weighted) | Better accuracy, defensible | Requires reliable capacity-metrics telemetry; harder to explain to non-technical stakeholders |
+| Centrally funded platform | Strategic platform-adoption phase, executive-sponsored | Weak accountability; users have no incentive to optimise |
+| Hybrid (central platform + heavy-user chargeback) | Most realistic for mid-maturity orgs | More complex to explain and reconcile |
+
+**Pragmatic adoption sequence:**
+
+1. Start with workspace-ownership allocation.
+2. Use capacity-utilisation metrics from the Fabric Capacity Metrics app to
+   identify heavy consumers.
+3. Apply exceptions for large workloads (e.g. data engineering pipelines that
+   dominate CU).
+4. Move to usage-weighted allocation once the capacity-metrics telemetry is
+   trusted.
+
+Going to usage-weighted before the telemetry is trusted produces arguments rather
+than action. Trust the data first, then bill on it.
+
+---
+
+## Pricing comparison - Pro vs PPU vs Fabric F-SKU
+
+Fabric capacities replace per-user Power BI Pro and PPU licensing at scale. The
+breakeven is headcount-dependent.
+
+- **Power BI Pro** - per-user, monthly. Suits low-headcount tenancies, read-only
+  consumers, or organisations where a small fraction of users need analytics.
+- **Power BI Premium per User (PPU)** - per-user, monthly, gives Premium feature
+  set without shared capacity. Useful for power users who need Premium-only
+  features (paginated reports, larger model sizes) but are too few to justify a
+  capacity.
+- **Fabric F-SKU** - capacity-based. Replaces both Pro and PPU at scale and adds
+  data engineering / Spark / data-warehouse workloads to the same capacity.
+
+**Rough breakeven:** above ~100-200 users with active Premium feature use, an
+F-SKU starts to compete economically. Below that threshold, Pro or PPU is
+usually cheaper. The exact crossover depends on F-SKU size selected, workspace
+mix, and whether Spark / pipeline workloads are running on the capacity.
+
+Provide a decision-tree-style guide to the customer rather than a single-number
+breakeven - the answer depends on feature mix, not just headcount.
+
+Source: https://azure.microsoft.com/en-us/pricing/details/power-bi/
+
+---
+
+## Monitoring - where to look
+
+### Microsoft Fabric Capacity Metrics app
+
+Built into the Fabric admin portal. The primary tool for FinOps and platform
+engineering. The metrics that matter:
+
+- **CU usage smoothed** - the 24-hour-smoothed view, which is what throttling
+  decisions are based on. Use this for sizing, not the raw spike view.
+- **Throttling events** - count and duration. Persistent throttling is the signal
+  to upsize the F-SKU or migrate workloads.
+- **Top items by CU consumption** - typically Power BI datasets, dataflows, or
+  Spark notebooks. Surface the top 10 each week as a starting point for
+  optimisation.
+- **Background vs interactive split** - background operations (refreshes,
+  pipelines) often dominate CU but are easier to schedule off-peak; interactive
+  operations are user-perceived and cannot be scheduled.
+
+Source: https://learn.microsoft.com/en-us/fabric/enterprise/metrics-app
+
+### Azure Monitor / Log Analytics integration
+
+Fabric capacity metrics can be sent to Log Analytics via diagnostic settings -
+the right path for customers who already have a centralised observability and
+cost-data pipeline. Once in Log Analytics, KQL is the query layer.
+
+```kql
+// Top 10 Fabric workspaces by CU consumption over the last 30 days
+// Requires diagnostic settings exporting Fabric capacity metrics to Log Analytics.
+// Adjust table name to match your diagnostic-setting target.
+FabricCapacityMetrics_CL
+| where TimeGenerated > ago(30d)
+| where MetricName_s == "CU_Consumed"
+| summarize total_cu = sum(MetricValue_d)
+            by WorkspaceId_g, WorkspaceName_s
+| order by total_cu desc
+| take 10
+```
+
+The query is illustrative - the exact column names depend on the diagnostic-
+setting export schema, which evolves. Verify the schema in your tenant before
+using this in production reports.
+
+### Cost Management
+
+Azure Cost Management surfaces capacity-level cost only, **not workspace-level**.
+Workspace-level allocation has to come from the Fabric Capacity Metrics app
+combined with tag-based attribution. Do not expect Cost Management alone to
+answer the "who consumed the capacity?" question.
+
+---
+
+## Monthly review cadence - Fabric side
+
+| Review item | Source signal |
+|---|---|
+| Top cost drivers | Capacity utilisation by workspace (Fabric Capacity Metrics app) |
+| Waste | Idle workspaces, oversized capacities, scheduled refreshes that no longer have business owners |
+| Allocation gaps | Workspaces without owner, cost centre, or business purpose tags |
+| Commitment status | Reserved Capacity utilisation, paused-capacity adherence to schedule |
+| Anomalies | Capacity spikes, throttling events, overload windows |
+| Actions | Delete idle workspaces, downsize over-provisioned capacities, reserve stable ones, govern creation |
+
+This review is monthly during the first 6-12 months post-migration, then
+quarterly once the operating model is mature.
+
+---
+
+> *Cloud FinOps Skill by [OptimNow](https://optimnow.io) - licensed under [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/).*


### PR DESCRIPTION
Adds a new `finops-fabric.md` reference covering Microsoft Fabric capacity FinOps (F-SKU model, Capacity Units and 24-hour CU smoothing, throttling, manual pause/resume, Reserved Capacity, the Pro/PPU to Fabric migration governance trap, shared-capacity allocation models, Capacity Metrics app, Pro vs PPU vs F-SKU breakeven). Extends `finops-databricks.md` with allocation and governance content (workspace + DBU executor patterns, the Azure VM RI vs DBU clarification, DBCU commitments, Photon and serverless multipliers, amortised vs PAYG split, monthly cadence, sequencing). Both files share a 'data-platform FinOps problem' framing. SKILL.md, POWER.md, and README.md updated to advertise the new topics.