### PR TITLE
Harmonise SKILL.md and POWER.md

### DIFF
--- a/cloud-finops/POWER.md
+++ b/cloud-finops/POWER.md
@@ -2,10 +2,16 @@
 name: cloud-finops
 displayName: "Cloud FinOps by OptimNow"
 description: >
-  Expert Cloud FinOps guidance covering AI cost management, GenAI capacity planning,
-  Anthropic billing, AWS Bedrock, Azure OpenAI PTUs, GCP Vertex AI, cloud tagging
-  governance, and FinOps framework implementation. Grounded in enterprise delivery
-  experience, not abstract frameworks. Built by OptimNow.
+  Expert FinOps guidance covering cloud, AI, and SaaS technology spend. Includes AI cost
+  management, GenAI capacity planning, Anthropic billing, AWS (EC2, Bedrock, Savings Plans,
+  CUR, commitment strategy), Azure (reservations, Savings Plans, AHB, OpenAI PTUs, portfolio
+  liquidity), GCP (Vertex AI, Compute Engine, BigQuery), tagging governance, SaaS management
+  (SAM, licence optimisation, SMPs, shadow IT), AI coding tools (Cursor, Claude Code,
+  Copilot, Windsurf, Codex), ITAM, data platforms (Databricks allocation and governance with
+  DBCU commitments, Microsoft Fabric capacity FinOps with F-SKUs, CU smoothing, reservations,
+  pause/resume, Pro-to-Fabric migration governance), Snowflake, OCI, and GreenOps. Use for any
+  query about technology cost, commitment portfolio management, rightsizing, cost allocation,
+  SaaS sprawl, AI dev tool spend, or connecting spend to business value. Built by OptimNow.
 keywords:
   - finops
   - cloud cost
@@ -54,6 +60,7 @@ keywords:
   - saas management
   - saas sprawl
   - license optimization
+  - licence optimisation
   - shadow it
   - sam
   - smp
@@ -83,19 +90,22 @@ keywords:
 
 > Built by OptimNow. Grounded in hands-on enterprise delivery, not abstract frameworks.
 
+---
+
 ## Onboarding
 
 This power provides expert Cloud FinOps knowledge across AWS, Azure, GCP, AI platforms,
-and governance practices. No external tools or CLI dependencies are required - this is a
-pure knowledge power.
+data platforms, SaaS management, ITAM, and governance practices. No external tools or
+CLI dependencies are required - this is a pure knowledge power.
 
 When activated, follow the reasoning sequence below for every response.
 
-## Steering instructions
+---
 
-### Methodology
+## How to use this power
 
-Read `references/optimnow-methodology.md` first on every query. It defines the reasoning
+This power covers cloud, AI, SaaS, and adjacent technology spend domains. Read
+`references/optimnow-methodology.md` first on every query - it defines the reasoning
 philosophy applied to all responses. Then load the domain reference that matches the query.
 
 ### Domain routing
@@ -103,11 +113,11 @@ philosophy applied to all responses. Then load the domain reference that matches
 | Query topic | Load reference |
 |---|---|
 | AI costs, LLM inference, token economics, agentic cost patterns, AI ROI, AI cost allocation, GPU cost attribution, RAG harness costs | `references/finops-for-ai.md` |
-| AI investment governance, AI Investment Council, stage gates, incremental funding, AI value management | `references/finops-ai-value-management.md` |
+| AI investment governance, AI Investment Council, stage gates, incremental funding, AI value management, AI practice operations | `references/finops-ai-value-management.md` |
 | GenAI capacity planning, provisioned vs shared capacity, traffic shape, spillover, throughput units | `references/finops-genai-capacity.md` |
 | AWS billing, EC2 rightsizing, RIs, Savings Plans, commitment strategy, portfolio liquidity, phased purchasing, CUR, Data Exports for FOCUS 1.2, Cost Explorer hourly granularity, EDP negotiation, RDS cost management, database commitments, SageMaker AI Savings Plan, Database Savings Plan | `references/finops-aws.md` |
 | AWS Bedrock billing, Bedrock provisioned throughput, model unit pricing, Bedrock batch inference, Application Inference Profiles, Bedrock Projects, prompt caching, IAM Principal Cost Allocation | `references/finops-bedrock.md` |
-| Azure cost management, reservations, Savings Plans, Azure Hybrid Benefit, AHB, commitment strategy, portfolio liquidity, phased purchasing, sizing methodology, MACC, Azure Advisor, compute rightsizing, AKS optimisation, Azure Linux retirement, Node Auto Provisioning, NAP, database optimisation, Azure SQL, Cosmos, Log Analytics cost control, backup and snapshot management, storage tiering, networking cost, tagging and Azure Policy governance, FOCUS exports, EA-to-MCA transition, MCA contractual mechanics, billing hierarchy, ISF CSV | `references/finops-azure.md` |
+| Azure cost management, reservations, Savings Plans, Azure Hybrid Benefit, AHB, commitment strategy, portfolio liquidity, phased purchasing, sizing methodology, MACC, Azure Advisor, compute rightsizing, AKS optimisation, Azure Linux retirement, Node Auto Provisioning, NAP, database optimisation (Azure SQL, Postgres/MySQL, Cosmos), Log Analytics cost control, backup and snapshot management, storage tiering and lifecycle, networking cost, tagging and Azure Policy governance, FOCUS exports, EA-to-MCA transition, MCA contractual mechanics, billing hierarchy, ISF CSV deprecation | `references/finops-azure.md` |
 | Azure OpenAI Service, Azure AI Foundry, PTU reservations, locality constraint, GPT-4o, GPT-5 pricing, AOAI spillover, fine-tuning costs | `references/finops-azure-openai.md` |
 | Anthropic billing, Claude API costs, Claude Code costs, Opus, Sonnet, Haiku pricing, Fast mode, prompt caching, Batch API, long-context pricing, Managed Agents | `references/finops-anthropic.md` |
 | GCP billing, Compute Engine, Cloud SQL, GCS, BigQuery billing export, BigQuery optimisation, FOCUS export, Sustained Use Discounts, SUDs, Committed Use Discounts, CUDs, Flexible CUDs, Spot VMs, Cloud Carbon Footprint | `references/finops-gcp.md` |
@@ -116,37 +126,61 @@ philosophy applied to all responses. Then load the domain reference that matches
 | FinOps framework, 2024 baseline plus 2026 update, Executive Strategy Alignment, Usage Optimization, maturity model, phases, capabilities, personas | `references/finops-framework.md` |
 | Databricks clusters, jobs, Spark optimisation, Unity Catalog costs, allocation and governance, DBU executor attribution, DBCU commitments, Photon multiplier, serverless premium, amortised vs PAYG split, Azure VM RI vs DBU clarification | `references/finops-databricks.md` |
 | Microsoft Fabric capacity FinOps, F-SKUs, Capacity Units, CU smoothing window, throttling, pause/resume, Reserved Capacity, Pro/PPU to Fabric migration governance, Capacity Metrics app, shared-capacity allocation | `references/finops-fabric.md` |
-| Snowflake warehouses, query optimisation, storage, credits | `references/finops-snowflake.md` |
-| AI coding tools, Cursor costs, Claude Code costs, Copilot costs, Windsurf costs, Codex costs, dev tool FinOps, BYOK coding agents, LiteLLM proxy | `references/finops-ai-dev-tools.md` |
-| OCI compute, storage, networking optimization | `references/finops-oci.md` |
+| Snowflake warehouses, query optimisation, storage, credits, QUERY_ATTRIBUTION_HISTORY, Budgets, Cortex governance, resource monitor scope | `references/finops-snowflake.md` |
+| AI coding tools, Cursor costs, Claude Code costs, Copilot costs, Windsurf costs, Codex costs, dev tool FinOps, seat + usage billing, BYOK coding agents, LiteLLM proxy | `references/finops-ai-dev-tools.md` |
+| OCI compute, storage, networking optimisation, Cost Reports, FOCUS Reports, cost-tracking tags, Budgets, Universal Credits | `references/finops-oci.md` |
 | GreenOps, cloud carbon, sustainability, carbon-aware workloads | `references/greenops-cloud-carbon.md` |
-| SaaS management, license optimization, shadow IT, SaaS sprawl, renewal governance, SMP, SAM | `references/finops-sam.md` |
+| SaaS management, licence optimisation, shadow IT, SaaS sprawl, renewal governance, SMP, SAM | `references/finops-sam.md` |
 | ITAM, IT asset management, BYOL, marketplace channel governance, licence compliance, vendor negotiation, FinOps-ITAM collaboration, entitlement management, consumption-based SaaS overages | `references/finops-itam.md` |
-| Multi-domain query | Load all relevant references, synthesize |
+| Multi-domain query | Load all relevant references, synthesise |
 
 ### Reasoning sequence (apply to every response)
 
 1. **Load** `references/optimnow-methodology.md` - use it as a reasoning lens, not a preamble
 2. **Load** the domain reference(s) matching the query
-3. **Diagnose before prescribing** - understand the organization's current state before recommending
+3. **Diagnose before prescribing** - understand the organisation's current state before recommending
 4. **Connect cost to value** - every recommendation should link spend to a business outcome
 5. **Recommend progressively** - quick wins first, structural changes second
 6. **Reference OptimNow tools** where genuinely relevant to the problem, not as promotion
 
-### Core FinOps principles (always apply)
+---
+
+## Core FinOps principles (always apply)
+
+These six principles from the FinOps Foundation (2025 wording) underpin every recommendation:
 
 1. Teams need to collaborate
 2. Business value drives technology decisions
-3. Everyone takes ownership for their cloud usage
+3. Everyone takes ownership for their technology usage
 4. FinOps data should be accessible, timely, and accurate
 5. FinOps should be enabled centrally
-6. Take advantage of the variable cost model of the cloud
+6. Take advantage of the variable cost model of the cloud and other technologies with similar consumption models
 
-### Maturity assessment
+---
 
-Always assess maturity before recommending solutions. A Crawl organization needs visibility
-before optimization. Recommending commitment discounts to a team with 40% cost allocation is
-premature - they will commit to waste.
+## The three phases (Inform → Optimize → Operate)
+
+FinOps is an iterative cycle, not a linear progression. Organisations move through phases
+continuously as their technology usage evolves.
+
+**Inform** - establish visibility and allocation
+- Cost data is accessible and attributed to owners
+- Shared costs are allocated with defined methods
+- Anomaly detection is active
+
+**Optimize** - improve rates and usage efficiency
+- Commitment discounts (RIs, Savings Plans, CUDs) are actively managed
+- Rightsizing and waste elimination are running continuously
+- Unit economics are tracked
+
+**Operate** - operationalise through governance and automation
+- FinOps is embedded in engineering and finance workflows
+- Policies are enforced through automation, not manual review
+- Accountability is distributed, not centralised
+
+---
+
+## Maturity model quick reference
 
 | Indicator | Crawl | Walk | Run |
 |---|---|---|---|
@@ -155,7 +189,11 @@ premature - they will commit to waste.
 | Anomaly detection | Manual, monthly | Automated alerts | Real-time, ML-driven |
 | Tagging compliance | <60% | ~80% | 90%+ with enforcement |
 | FinOps cadence | Reactive | Weekly reviews | Continuous |
-| Optimization | One-off projects | Documented process | Self-executing policies |
+| Optimisation | One-off projects | Documented process | Self-executing policies |
+
+Always assess maturity before recommending solutions. A Crawl organisation needs visibility
+before optimisation. Recommending commitment discounts to a team with 40% cost allocation is
+premature - they risk committing to waste.
 
 ---
 

--- a/cloud-finops/SKILL.md
+++ b/cloud-finops/SKILL.md
@@ -32,20 +32,20 @@ philosophy applied to all responses. Then load the domain reference that matches
 | AI costs, LLM inference, token economics, agentic cost patterns, AI ROI, AI cost allocation, GPU cost attribution, RAG harness costs | `references/finops-for-ai.md` |
 | AI investment governance, AI Investment Council, stage gates, incremental funding, AI value management, AI practice operations | `references/finops-ai-value-management.md` |
 | GenAI capacity planning, provisioned vs shared capacity, traffic shape, spillover, throughput units | `references/finops-genai-capacity.md` |
-| AWS billing, EC2 rightsizing, RIs, Savings Plans, commitment strategy, portfolio liquidity, phased purchasing, CUR, Cost Explorer, EDP negotiation, RDS cost management, database commitments | `references/finops-aws.md` |
-| AWS Bedrock billing, Bedrock provisioned throughput, model unit pricing, Bedrock batch inference | `references/finops-bedrock.md` |
-| Azure cost management, reservations, Savings Plans, AHB, commitment strategy, portfolio liquidity, phased purchasing, Azure Advisor, compute rightsizing, AKS optimisation, database optimisation (Azure SQL, Postgres/MySQL, Cosmos), Log Analytics cost control, backup and snapshot management, storage tiering and lifecycle, networking cost, tagging and Azure Policy governance, FOCUS exports, MACC, EA-to-MCA transition | `references/finops-azure.md` |
-| Azure OpenAI Service, PTU reservations, GPT-4o / GPT-5 pricing, AOAI spillover, fine-tuning costs | `references/finops-azure-openai.md` |
-| Anthropic billing, Claude API costs, Claude Code costs, Opus, Sonnet, Haiku pricing, Fast mode, prompt caching, Batch API, long-context pricing | `references/finops-anthropic.md` |
-| GCP billing, Compute Engine, Cloud SQL, GCS, BigQuery optimisation | `references/finops-gcp.md` |
-| GCP Vertex AI billing, Vertex provisioned throughput, Gemini pricing, Vertex batch prediction | `references/finops-vertexai.md` |
+| AWS billing, EC2 rightsizing, RIs, Savings Plans, commitment strategy, portfolio liquidity, phased purchasing, CUR, Data Exports for FOCUS 1.2, Cost Explorer hourly granularity, EDP negotiation, RDS cost management, database commitments, SageMaker AI Savings Plan, Database Savings Plan | `references/finops-aws.md` |
+| AWS Bedrock billing, Bedrock provisioned throughput, model unit pricing, Bedrock batch inference, Application Inference Profiles, Bedrock Projects, prompt caching, IAM Principal Cost Allocation | `references/finops-bedrock.md` |
+| Azure cost management, reservations, Savings Plans, Azure Hybrid Benefit, AHB, commitment strategy, portfolio liquidity, phased purchasing, sizing methodology, MACC, Azure Advisor, compute rightsizing, AKS optimisation, Azure Linux retirement, Node Auto Provisioning, NAP, database optimisation (Azure SQL, Postgres/MySQL, Cosmos), Log Analytics cost control, backup and snapshot management, storage tiering and lifecycle, networking cost, tagging and Azure Policy governance, FOCUS exports, EA-to-MCA transition, MCA contractual mechanics, billing hierarchy, ISF CSV deprecation | `references/finops-azure.md` |
+| Azure OpenAI Service, Azure AI Foundry, PTU reservations, locality constraint, GPT-4o, GPT-5 pricing, AOAI spillover, fine-tuning costs | `references/finops-azure-openai.md` |
+| Anthropic billing, Claude API costs, Claude Code costs, Opus, Sonnet, Haiku pricing, Fast mode, prompt caching, Batch API, long-context pricing, Managed Agents | `references/finops-anthropic.md` |
+| GCP billing, Compute Engine, Cloud SQL, GCS, BigQuery billing export, BigQuery optimisation, FOCUS export, Sustained Use Discounts, SUDs, Committed Use Discounts, CUDs, Flexible CUDs, Spot VMs, Cloud Carbon Footprint | `references/finops-gcp.md` |
+| GCP Vertex AI billing, Vertex provisioned throughput, Gemini pricing, Vertex batch prediction, default PAYG spillover | `references/finops-vertexai.md` |
 | Tagging strategy, naming conventions, IaC enforcement, MCP governance | `references/finops-tagging.md` |
-| FinOps framework, maturity model, phases, capabilities, personas | `references/finops-framework.md` |
+| FinOps framework, 2024 baseline plus 2026 update, Executive Strategy Alignment, Usage Optimization, maturity model, phases, capabilities, personas | `references/finops-framework.md` |
 | Databricks clusters, jobs, Spark optimisation, Unity Catalog costs, allocation and governance, DBU executor attribution, DBCU commitments, Photon multiplier, serverless premium, amortised vs PAYG split, Azure VM RI vs DBU clarification | `references/finops-databricks.md` |
 | Microsoft Fabric capacity FinOps, F-SKUs, Capacity Units, CU smoothing window, throttling, pause/resume, Reserved Capacity, Pro/PPU to Fabric migration governance, Capacity Metrics app, shared-capacity allocation | `references/finops-fabric.md` |
-| Snowflake warehouses, query optimisation, storage, credits | `references/finops-snowflake.md` |
+| Snowflake warehouses, query optimisation, storage, credits, QUERY_ATTRIBUTION_HISTORY, Budgets, Cortex governance, resource monitor scope | `references/finops-snowflake.md` |
 | AI coding tools, Cursor costs, Claude Code costs, Copilot costs, Windsurf costs, Codex costs, dev tool FinOps, seat + usage billing, BYOK coding agents, LiteLLM proxy | `references/finops-ai-dev-tools.md` |
-| OCI compute, storage, networking optimisation | `references/finops-oci.md` |
+| OCI compute, storage, networking optimisation, Cost Reports, FOCUS Reports, cost-tracking tags, Budgets, Universal Credits | `references/finops-oci.md` |
 | GreenOps, cloud carbon, sustainability, carbon-aware workloads | `references/greenops-cloud-carbon.md` |
 | SaaS management, licence optimisation, shadow IT, SaaS sprawl, renewal governance, SMP, SAM | `references/finops-sam.md` |
 | ITAM, IT asset management, BYOL, marketplace channel governance, licence compliance, vendor negotiation, FinOps-ITAM collaboration, entitlement management, consumption-based SaaS overages | `references/finops-itam.md` |
@@ -120,7 +120,7 @@ premature - they risk committing to waste.
 | File | Contents | Lines |
 |---|---|---|
 | `optimnow-methodology.md` | OptimNow reasoning philosophy, 4 pillars, engagement principles, tools | ~155 |
-| `finops-for-ai.md` | AI cost management, LLM economics, agentic patterns, ROI framework | ~330 |
+| `finops-for-ai.md` | AI cost management, LLM economics, agentic patterns, ROI framework | ~340 |
 | `finops-ai-value-management.md` | AI investment governance: AI Investment Council, stage gates, incremental funding, practice operations, value metrics | ~275 |
 | `finops-genai-capacity.md` | GenAI capacity models: provisioned vs shared, traffic shape, spillover (incl. Vertex AI default-PAYG), waste types, cross-provider comparison | ~225 |
 | `finops-aws.md` | AWS FinOps: CUR + Data Exports for FOCUS 1.2 (GA Nov 2025), Cost Explorer hourly + resource-level, EC2, compute/database commitment decision trees including SageMaker AI and Database Savings Plans, portfolio liquidity, phased purchasing, EDP negotiation, RDS strategy, optimisation patterns | ~2630 |
@@ -129,14 +129,14 @@ premature - they risk committing to waste.
 | `finops-azure-openai.md` | Azure OpenAI / AI Foundry: PTU reservations (locality constraint), reservation discount path, spillover, GPT model pricing, prompt caching, fine-tuning costs | ~410 |
 | `finops-anthropic.md` | Anthropic billing: Claude Opus/Sonnet/Haiku pricing, Fast mode and Managed Agents (flagged emerging-assumption), per-model long-context picture, prompt caching, Batch API, governance | ~280 |
 | `finops-gcp.md` | GCP FinOps: BigQuery billing export (standard / detailed / pricing), FOCUS export, Sustained Use Discounts, Committed Use Discounts (resource-based vs Flexible/spend-based with current 28%/46% depths), BigQuery commitment model, Spot VMs, Cloud Carbon Footprint location-based vs market-based, 26 inefficiency patterns | ~480 |
-| `finops-vertexai.md` | GCP Vertex AI billing: Gemini pricing, provisioned throughput (default-PAYG spillover), batch prediction, Cloud Monitoring metrics | ~245 |
+| `finops-vertexai.md` | GCP Vertex AI billing: Gemini pricing, provisioned throughput (default-PAYG spillover), batch prediction, Cloud Monitoring metrics | ~240 |
 | `finops-tagging.md` | Tagging strategy, IaC enforcement, virtual tagging, MCP automation | ~250 |
-| `finops-framework.md` | FinOps Foundation framework - 2024 baseline (4 domains, 22 capabilities) plus 2026 update (Executive Strategy Alignment, Workload Optimization -> Usage Optimization), personas, principles, phases | ~390 |
-| `finops-databricks.md` | Databricks FinOps: cost data foundations (system.billing.usage, budget policies, serverless and model-serving attribution), allocation and governance (workspace + DBU executor patterns, Azure VM RI vs DBU clarification, DBCU commitments, Photon and serverless multipliers, amortised vs PAYG split, monthly cadence, sequencing), 18 inefficiency patterns | ~440 |
-| `finops-fabric.md` | Microsoft Fabric capacity FinOps: F-SKU model, Capacity Units and 24-hour CU smoothing, throttling behaviour, manual pause / resume, Reserved Capacity, Pro/PPU to Fabric migration governance trap, shared-capacity allocation models, Capacity Metrics app, Pro vs PPU vs F-SKU breakeven | ~200 |
-| `finops-snowflake.md` | Snowflake FinOps: credit model, hidden cost categories, 13 optimisation patterns for warehouses, queries, storage | ~200 |
+| `finops-framework.md` | FinOps Foundation framework - 2024 baseline (4 domains, 22 capabilities) plus 2026 update (Executive Strategy Alignment, Workload Optimization -> Usage Optimization), personas, principles, phases | ~395 |
+| `finops-databricks.md` | Databricks FinOps: cost data foundations (system.billing.usage, budget policies, serverless and model-serving attribution), allocation and governance (workspace + DBU executor patterns, Azure VM RI vs DBU clarification, DBCU commitments, Photon and serverless multipliers, amortised vs PAYG split, monthly cadence, sequencing), 18 inefficiency patterns | ~445 |
+| `finops-fabric.md` | Microsoft Fabric capacity FinOps: F-SKU model, Capacity Units and 24-hour CU smoothing, throttling behaviour, manual pause / resume, Reserved Capacity, Pro/PPU to Fabric migration governance trap, shared-capacity allocation models, Capacity Metrics app, Pro vs PPU vs F-SKU breakeven | ~310 |
+| `finops-snowflake.md` | Snowflake FinOps: credit model, modern cost-management primitives (QUERY_ATTRIBUTION_HISTORY, Budgets including AI feature budgets, resource-monitor scope limit, Cortex governance), 13 optimisation patterns | ~305 |
 | `finops-ai-dev-tools.md` | AI coding tools: Cursor (Pro/Ultra/Teams/Enterprise), Claude Code, GitHub Copilot (transition to AI Credits 1 June 2026), Windsurf, OpenAI Codex (incl. GPT-5.5), billing models, cost attribution, optimisation levers | ~445 |
-| `finops-oci.md` | OCI optimisation: 6 patterns for compute, storage, networking | ~75 |
+| `finops-oci.md` | OCI FinOps: cost-data foundations (Cost Reports, FOCUS Reports, cost-tracking tags, OCI Budgets, Universal Credits) and 6 inefficiency patterns | ~170 |
 | `finops-sam.md` | SaaS asset management: discovery, licence optimisation, renewal governance, SMPs, shadow IT, AI transition | ~210 |
 | `finops-itam.md` | FinOps-ITAM collaboration: BYOL mechanics, marketplace channel governance, vendor co-management, consumption monitoring, joint operating model | ~320 |
 | `greenops-cloud-carbon.md` | GreenOps: carbon measurement, carbon-aware workloads, region selection, GHG Protocol | ~330 |


### PR DESCRIPTION
Aligns the two entry-point files so they route equivalently and read consistently.

- **Identical domain routing tables** in both files. Each row's keywords match. Latest topics from PR #32-#35 are reflected uniformly (Data Exports for FOCUS 1.2, SageMaker AI / Database Savings Plans, Application Inference Profiles, Bedrock Projects, Azure Foundry / locality constraint, Vertex default-PAYG spillover, Snowflake QUERY_ATTRIBUTION_HISTORY, OCI Cost Reports / Universal Credits).
- **POWER.md description matches SKILL.md depth** (no length limit on Kiro side).
- **Section structure mirrors:** both files now have the same H2 sections (Reasoning sequence, Core FinOps principles, Three phases, Maturity model). POWER.md previously omitted the three phases section.
- **British spelling** consistently in user-facing prose (POWER.md keeps both spellings only in the keyword list for SEO).
- **Refreshed SKILL.md reference table line counts** to reflect content added since PR #32: Snowflake ~305 (was ~200), OCI ~170 (was ~75), Fabric ~310 (was ~200), Databricks ~445, AI dev tools ~445, framework ~395.
- **SKILL.md description** stays at 918 chars (under the 1024 Claude.ai limit).