### PR TITLE
Add GCP/Vertex review gaps - char pricing, context caching, CUD Sharing, Gemini Code Assist

### DIFF
--- a/cloud-finops/references/finops-ai-dev-tools.md
+++ b/cloud-finops/references/finops-ai-dev-tools.md
@@ -277,6 +277,35 @@ Windsurf uses a credit system where each credit costs $0.04 and maps to the unde
 model provider's API price plus a 20% margin. Add-on credits are available at $10 for 250
 (individual) or $40 for 1,000 (Teams/Enterprise).
 
+### Gemini Code Assist
+
+Gemini Code Assist is Google's AI coding tool, distributed primarily via Google
+Cloud and Google Workspace channels rather than as a standalone subscription.
+Two distinct entitlement paths matter for FinOps:
+
+- **Bundled with Google Workspace / Google Cloud editions.** Some Workspace and
+  GCP editions include Gemini Code Assist in the seat licence. The marginal cost
+  of enabling it for already-licensed users is zero - which makes adoption
+  economics very different from the seat + usage model of Cursor or Copilot.
+- **Standalone subscription tiers** (Standard, Enterprise) for organisations
+  without bundling. Per-user monthly pricing; verify current rate against the
+  Google Cloud pricing page.
+
+**FinOps angle:**
+- For organisations already on a Workspace edition that includes Code Assist,
+  pay-per-seat tools (Cursor / Copilot) become harder to justify on cost alone -
+  the comparison is "Code Assist for $0 marginal cost" vs "Cursor at $X / month
+  per seat". Quality benchmarking still matters; cost is no longer the only
+  driver.
+- For BYOK comparisons, Gemini Code Assist's token consumption against your
+  Vertex AI quota is the relevant cost line - similar to how Claude Code on API
+  key mode bills against your Anthropic account. Apply the same cost-attribution
+  patterns documented for BYOK tools earlier in this file.
+- Gemini API context-caching pricing differs from token billing - see
+  `finops-vertexai.md` for Vertex AI Context Caching mechanics.
+
+Source: https://cloud.google.com/products/gemini/code-assist
+
 ---
 
 ## Cost attribution patterns

--- a/cloud-finops/references/finops-gcp.md
+++ b/cloud-finops/references/finops-gcp.md
@@ -144,7 +144,38 @@ CUDs cover **Compute Engine, GKE (via the underlying nodes), Cloud SQL, Cloud Ru
 cover Cloud Functions, BigQuery, GCS, or Pub/Sub - those services have their own
 commitment models (BigQuery slot reservations, etc.).
 
+**CUD Sharing - the single most-missed CUD setting.** By default, CUD discounts
+apply only **within the project that purchased them**. To pool CUDs across an
+organisation - the typical multi-team / multi-project scenario - you must
+explicitly enable **CUD Sharing** at the **billing-account level**. Without it,
+one project burns its CUDs to zero while sibling projects pay PAYG, and the
+billing-account-level coverage looks healthy in aggregate while individual
+project-level utilisation is poor. Day-1 audit on any GCP commitment engagement:
+verify whether CUD Sharing is enabled. Source:
+https://cloud.google.com/billing/docs/how-to/cud-analysis
+
 Sources: https://cloud.google.com/compute/docs/instances/committed-use-discounts-overview, https://cloud.google.com/compute/docs/instances/signing-up-flexible-committed-use-discounts
+
+### Compute SKU billing - vCPU and memory bill separately
+
+GCP bills Compute Engine resources with the **vCPU and memory components on
+separate SKUs**, unlike AWS where the EC2 instance is a single billable unit.
+This is invisible in the console summary but explicit in BigQuery billing export -
+a single VM produces multiple cost rows per day (one for vCPU, one for memory,
+plus disk, network, licensing, sustained-use credits, etc.).
+
+**Practical implications for cost analytics:**
+- Aggregating "cost per VM" requires summing across SKUs, not reading a single
+  line. Custom Power BI / BigQuery dashboards that treat one row = one resource
+  will under-report.
+- Right-sizing analysis must consider vCPU and memory independently - GCP's
+  custom machine types let you tune the ratio, which AWS cannot match at the
+  same granularity.
+- CUDs apply to the vCPU and memory components separately; mixed coverage is
+  possible (e.g. 100% vCPU CUD, 60% memory CUD) and shows as such in CUD
+  utilisation reports.
+
+Source: https://cloud.google.com/compute/all-pricing
 
 ### Spot VMs
 

--- a/cloud-finops/references/finops-vertexai.md
+++ b/cloud-finops/references/finops-vertexai.md
@@ -36,10 +36,27 @@ carry disproportionately higher costs.
 
 ## Model pricing reference
 
-### On-demand pricing structure
+### On-demand pricing structure - tokens AND characters
 
-Vertex AI on-demand pricing is per-million tokens, billed per API call. No minimum spend,
-no upfront commitment.
+Vertex AI on-demand pricing is per-million tokens for newer Gemini SKUs. **However,
+some Gemini APIs and earlier model versions still bill per 1,000 characters (input
+and output)** rather than per token. This is a real difference from AWS / OpenAI /
+Anthropic, which all bill per token.
+
+**Practical implications:**
+- Capacity-planning math from Anthropic or OpenAI engagements does not transpose
+  cleanly: 1,000 characters is roughly 250 tokens for English (ratio varies per
+  language - East Asian scripts can be 1:1 character-to-token, English is ~4:1).
+- Verify the unit on Vertex's pricing page per model before quoting. Two Gemini
+  variants on the same product family can use different units depending on model
+  version and surface (Vertex Studio, Vertex API, Gemini API).
+- For multilingual workloads, the character-based pricing is sometimes cheaper
+  than the token-based equivalent (the per-character rate can favour languages
+  that tokenise unfavourably under English-trained tokenisers).
+
+Source: https://cloud.google.com/vertex-ai/generative-ai/pricing
+
+No minimum spend, no upfront commitment, regardless of unit.
 
 | Model family | Relative cost tier | Notes |
 |---|---|---|
@@ -193,9 +210,37 @@ contract, cost per generated email) for margin modelling as usage scales.
 ### Prompt optimization
 
 - Audit system prompt length  - verbose instructions inflate every API call
-- Implement context caching where supported (Vertex AI supports context caching for Gemini)
+- Implement **Vertex AI Context Caching** where supported (Gemini Pro, Flash 1.5+) - see below
 - Truncate or summarize conversation history for multi-turn applications
 - Avoid sending redundant context in RAG pipelines
+
+### Vertex AI Context Caching - direct lever for long-context workloads
+
+Vertex AI supports **explicit context caching** for selected Gemini models (Gemini
+Pro, Flash 1.5 and later). Equivalent in spirit to Anthropic / Bedrock prompt
+caching - cache a stable context once, reuse it across many requests at a steeply
+discounted input-token rate.
+
+**Mechanics:**
+- Cache write: priced per cached token (or character) at a small premium over the
+  base input rate.
+- Cache hit (read): priced at a meaningfully lower rate than full input.
+- TTL: configurable cache lifetime (typically minutes to hours, model-dependent).
+- Minimum context size: caching is only beneficial above a token / character
+  threshold the model documents - small contexts do not break even.
+
+**Where it matters:**
+- RAG pipelines with stable retrieved context across many user queries.
+- Long system prompts (>1,000 tokens) reused across an interactive session.
+- Agentic loops re-sending tool definitions and conversation history.
+- Batch evaluation against a stable corpus.
+
+**Where it does not help:**
+- One-shot calls with unique input.
+- Workloads where the context changes substantively each request.
+- Models that do not support caching (verify per model and per region).
+
+Source: https://cloud.google.com/vertex-ai/generative-ai/docs/context-cache/context-cache-overview
 
 ### Context window management
 


### PR DESCRIPTION
Five additions surfaced by an external review of the GCP/Vertex content. Most of Gemini's review against an older snapshot was already addressed by PR #16/#23/#28/#30; these are the genuinely missing pieces:

**Vertex AI:**
- **Character-based pricing** - some Gemini APIs and earlier model versions still bill per 1,000 characters (input/output) rather than per token. Capacity-planning math from Anthropic / OpenAI engagements does not transpose cleanly. Multilingual workloads can favour character-based pricing.
- **Vertex AI Context Caching** - new dedicated subsection covering cache write / cache hit pricing relative to base input rate, TTL configuration, minimum context size threshold, where caching helps and where it does not.

**GCP:**
- **CUD Sharing** - flagged as the most-missed CUD setting. By default, CUDs apply only within the project that purchased them. Pooling across an org requires explicitly enabling CUD Sharing at the billing-account level. Day-1 audit item.
- **vCPU + memory bill on separate SKUs** - GCP bills these as separate billing-export rows per VM, unlike AWS's single-instance billing line. Affects custom Power BI / BigQuery dashboards and CUD-utilisation reports.

**AI dev tools:**
- **Gemini Code Assist** - new section covering Workspace / GCP-bundled vs standalone subscription paths, the marginal-cost-zero implication for organisations already on bundled Workspace editions, BYOK comparison via Vertex AI quota, cross-reference to Vertex Context Caching.