### PR TITLE
Add Claude Code plugin packaging

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "optimnow",
+  "description": "Cloud Financial Management references and tooling by OptimNow.",
+  "owner": {
+    "name": "OptimNow",
+    "url": "https://optimnow.io"
+  },
+  "plugins": [
+    {
+      "name": "cloud-finops",
+      "description": "Expert FinOps guidance for cloud, AI, SaaS, and data-platform spend. 21 reference files spanning AWS, Azure, GCP, Anthropic, Bedrock, Azure OpenAI, Vertex AI, Databricks, Microsoft Fabric, Snowflake, OCI, AI coding tools, FinOps Framework 2024+2026, GreenOps, SaaS asset management, and ITAM. Open source, model-agnostic, refreshed bi-monthly.",
+      "author": {
+        "name": "OptimNow",
+        "url": "https://optimnow.io"
+      },
+      "category": "knowledge",
+      "source": {
+        "source": "github",
+        "repo": "OptimNow/cloud-finops-skills"
+      },
+      "homepage": "https://github.com/OptimNow/cloud-finops-skills"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,35 @@
+{
+  "name": "cloud-finops",
+  "version": "1.10.0",
+  "description": "Expert FinOps guidance for cloud, AI, SaaS, and data-platform spend (multi-provider, model-agnostic).",
+  "author": {
+    "name": "OptimNow",
+    "url": "https://optimnow.io"
+  },
+  "repository": "https://github.com/OptimNow/cloud-finops-skills",
+  "license": "CC-BY-SA-4.0",
+  "homepage": "https://github.com/OptimNow/cloud-finops-skills",
+  "keywords": [
+    "finops",
+    "cloud-cost",
+    "ai-cost",
+    "saas-cost",
+    "multi-cloud",
+    "aws",
+    "azure",
+    "gcp",
+    "anthropic",
+    "vertex-ai",
+    "bedrock",
+    "azure-openai",
+    "databricks",
+    "snowflake",
+    "fabric",
+    "oci",
+    "greenops",
+    "cost-allocation",
+    "commitment-strategy",
+    "rightsizing",
+    "tag-governance"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -262,6 +262,26 @@ domain-specific content is shared.
 See **[INSTALLATION.md](./INSTALLATION.md)** for step-by-step setup instructions
 covering Claude Code, Kiro IDE, Claude.ai, and API integration.
 
+### Quick install: Claude Code plugin
+
+For Claude Code users, the skill is also distributed as a self-hosted plugin with
+auto-update support. Two commands:
+
+```bash
+/plugin marketplace add OptimNow/cloud-finops-skills
+/plugin install cloud-finops@optimnow
+```
+
+To pull the latest content (including the bi-monthly automated updates):
+
+```bash
+/plugin update cloud-finops@optimnow
+```
+
+For Claude Desktop / claude.ai users, the manual zip-upload path stays as documented
+in `INSTALLATION.md` (Option 1). Both distribution channels share the same skill
+content - pick the one that matches how you use Claude.
+
 ---
 
 ## This skill is actively maintained


### PR DESCRIPTION
Adds two manifest files at the repo root that make this repository installable as a Claude Code plugin via a self-hosted marketplace:

- `.claude-plugin/plugin.json` — declares the cloud-finops plugin with version, author, repository, license, and keywords
- `.claude-plugin/marketplace.json` — declares the OptimNow marketplace listing the cloud-finops plugin, sourced from this GitHub repo

README updated with the install command:

```
/plugin marketplace add OptimNow/cloud-finops-skills
/plugin install cloud-finops@optimnow
/plugin update cloud-finops@optimnow
```

The existing zip-distribution path for Claude Desktop / claude.ai users remains unchanged. Both channels share the same `cloud-finops/` source folder — no duplication.