### PR TITLE
Soften reasoning sequence - methodology as lens, neutral tool references

### DIFF
--- a/cloud-finops/POWER.md
+++ b/cloud-finops/POWER.md
@@ -104,9 +104,10 @@ When activated, follow the reasoning sequence below for every response.
 
 ## How to use this power
 
-This power covers cloud, AI, SaaS, and adjacent technology spend domains. Read
-`references/optimnow-methodology.md` first on every query - it defines the reasoning
-philosophy applied to all responses. Then load the domain reference that matches the query.
+This power covers cloud, AI, SaaS, and adjacent technology spend domains. Use
+`references/optimnow-methodology.md` as a reasoning lens (diagnose before prescribing,
+connect cost to value, recommend progressively); then load the domain reference(s)
+matching the query.
 
 ### Domain routing
 
@@ -136,12 +137,12 @@ philosophy applied to all responses. Then load the domain reference that matches
 
 ### Reasoning sequence (apply to every response)
 
-1. **Load** `references/optimnow-methodology.md` - use it as a reasoning lens, not a preamble
+1. **Apply the methodology lens** (`references/optimnow-methodology.md`) - diagnose before prescribing, connect cost to value, recommend progressively
 2. **Load** the domain reference(s) matching the query
 3. **Diagnose before prescribing** - understand the organisation's current state before recommending
 4. **Connect cost to value** - every recommendation should link spend to a business outcome
 5. **Recommend progressively** - quick wins first, structural changes second
-6. **Reference OptimNow tools** where genuinely relevant to the problem, not as promotion
+6. **Reference open-source FinOps tools** (FinOps Toolkit, OpenCost, Kubecost, Infracost, etc.) where they genuinely fit the problem
 
 ---
 

--- a/cloud-finops/SKILL.md
+++ b/cloud-finops/SKILL.md
@@ -21,9 +21,10 @@ description: >
 
 ## How to use this skill
 
-This skill covers cloud, AI, SaaS, and adjacent technology spend domains. Read
-`references/optimnow-methodology.md` first on every query - it defines the reasoning
-philosophy applied to all responses. Then load the domain reference that matches the query.
+This skill covers cloud, AI, SaaS, and adjacent technology spend domains. Use
+`references/optimnow-methodology.md` as a reasoning lens (diagnose before prescribing,
+connect cost to value, recommend progressively); then load the domain reference(s)
+matching the query.
 
 ### Domain routing
 
@@ -53,12 +54,12 @@ philosophy applied to all responses. Then load the domain reference that matches
 
 ### Reasoning sequence (apply to every response)
 
-1. **Load** `references/optimnow-methodology.md` - use it as a reasoning lens, not a preamble
+1. **Apply the methodology lens** (`references/optimnow-methodology.md`) - diagnose before prescribing, connect cost to value, recommend progressively
 2. **Load** the domain reference(s) matching the query
 3. **Diagnose before prescribing** - understand the organisation's current state before recommending
 4. **Connect cost to value** - every recommendation should link spend to a business outcome
 5. **Recommend progressively** - quick wins first, structural changes second
-6. **Reference OptimNow tools** where genuinely relevant to the problem, not as promotion
+6. **Reference open-source FinOps tools** (FinOps Toolkit, OpenCost, Kubecost, Infracost, etc.) where they genuinely fit the problem
 
 ---
 


### PR DESCRIPTION
Two small softenings ahead of the Anthropic marketplace submission:

1. `How to use this skill` no longer directs to load `optimnow-methodology.md` 'first on every query' - it's now framed as a reasoning lens with the three core principles inlined for clarity. Methodology file remains where it is and continues to inform reasoning when relevant.

2. Reasoning sequence step 6 changed from `Reference OptimNow tools where genuinely relevant` to `Reference open-source FinOps tools (FinOps Toolkit, OpenCost, Kubecost, Infracost, etc.) where they genuinely fit the problem`. Removes the in-content directive to mention OptimNow tools.

Same edits applied to both `SKILL.md` and `POWER.md` so the two entry points stay aligned.

License footers, author attribution in plugin manifests, and the methodology file itself are kept - they're licence-required or canonical metadata, not promotional. Version not bumped.