### PR TITLE
GreenOps: AWS Sustainability Console, Well-Architected Pillar, engagement framing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,27 @@ reference file. See `pipeline/README.md` for the full workflow.
 
 ---
 
+## Pending follow-ups
+
+- **Extend GreenOps depth to Azure and GCP.** The May 2026 GreenOps pass added AWS-specific
+  depth to `references/greenops-cloud-carbon.md` (Sustainability Console v2 with Methodology v3
+  alignment, the unused-capacity ventilation trap, critical reading of AWS sustainability claims,
+  AWS region intensity anchors with the 15x gap, hardware/storage anchors, Well-Architected
+  Sustainability Pillar SUS01-SUS06 with critical-read notes). The next pass should bring the
+  same depth to Azure and GCP:
+  - **Azure**: Emissions Impact Dashboard refresh (current methodology version, scope coverage,
+    location-based vs market-based handling), Azure region intensity anchors with concrete
+    numbers, Azure-specific hardware anchors (Cobalt 100, Ampere Altra, Spot equivalents), and
+    Azure Well-Architected sustainability guidance critical reading.
+  - **GCP**: Carbon Footprint refresh (granularity, scope coverage, location-based vs
+    market-based view), GCP region intensity anchors, GCP-specific hardware anchors (Axion, Tau
+    T2A, Spot/preemptible equivalents).
+  - Keep the engagement-framing section vendor-agnostic - it does not need to be duplicated
+    per provider. The trade-off tables, four-quadrant cost-vs-carbon framework, and CSRD
+    stakeholder roles already apply across all three providers.
+
+---
+
 ## Model compatibility
 
 The skill files are plain markdown - any LLM can read them. What differs across models

--- a/cloud-finops/SKILL.md
+++ b/cloud-finops/SKILL.md
@@ -8,9 +8,10 @@ description: >
   (SAM, licence optimisation, SMPs, shadow IT), AI coding tools (Cursor, Claude Code,
   Copilot, Windsurf, Codex), ITAM, data platforms (Databricks allocation and governance with
   DBCU commitments, Microsoft Fabric capacity FinOps with F-SKUs, CU smoothing, reservations,
-  pause/resume, Pro-to-Fabric migration governance), Snowflake, OCI, and GreenOps. Use for any
-  query about technology cost, commitment portfolio management, rightsizing, cost allocation,
-  SaaS sprawl, AI dev tool spend, or connecting spend to business value. Built by OptimNow.
+  pause/resume, Pro-to-Fabric migration governance), Snowflake, OCI, and GreenOps (AWS
+  Sustainability Console, CSRD engagement framing). Use for any query about technology cost,
+  commitment portfolio management, rightsizing, cost allocation, SaaS sprawl, AI dev tool spend,
+  or connecting spend to business value. Built by OptimNow.
 ---
 
 # FinOps - Expert Guidance

--- a/cloud-finops/references/greenops-cloud-carbon.md
+++ b/cloud-finops/references/greenops-cloud-carbon.md
@@ -5,7 +5,7 @@
 > integration, workload shifting strategies (temporal and spatial), region selection,
 > and reporting alignment with GHG Protocol and EU/SEC regulations.
 >
-> Distilled from: Forrester, Thoughtworks, Green Software Foundation, AWS CCFT docs,
+> Distilled from: Forrester, Thoughtworks, Green Software Foundation, AWS Sustainability Console docs,
 > CloudCarbonFootprint.org, North.Cloud, Climatiq, and Microsoft/UBS Carbon Aware SDK
 > case study (2023–2025).
 
@@ -33,7 +33,7 @@ significantly.
 
 | Tool | Scope coverage | Granularity | Limitations |
 |---|---|---|---|
-| **AWS CCFT** (updated Jan 2025) | Scope 1, 2, 3 | Regional, by service | Lagged data; limited for workload-level optimization |
+| **AWS Sustainability Console** (renamed from CCFT, broken out of Billing 31 March 2026; Methodology v3 Oct 2025) | Scope 1, 2, 3 | Monthly, by service and region | Monthly only; "Others" service bucket; unused-capacity ventilation creates 5-15% month-to-month variance |
 | **GCP Carbon Footprint** | Scope 1, 2, 3 | Region + service, location-based and market-based | Most granular of the three |
 | **Azure Emissions Impact Dashboard** | Scope 1, 2, 3 | Service-level | Relies on market-based method (RECs); less granular than GCP |
 
@@ -42,12 +42,93 @@ significantly.
 real carbon intensity of the local grid. For optimization decisions, prefer location-based
 data. For ESG reporting, understand which method your auditors require.
 
-**AWS CCFT setup checklist (2025 methodology):**
-- [ ] Enable CCFT in the Billing & Cost Management console
-- [ ] Configure Data Exports to S3 (CSV or Parquet, automated monthly delivery)
-- [ ] Scope the export to the management account to cover all member accounts
-- [ ] Use January 2025 forward data for the updated Scope 3 methodology
+**AWS Sustainability Console setup checklist:**
+- [ ] Open the standalone Sustainability Console (broken out of Billing & Cost Management on 31 March 2026)
+- [ ] Configure Data Exports to S3 (CSV or Parquet, automated monthly delivery) - same mechanism as Cost and Usage Reports
+- [ ] Scope the export to the management (payer) account to cover all member accounts
+- [ ] Use Methodology v3 (October 2025) - aligned to GHG Protocol, ISO 14064, ISO 14040/14044, ICT sector guide; externally verified
 - [ ] Pair with Cost Explorer tags to correlate emissions to teams or products
+
+### AWS Sustainability Console - what changed in 2026 and what to watch
+
+The tool was renamed from "Customer Carbon Footprint Tool" (CCFT) to **AWS Sustainability Console**
+on **31 March 2026** and broken out of the Billing & Cost Management console as a standalone
+service.
+
+**Console v2 features (March 2026):**
+- Standalone console (no longer nested under Billing).
+- Location-based and market-based emissions displayed side-by-side rather than toggled.
+- Scope 1, 2, and 3 visible directly on the main view.
+- Granularity: monthly. No daily or hourly breakdown.
+- Filtering by service (EC2, S3, CloudFront - others bucketed as "Others") and by region.
+- Multi-account support via the payer account; can select specific accounts.
+- Time-period selection (rolling months or full year).
+
+**Three data-extraction options:**
+- Manual CSV export from the console.
+- **Data Exports** - same mechanism as Cost and Usage Reports, automates delivery to an S3
+  bucket. Use this for any production carbon dashboard.
+- API and CLI access for programmatic integration.
+
+**Methodology v3 (October 2025), ~43 pages, public, peer-reviewed.** Aligned to:
+- **GHG Protocol Corporate Standard** for scope 1/2/3 framing.
+- **ISO 14064** for organisational GHG accounting.
+- **ISO 14040 / ISO 14044** for life-cycle assessment (used for scope 3 hardware embodied
+  emissions).
+- **Sector-specific GHG Protocol guide for ICT.**
+- Third-party validated by an external assurance provider (verify the current verifier on the
+  methodology document before quoting in client work).
+
+This methodology alignment matters specifically for **CSRD reporting** in the EU - clients facing
+CSRD audit requirements need the methodology to be ISO-aligned and externally verified, which v3
+achieves.
+
+**Common trap - the unused-capacity ventilation mechanic.** AWS does not measure individual
+instance-level emissions precisely. The calculation works as follows:
+
+1. Total data center emissions are measured (scope 1+2 for the facility, scope 3 for embodied
+   hardware).
+2. Customer allocations are computed from per-customer usage of metered services.
+3. **Unused or unallocated capacity is ventilated proportionally across all customers based on
+   usage share** - the unused racks were still built, powered, and cooled.
+
+Consequence: **the same workload reports different carbon month-to-month even with no architectural
+change**, because the unused-capacity ratio in the data center varies. Expect 5-15% month-to-month
+variance and do not interpret it as workload drift. Flag this explicitly to clients before they
+start chasing phantom anomalies.
+
+### Critical reading of AWS sustainability claims
+
+**The "100% renewable energy matched" claim is market-based, not physical.** AWS purchases enough
+renewable energy globally - via PPAs, RECs in the US, Guarantees of Origin in Europe - to match
+aggregate consumption. This does not mean any specific data center pulls renewable electrons from
+its local grid. AWS regions in Ireland (~350 g CO2/kWh grid intensity) and Germany
+(~300 g CO2/kWh) draw from gas-heavy grids regardless of the global renewable-matching claim. Use
+**location-based** numbers for workload-placement decisions, not market-based.
+
+**The Climate Pledge "net zero by 2040" headline covers scope 1+2 in most communications.**
+Scope 3 emissions (supply chain, hardware manufacturing, customer use of products) are larger and
+reduce more slowly. When a client's CSRD scope includes scope 3 disclosure, the AWS marketing
+headline is not enough - request scope 3 detail explicitly.
+
+**The "moving to AWS reduces emissions by 80%+" framing is vendor-funded analysis.** Studies cited
+by AWS (451 Research, S&P Global) use methodology AWS commissions. Independent academic work
+(Masanet et al., Berkeley) supports the directional claim - hyperscale is more efficient than
+on-prem - but with smaller deltas, especially when on-prem is a modern facility. Treat the 80%
+figure as a marketing ceiling, not a planning baseline.
+
+### AWS-specific hardware and storage anchors
+
+- **Graviton processors.** AWS publishes ~60% lower carbon at equivalent performance vs comparable
+  x86 instances. Verify the current published figure on the AWS Graviton sustainability page
+  before quoting (numbers change with new generations). Cheaper *and* meaningfully lower carbon -
+  one of the rare unambiguous wins.
+- **Parquet vs CSV storage.** ~90% size reduction with column compression. Generic to any
+  column-oriented format, not AWS-specific, but worth flagging because it is one of the largest
+  single-action data optimisations.
+- **Spot instances as a scope 3 lever.** Cost benefit is well-known. The carbon benefit lands less
+  often: Spot extends useful hardware life, amortising embodied emissions across more
+  workload-hours. Make this explicit when presenting Spot to a sustainability-driven client.
 
 ### Open source: Cloud Carbon Footprint (CCF)
 
@@ -132,15 +213,30 @@ emissions by up to 75% for a given workload.
 
 ### Low-carbon regions by provider (indicative)
 
-| Provider | Lower carbon regions | Higher carbon regions |
+| Provider | Lower-carbon regions | Higher-carbon regions |
 |---|---|---|
-| **AWS** | us-east-1 (Virginia), us-east-2 (Ohio), eu-west-1 (Ireland)  - 100% renewable matched | Regions with coal-heavy grids vary; check CCFT regional data |
+| **AWS** | Paris (eu-west-3), Stockholm (eu-north-1) | Virginia (us-east-1), Dublin (eu-west-1), Frankfurt (eu-central-1) |
 | **GCP** | Montreal, Toronto, Santiago (90%+ carbon-free energy) | Varies by grid mix |
 | **Azure** | Nordics, Ireland, parts of Canada | Regions dependent on coal or gas grids |
 
-**Recommendation:** Before selecting a region for a new workload, check the carbon
-intensity in CCF's regional breakdown or the Climatiq region comparison chart. Do not
-rely solely on provider sustainability claims  - use location-based data.
+**AWS region intensities - quantitative anchors (location-based):**
+
+| AWS region | Approximate grid intensity | Grid mix |
+|---|---|---|
+| Paris (eu-west-3) | ~20-25 g CO2/kWh | Nuclear-heavy |
+| Stockholm (eu-north-1) | ~20-25 g CO2/kWh | Hydro and nuclear |
+| Frankfurt (eu-central-1) | ~300-350 g CO2/kWh | In transition, improving |
+| Dublin (eu-west-1) | ~300-350 g CO2/kWh | Gas-heavy |
+| Virginia (us-east-1) | ~350-400 g CO2/kWh | Gas + coal mix |
+
+The intensity gap between Paris/Stockholm and US-East-1 is roughly **15x**. Use this number in
+client conversations to make region selection concrete. Source via [Electricity
+Maps](https://electricitymaps.com), not via vendor claims - vendor numbers reflect market-based
+methodology, while Electricity Maps reflects physical grid reality.
+
+**Recommendation:** Before selecting a region for a new workload, check the carbon intensity in
+Electricity Maps, CCF's regional breakdown, or the Climatiq region comparison chart. Do not rely
+solely on provider sustainability claims - use location-based data.
 
 **Practical constraint:** Latency, data residency, and compliance requirements limit
 region flexibility. Carbon region selection applies primarily to:
@@ -220,6 +316,217 @@ followed by integration into the risk platform scheduler for non-time-sensitive 
 
 ---
 
+## AWS Well-Architected Sustainability Pillar - the six areas
+
+The pillar predates 2025 and its structure has been stable. Six best-practice areas (SUS01
+through SUS06). Treat each concisely, with a critical-read note where the AWS framing is
+overstated or under-operationalised.
+
+### SUS01 - Region selection
+
+AWS recommends choosing regions based on customer distance, business need, and grid carbon
+intensity. The pillar treats region selection as a sustainability action.
+
+**Critical read.** Region intensity matters for **location-based** reporting; for **market-based**
+reporting AWS markets all regions as 100% renewable matched. The pillar does not call this
+distinction out clearly - the consultant needs to know which reporting mode the client uses
+before recommending a region migration as a sustainability action.
+
+### SUS02 - Alignment to demand
+
+Match infrastructure capacity to actual demand. Right-size, scale dynamically, decommission idle
+resources.
+
+**Critical read.** This is the FinOps right-sizing playbook reframed in carbon language. The
+audit, the queries, the recommendations are the same. Do not run two separate workstreams; run
+one and present results in both lenses.
+
+### SUS03 - Software architecture patterns
+
+Optimise software for hardware (use efficient libraries, avoid bloat), remove unused features,
+refactor for parallelism, choose efficient programming languages.
+
+**Critical read.** Most aspirational area. Hardest to operationalise on a 6-week or 6-month
+engagement. "Switch programming language" is not an engagement deliverable. Treat as a long-cycle
+architectural recommendation surfaced for the client's roadmap, not a quick win. The library-size
+and unused-feature-removal advice is more actionable but rarely material at scale.
+
+### SUS04 - Data patterns
+
+Storage tier selection, lifecycle automation, deduplication, compression, format choice (Parquet
+over CSV), retention pruning aligned to actual need.
+
+**Critical read.** Almost complete overlap with FinOps storage optimisation. Same actions, same
+audit. The carbon-specific framing is "embodied emissions of the underlying disk," but the
+practical actions match cost optimisation precisely.
+
+### SUS05 - Hardware patterns
+
+Use efficient processor families (Graviton on AWS, equivalents elsewhere), upgrade to current
+generations, use Spot to extend hardware lifetime, choose specialised accelerators only when
+needed.
+
+**Critical read.** This is the area where the carbon argument is strongest and sometimes lands
+harder than the cost argument alone. Graviton is cheaper *and* meaningfully lower carbon. Spot
+extends hardware lifetime - a real scope 3 lever, not just a cost lever. Recommend Hardware
+Patterns first when a client is genuinely sustainability-driven.
+
+### SUS06 - Development and deployment process
+
+CI/CD efficiency, build cadence, sustainability metrics in dashboards, culture and people.
+
+**Critical read.** Real but lightweight. Nightly-build emissions are rarely material at customer
+scale. The cultural and metrics points are sound but generic - they apply to any optimisation
+discipline, not specifically sustainability.
+
+### The pillar overall - summary critical read
+
+The Sustainability Pillar is **mostly the cost-optimisation pillar reframed in a carbon lens**,
+with three sustainability-specific levers worth treating separately: (a) region selection for
+location-based reporting, (b) hardware modernisation to lower-carbon processor families, (c) Spot
+for hardware lifetime extension. Everything else overlaps with existing FinOps practice.
+
+This means the engagement structure for a "GreenOps audit" should typically be:
+- One unified audit looking through both lenses.
+- One report presenting findings in both cost and carbon terms.
+- Three sustainability-specific recommendation tracks layered on top.
+
+Do not sell GreenOps as a separate engagement when the bulk of the work is already in scope under
+FinOps.
+
+---
+
+## GreenOps engagement framing - vendor-agnostic
+
+### Sizing the GreenOps opportunity
+
+For most cloud customers, the achievable scope 1+2+3 reduction in cloud workloads sits in the
+**5-15% range** over a 12-18 month engagement, expressed in tonnes CO2e. The headline reduction
+in carbon footprint is rarely transformational on its own.
+
+Decompose the typical opportunity:
+- **70-80% of the carbon reduction comes from FinOps actions you would already take** -
+  right-sizing, scheduling, decommissioning, lifecycle tiering.
+- **20-30% is sustainability-specific** - region migration, hardware modernisation, Spot adoption
+  for embodied-emissions amortisation, retention policy reductions specifically for
+  embodied-storage reasons.
+
+Set this expectation upfront with clients. A "GreenOps engagement" that promises 30%+ reductions
+in 6 months is overpromising unless the customer's baseline is unusually wasteful.
+
+### Where FinOps and GreenOps converge (the bulk of the work)
+
+| Action | FinOps benefit | GreenOps benefit |
+|---|---|---|
+| Right-sizing oversized VMs | Compute cost down | Lower direct emissions, lower embodied amortisation |
+| Auto-shutdown / scheduling | Compute cost down | Lower direct emissions during off-hours |
+| Decommissioning idle / orphan resources | Direct cost reduction | Eliminates unused embodied carbon allocation |
+| Storage lifecycle (hot to cool to archive) | Storage cost down | Lower embodied + powered storage |
+| Snapshot and backup hygiene | Storage cost down | Same |
+| Retention policy alignment to business need | Storage cost down | Same |
+
+Frame to clients: **every cost optimisation is also a carbon optimisation, with rare exceptions.**
+
+### Where they diverge (the cases that need explicit decisioning)
+
+Four scenarios where cost and carbon point in different directions and the decision is strategic,
+not technical.
+
+**Region migration for carbon.** Moving from US-East-1 (~375 g CO2/kWh) to Sweden (~25 g) reduces
+location-based emissions by ~15x. Trade-offs: higher latency to US users, potentially different
+SKU pricing, egress charges to legacy systems, data-residency implications. Net cost may rise
+even though carbon falls dramatically.
+
+**Premium hardware for efficiency.** Latest-generation processors typically cost more per hour
+but deliver more work per watt. Net cost per workload-output may be lower even at higher hourly
+rate, but only if the workload actually utilises the new hardware features. For static workloads,
+the migration cost may exceed savings. For carbon, latest-generation almost always wins.
+
+**Hardware lifetime extension via Spot.** Spot reduces effective embodied-emissions amortisation
+per workload-hour because the instances would otherwise sit idle. Trade-off: evictability,
+complexity in workload design. Cost benefit is established; carbon benefit lands less often.
+
+**Carbon reporting overhead.** Setting up CSRD-grade carbon reporting has its own infrastructure
+cost (FinOps Hubs / Power BI / third-party platform). The reporting itself is overhead - the
+value is in the optimisation it enables. Be explicit with the client about what they are paying
+for and what they get.
+
+### The cost-vs-carbon trade-off - four-quadrant framework
+
+When cost and carbon diverge, the decision is strategic. Use this framing in client
+conversations:
+
+| Quadrant | Action |
+|---|---|
+| Lower cost + lower carbon | Pure win. No decision required. The bulk of optimisation. |
+| Lower cost + higher carbon (rare) | Document the trade-off explicitly. Decide based on client's stated priority hierarchy. |
+| Higher cost + lower carbon | Frame as a strategic sustainability investment. Compute a carbon-per-euro ROI. Escalate to the sustainability committee, not the CFO alone. |
+| Higher cost + higher carbon | Never recommend. |
+
+The "higher cost + lower carbon" quadrant is where consulting judgment matters most. A region
+migration that costs €500k extra per year and reduces 200 tCO2e is €2.5k/tCO2e - useful to
+compare against the customer's carbon-pricing assumption (internal carbon price, expected carbon
+tax, voluntary offset rate). Many enterprise customers use €50-150/tCO2e as an internal price;
+the region migration above is far more expensive than that and probably not justified on carbon
+alone, but might be justified strategically.
+
+### The CSRD / climate-disclosure conversation
+
+For European clients (and increasingly global ones via SEC and similar regulators), carbon
+reporting is no longer optional. The roles to know:
+
+**Chief Sustainability Officer / Head of Sustainability.** Owns the disclosure narrative. Wants
+methodology defensibility (ISO standards, third-party verification, scope completeness). Cares
+less about absolute optimisation than about reportability and audit-readiness.
+
+**CFO / Group Controller.** Owns the financial disclosure. Wants the carbon disclosure to align
+with cost disclosure - consistent boundaries (which subsidiaries, which legal entities),
+consistent allocation methodology (how shared services are split), consistent reporting cadence.
+
+**Cloud platform owner / FinOps lead.** Owns the cloud data and the cost-allocation model. Needs
+to operationalise emissions reporting on top of the existing cost reporting machinery - same
+export pipelines, additional carbon dimensions.
+
+**The deliverable for a CSRD-flavoured engagement is typically:**
+- A documented carbon allocation methodology (which scopes, location-based vs market-based,
+  calculation method, sources).
+- A monthly or quarterly emissions report aligned to the financial reporting cadence.
+- A reduction roadmap tied to the financial planning cycle (multi-year budget alignment).
+
+The consulting work is as much about **reporting infrastructure** as about optimisation.
+Sometimes more.
+
+### The vendor-agnostic stance on carbon numbers
+
+Vendor-reported carbon data should not be the only source of truth. Vendor methodology favours
+vendor framing - not necessarily wrong, but worth triangulating. Build the cross-check into the
+default workflow:
+
+- **Cloud Carbon Footprint (open source).** Independent estimates across AWS, Azure, GCP. Useful
+  sanity check on vendor-reported numbers.
+- **Climatiq API.** Programmatic carbon estimates with documented emission factors. Useful for
+  embedding in custom dashboards.
+- **Electricity Maps.** Real-time grid intensity, location-based. Use to verify region-selection
+  assumptions and to anchor the location-based vs market-based conversation in physical reality.
+- **Academic sources.** Masanet et al. (Berkeley), the IEA, the European Environment Agency for
+  context on how cloud emissions compare to other sectors.
+
+State this stance explicitly in the engagement so the workflow always cross-checks vendor numbers
+against an independent source.
+
+### The three actions for any engagement (vendor-agnostic)
+
+1. **Measure.** Establish the baseline using vendor-native tools (Sustainability Console for AWS,
+   Emissions Impact Dashboard for Azure, Carbon Footprint for GCP) cross-checked against an
+   independent source (CCF or Climatiq).
+2. **Act.** Run the FinOps audit through both lenses - cost and carbon - and present findings in
+   both. Layer the three sustainability-specific recommendations (region, hardware,
+   Spot/equivalent).
+3. **Report.** Build the recurring reporting mechanism - monthly or quarterly, aligned to
+   financial reporting cadence, methodology documented for audit.
+
+---
+
 ## Immediate wins (quick actions)
 
 These actions reduce both cost and carbon. Prioritize in this order:
@@ -280,7 +587,7 @@ Cloud providers report their data center emissions under Scope 1 and 2.
 
 - [ ] Determine which reporting standard applies (GHG Protocol, CSRD, SEC, or internal)
 - [ ] Decide on location-based vs. market-based methodology  - document the choice
-- [ ] Enable Scope 3 data in AWS CCFT (available from Jan 2025 methodology)
+- [ ] Enable Scope 3 data in the AWS Sustainability Console (Methodology v3, October 2025, externally verified)
 - [ ] Use GCP's location-based and market-based views to understand the gap
 - [ ] Export monthly carbon data to a central data store alongside cost data
 - [ ] Assign a carbon data owner (typically the FinOps lead or sustainability team)
@@ -293,7 +600,7 @@ Cloud providers report their data center emissions under Scope 1 and 2.
 
 | Tool | Type | Use case | Link |
 |---|---|---|---|
-| AWS Customer Carbon Footprint Tool | Native | AWS Scope 1/2/3 reporting | aws.amazon.com/sustainability/tools |
+| AWS Sustainability Console | Native | AWS Scope 1/2/3 reporting (renamed from CCFT 31 March 2026; Methodology v3 Oct 2025) | aws.amazon.com/sustainability/tools |
 | GCP Carbon Footprint | Native | GCP emissions, most granular | console.cloud.google.com |
 | Azure Emissions Impact Dashboard | Native | Azure Scope 1/2/3 reporting | portal.azure.com |
 | Cloud Carbon Footprint (CCF) | Open source | Multi-cloud, workload optimization | cloudcarbonfootprint.org |


### PR DESCRIPTION
## Summary

Single focused pass on `cloud-finops/references/greenops-cloud-carbon.md` to add engagement-pattern depth, refresh the AWS section, and surface the Well-Architected Sustainability Pillar.

- **AWS section refresh.** Renamed CCFT to **AWS Sustainability Console** (broken out of Billing on 31 March 2026); added v2 console features, Data Exports option, and Methodology v3 (October 2025) alignment to GHG Protocol / ISO 14064 / ISO 14040 / ISO 14044 / ICT sector guide. Documented the unused-capacity ventilation mechanic that creates 5-15% month-to-month variance with no architectural change.
- **Critical reading of AWS sustainability claims** (new callout). Market-based vs physical 100% renewable matching, Climate Pledge scope-1+2 framing, the vendor-funded 80% reduction figure.
- **AWS-specific hardware and storage anchors.** Graviton ~60% lower carbon, Parquet ~90% size reduction, Spot as a scope 3 lever for embodied-emissions amortisation.
- **Region selection fixed.** us-east-1 was wrongly labelled lower-carbon. New AWS-region intensity sub-table with quantitative anchors (Paris/Stockholm ~20-25 g, Frankfurt/Dublin ~300-350 g, Virginia ~350-400 g) and the **15x gap** highlighted, sourced via Electricity Maps rather than vendor claims.
- **AWS Well-Architected Sustainability Pillar (new top-level section).** SUS01-SUS06 with critical-read notes; summary that the pillar is mostly cost-optimisation reframed, with three sustainability-specific levers worth treating separately (region selection, hardware modernisation, Spot for hardware lifetime).
- **GreenOps engagement framing - vendor-agnostic (new top-level section).** 5-15% opportunity sizing (70-80% of reduction comes from FinOps actions), FinOps/GreenOps convergence and divergence tables, four-quadrant cost-vs-carbon framework with EUR/tCO2e calculation, CSRD stakeholder roles (CSO, CFO, FinOps lead), vendor-agnostic stance on cross-checking carbon numbers (CCF, Climatiq, Electricity Maps, academic sources), three-action engagement framework (Measure / Act / Report).
- **SKILL.md description** extended with brief `GreenOps (AWS Sustainability Console, CSRD engagement framing)` clause. 954 chars, 70-char margin under the 1024 limit.

Net diff: 2 files changed, 325 insertions(+), 17 deletions(-).

## Test plan

- [ ] Ask a CCFT-related question to verify the model now responds with "AWS Sustainability Console" and references Methodology v3.
- [ ] Ask a region-selection question for AWS - verify the response cites the 15x gap and Electricity Maps as the source of truth.
- [ ] Ask "should we run a separate GreenOps engagement?" - verify the response surfaces the unified-audit framing rather than recommending a parallel workstream.
- [ ] Ask a CSRD scope-3 question - verify the response distinguishes location-based vs market-based and references Methodology v3 verification.
- [ ] Ask "what carbon reduction can we expect from a GreenOps engagement?" - verify the 5-15% sizing anchor and the 70-80% FinOps overlap claim are reproduced.
- [ ] Confirm `cloud-finops/SKILL.md` description still loads cleanly under the 1024-char Claude.ai upload limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)