### PR TITLE
Bump plugin to v1.11.0 - GreenOps depth + self-hosted vs managed reference

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "cloud-finops",
-      "description": "Expert FinOps guidance for cloud, AI, SaaS, and data-platform spend. 21 reference files spanning AWS, Azure, GCP, Anthropic, Bedrock, Azure OpenAI, Vertex AI, Databricks, Microsoft Fabric, Snowflake, OCI, AI coding tools, FinOps Framework 2024+2026, GreenOps, SaaS asset management, and ITAM. Open source, model-agnostic, refreshed bi-monthly.",
+      "description": "Expert FinOps guidance for cloud, AI, SaaS, and data-platform spend. 22 reference files spanning AWS, Azure, GCP, Anthropic, Bedrock, Azure OpenAI, Vertex AI, Databricks, Microsoft Fabric, Snowflake, OCI, AI coding tools, FinOps Framework 2024+2026, GreenOps (AWS Sustainability Console, CSRD engagement framing), self-hosted vs managed AI inference decisioning, SaaS asset management, and ITAM. Open source, model-agnostic, refreshed bi-monthly.",
       "author": {
         "name": "OptimNow",
         "url": "https://optimnow.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloud-finops",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "Expert FinOps guidance for cloud, AI, SaaS, and data-platform spend (multi-provider, model-agnostic).",
   "author": {
     "name": "OptimNow",


### PR DESCRIPTION
## Summary

Plugin version bump for the two content PRs that just merged (#43 and #44).

- `.claude-plugin/plugin.json`: `1.10.0` → `1.11.0` (minor bump for user-visible feature additions, per the project semver convention).
- `.claude-plugin/marketplace.json`: reference count `21` → `22`; description now surfaces the GreenOps engagement framing and the new self-hosted vs managed AI inference decisioning so install-time browsers see the new capabilities.

## What this version contains

From #43 (greenops-aws-engagement-framing):
- AWS Sustainability Console rename (was CCFT, broken out of Billing 31 March 2026), Methodology v3, unused-capacity ventilation trap.
- Critical reading of AWS sustainability claims (market-based vs physical, Climate Pledge scope, vendor-funded 80% figure).
- Quantitative AWS region intensity anchors with the 15x gap, sourced via Electricity Maps.
- Well-Architected Sustainability Pillar (SUS01-SUS06) with critical-read notes.
- Vendor-agnostic GreenOps engagement framing: 5-15% sizing, FinOps/GreenOps convergence and divergence tables, four-quadrant cost-vs-carbon framework, CSRD stakeholder roles.

From #44 (ai-self-hosted-vs-managed):
- New `finops-ai-self-hosted-vs-managed.md` reference (the 22nd reference file).
- Per-token vs per-hour billing comparison, hidden cost surface, 5-criteria ML-Ops maturity rubric, hybrid routing pattern, eight client diagnostic questions, six anti-patterns.
- Routing entries in SKILL.md / POWER.md, README.md coverage and usage examples, cross-references from `finops-for-ai.md` and `finops-genai-capacity.md`.

## Test plan

- [ ] Confirm the plugin still loads via `/plugin update cloud-finops@optimnow` after merge.
- [ ] Confirm the marketplace description renders cleanly (no truncation issues from the longer text).
- [ ] Verify `SKILL.md` description still loads under the 1024-char Claude.ai limit (currently 1003 chars, 21-char margin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)