### PR TITLE
Docs: clarify /plugin commands run at the Claude Code prompt

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -26,6 +26,13 @@ and cleans up. Works on Mac, Linux, and WSL.
 
 ## Option 2: Manual install (Claude Code)
 
+> **For most Claude Code users**, the plugin marketplace path documented in
+> [README.md](./README.md#quick-install-claude-code-plugin) is simpler and supports
+> auto-updates. Those `/plugin ...` commands are typed at the **Claude Code prompt**
+> (the chat input after running `claude`), not in a shell. Use the manual clone below
+> only when you want full control over where the skill files live or when you cannot
+> use the plugin marketplace.
+
 ```bash
 # Clone the repository
 git clone https://github.com/OptimNow/cloud-finops-skills.git

--- a/README.md
+++ b/README.md
@@ -279,14 +279,19 @@ covering Claude Code, Kiro IDE, Claude.ai, and API integration.
 For Claude Code users, the skill is also distributed as a self-hosted plugin with
 auto-update support. Two commands:
 
-```bash
+> **Where to type these:** at the **Claude Code prompt** - the chat input you see after
+> running `claude` in your terminal. They are slash commands, not shell commands. Pasting
+> them into PowerShell, bash, or zsh will fail.
+
+```text
 /plugin marketplace add https://github.com/OptimNow/cloud-finops-skills.git
 /plugin install cloud-finops@optimnow
 ```
 
-To pull the latest content (including the bi-monthly automated updates):
+To pull the latest content (including the bi-monthly automated updates), run this at the
+same Claude Code prompt:
 
-```bash
+```text
 /plugin update cloud-finops@optimnow
 ```
 


### PR DESCRIPTION
## Summary

The README previously showed `/plugin marketplace add ...`, `/plugin install ...`, and `/plugin update ...` inside ` ```bash ` code fences with no indication of where to type them. A reader who copies into PowerShell, bash, or zsh hits "command not found" - those are Claude Code slash commands, typed at the chat prompt after running `claude`, not shell commands.

## Changes

- **README.md**: language tag `bash` -> `text` on the three `/plugin` code blocks; added an explicit "Where to type these" callout pointing at the Claude Code prompt and warning that PowerShell/bash/zsh will not work.
- **INSTALLATION.md**: added a short note at the top of "Option 2: Manual install (Claude Code)" directing Claude Code users to the README plugin marketplace path as the simpler default, with the same prompt-location caveat. The manual clone procedure remains documented for cases that need it.

Docs-only change. No version bump - plugin behaviour is unchanged.

## Test plan

- [ ] Confirm the README "Quick install: Claude Code plugin" section reads cleanly with the new callout.
- [ ] Confirm the `text` code fences still render the commands correctly on GitHub.
- [ ] Confirm INSTALLATION.md Option 2 still works for the manual-clone path while pointing plugin-marketplace users elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)