### PR TITLE
Cross-tool installer + per-tool packaging matrix (11 tools)

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -1,138 +1,215 @@
 # Installation Guide
 
+The skill ships in a single canonical Claude / Agent-Skills format and is converted on
+the fly to the shape each target tool expects. One installer (`./install.sh`) handles
+the conversion for every supported tool. Per-tool blocks below are copy-pasteable.
+
 ## Prerequisites
 
-- Claude Code, or another agent that supports the Agent Skills specification
-- Git
+- `git` (for clone / fetch — only required if running the installer remotely)
+- `bash` 4+ (macOS / Linux / WSL)
+- For the Claude Projects zip: `python3` or `zip`
 
 ---
 
-## Option 1: One-liner install (recommended)
+## Quick reference: one installer, eleven tools
 
 ```bash
+# Auto-detect tools in the current project / $HOME and install for each
 curl -sL https://raw.githubusercontent.com/OptimNow/cloud-finops-skills/main/install.sh | bash
+
+# Or install for a specific tool
+curl -sL https://raw.githubusercontent.com/OptimNow/cloud-finops-skills/main/install.sh | bash -s -- --tool <name>
+
+# Other useful flags
+./install.sh --list              # list supported tools
+./install.sh --dry-run           # print what would happen
+./install.sh --user              # install at $HOME paths (Claude Code, Gemini CLI)
+./install.sh --dest <dir>        # override target directory
 ```
 
-This downloads the skill into the current directory. To install into a specific project:
+Supported tools: `claude-code`, `claude-projects`, `cursor`, `windsurf`, `chatgpt`,
+`gemini`, `gemini-cli`, `codex`, `aider`, `copilot`, `kiro`.
+
+---
+
+## Per-tool blocks
+
+### Claude Code (project)
 
 ```bash
-curl -sL https://raw.githubusercontent.com/OptimNow/cloud-finops-skills/main/install.sh | bash -s -- --dir ~/my-project
+./install.sh --tool claude-code
 ```
 
-The script clones the repo, copies the `cloud-finops/` folder, verifies the installation,
-and cleans up. Works on Mac, Linux, and WSL.
+Copies the skill folder to `<project>/.claude/skills/cloud-finops/`. Restart Claude Code
+or run `/reload-plugins` to pick up.
 
----
+For auto-updating installs, prefer the plugin marketplace path:
 
-## Option 2: Manual install (Claude Code)
+```
+/plugin marketplace add https://github.com/OptimNow/cloud-finops-skills.git
+/plugin install cloud-finops@optimnow
+/plugin update cloud-finops@optimnow
+```
 
-> **For most Claude Code users**, the plugin marketplace path documented in
-> [README.md](./README.md#quick-install-claude-code-plugin) is simpler and supports
-> auto-updates. Those `/plugin ...` commands are typed at the **Claude Code prompt**
-> (the chat input after running `claude`), not in a shell. Use the manual clone below
-> only when you want full control over where the skill files live or when you cannot
-> use the plugin marketplace.
+(Run those at the Claude Code prompt, not in a shell.)
+
+### Claude Code (user-level)
 
 ```bash
-# Clone the repository
-git clone https://github.com/OptimNow/cloud-finops-skills.git
-
-# Copy the skill folder to your project or skills directory
-cp -r cloud-finops-skills/cloud-finops ~/.claude/skills/
-
-# Verify structure
-ls ~/.claude/skills/cloud-finops/
-# Should show: SKILL.md, references/
+./install.sh --tool claude-code --user
 ```
 
-After copying, Claude Code will automatically detect the skill. Test it:
+Copies to `~/.claude/skills/cloud-finops/` so the skill is available across all your
+Claude Code projects.
 
-```
-"What are the first steps to manage AI inference costs?"
-"How do I choose between Reserved Instances and Savings Plans on AWS?"
-"We have zero tagging compliance - where do we start?"
-```
-
----
-
-## Option 3: Kiro IDE (power)
-
-In Kiro IDE, add the power directly from GitHub:
-
-1. Open the **Powers** panel in Kiro
-2. Click **Add power from GitHub**
-3. Enter the repository URL: `https://github.com/OptimNow/cloud-finops-skills/`
-4. The power installs automatically and activates when you mention cloud costs,
-   FinOps, AI spend, or any of the covered domains
-
-The power loads dynamically based on conversation context - no manual activation needed.
-
----
-
-## Option 4: Claude.ai skill upload
-
-If you are using Claude.ai (not Claude Code), you can upload the skill directly.
-
-### Step 1: Download the skill
-
-Clone or download this repository, then create a zip of the `cloud-finops/` folder:
+### Claude Projects / claude.ai (web upload)
 
 ```bash
-git clone https://github.com/OptimNow/cloud-finops-skills.git
-cd cloud-finops-skills
-zip -r cloud-finops.zip cloud-finops/
+./install.sh --tool claude-projects
 ```
 
-On Windows (PowerShell):
+Builds `dist/claude-projects/cloud-finops.zip`. Upload via Claude.ai or Claude Desktop:
+**Settings → Skills → Upload zip**.
 
-```powershell
-git clone https://github.com/OptimNow/cloud-finops-skills.git
-cd cloud-finops-skills
-Compress-Archive -Path cloud-finops -DestinationPath cloud-finops.zip
+The release workflow also attaches the same zip to every GitHub release - you can grab
+it from https://github.com/OptimNow/cloud-finops-skills/releases.
+
+### Cursor
+
+```bash
+./install.sh --tool cursor
 ```
 
-### Step 2: Open the Customize panel
+Writes `<project>/.cursor/rules/cloud-finops.mdc` (single rule with the full skill body
++ Cursor frontmatter). Cursor auto-loads `.cursor/rules/`. Trigger by asking a FinOps
+question in chat.
 
-On the Claude.ai home page, find and click **Manage connectors & skills** at the
-bottom of the sidebar.
+### Windsurf
 
-<img src="assets/claude-manage-connectors.png" alt="Claude.ai home page - Manage connectors and skills" width="400" />
+```bash
+./install.sh --tool windsurf
+```
 
-### Step 3: Go to Skills and click +
+Writes `<project>/.windsurf/rules/cloud-finops.md` with Windsurf rule frontmatter
+(`trigger: model_decision`).
 
-In the Customize panel, click **Skills** in the left sidebar, then click the **+**
-button at the top to add a new skill.
+### ChatGPT (Custom GPT)
 
-<img src="assets/claude-skill-customize.png" alt="Claude.ai Customize panel - Skills section" width="400" />
+```bash
+./install.sh --tool chatgpt
+```
 
-### Step 4: Upload the zip
+Builds two artefacts in `dist/chatgpt/`:
 
-Drag and drop `cloud-finops.zip` into the upload dialog, or click to browse.
-The zip must contain a `SKILL.md` file with valid YAML frontmatter.
+- `instructions.md` - target ≤ 8000 chars; the routing logic, reasoning sequence, and
+  response contract that go into the GPT's Instructions field. The installer warns if
+  the file exceeds the limit.
+- `knowledge/*.md` - 20 reference files for upload to the GPT's Knowledge section. The
+  21st reference (`optimnow-methodology.md`) is **merged into `finops-for-ai.md`** to
+  fit ChatGPT's 20-file cap; the methodology lens stays available via that file.
 
-<img src="assets/claude-skill-upload.png" alt="Claude.ai skill upload dialog" width="400" />
+Then manually:
 
-Once uploaded, the skill appears under **Personal plugins** and activates
-automatically when you ask FinOps-related questions.
+1. Open https://chatgpt.com/gpts/editor
+2. Paste `dist/chatgpt/instructions.md` into the Instructions field
+3. Upload all files from `dist/chatgpt/knowledge/` to the Knowledge section
+4. Set name (`Cloud FinOps`), category, visibility per preference
+
+**Trade-off:** ChatGPT's 8K Instructions limit means routing + response contract live
+inline, but the reference content is RAG-retrieved from Knowledge files. Compared to
+the Claude / Cursor install, ChatGPT may miss cross-reference detail because it
+retrieves chunks rather than loading the full skill into context.
+
+### Gemini Gems (web)
+
+```bash
+./install.sh --tool gemini
+```
+
+Builds `dist/gemini/instructions.md` (same content as ChatGPT) and
+`dist/gemini/knowledge/*.md` - references **grouped by domain** (aws, azure, gcp, ai,
+data-platforms, oci, cross-cutting, methodology) to fit Gemini Gems' tighter file cap.
+
+Manual upload at https://gemini.google.com/gems/. Same trade-off as ChatGPT applies.
+
+### Gemini CLI
+
+```bash
+./install.sh --tool gemini-cli --user
+```
+
+Copies to `~/.gemini/skills/cloud-finops/`.
+
+### OpenAI Codex CLI
+
+```bash
+./install.sh --tool codex
+```
+
+Writes `<project>/AGENTS.md` (or `AGENTS-cloud-finops.md` if `AGENTS.md` already exists,
+to avoid clobbering). Codex CLI reads `AGENTS.md` as project-level context.
+
+This is the interim path; an MCP server (planned) will be the cleaner cross-agent
+distribution mechanism.
+
+### Aider
+
+```bash
+./install.sh --tool aider
+```
+
+Writes `<project>/CONVENTIONS.md` (or `CONVENTIONS-cloud-finops.md` if one exists).
+Aider auto-reads `CONVENTIONS.md`. Default coverage is the four general references
+(AWS, Azure, GCP, AI). Add specific references at runtime with:
+
+```bash
+aider --read cloud-finops/references/finops-bedrock.md ...
+```
+
+### GitHub Copilot
+
+```bash
+./install.sh --tool copilot
+```
+
+Writes `<project>/.github/copilot-instructions.md`. Copilot's customisation surface
+is shallow - the file informs code-suggestion context but won't power deep FinOps Q&A
+the way Claude / Cursor do. Use as a lightweight context hint, not a full skill load.
+
+### Kiro IDE
+
+```bash
+./install.sh --tool kiro
+```
+
+Copies the skill to `<project>/.kiro/powers/cloud-finops/`. Kiro uses `POWER.md` as the
+entry point.
 
 ---
 
-## Option 5: Agent integration
+## Updating
 
-The skill is designed to integrate directly with OptimNow's Agent Smith.
-
-```python
-# In your Agent Smith configuration, add to the skills loader:
-skill_loader.load_skill("cloud-finops")
+```bash
+./install.sh --tool <name>
 ```
 
-Refer to the Agent Smith documentation for skill configuration details.
+Re-running the installer for a tool overwrites the previous install in place. The
+script is idempotent - safe to run on every release.
+
+For Claude Code plugin users:
+
+```
+/plugin update cloud-finops@optimnow
+```
 
 ---
 
-## Option 6: API integration (system prompt injection)
+## API integration (system-prompt injection)
 
-For direct API use, concatenate the skill files into your system prompt:
+For direct API use without one of the supported tools, concatenate the skill files
+into your system prompt. This is the model-agnostic path - works with any LLM API
+(Claude, OpenAI, Gemini, Mistral, others).
 
 ```python
 import os
@@ -150,13 +227,13 @@ def load_cloud_finops_skill(skill_dir: str) -> str:
 system_prompt = load_cloud_finops_skill("./cloud-finops")
 ```
 
-For token efficiency, load only the domain reference files relevant to your use case
-rather than all references at once.
+For token efficiency, load only the references relevant to your use case. For most
+single-domain queries, one reference file plus `optimnow-methodology.md` is sufficient.
 
-For GPT and other models, use a **response contract** in your system prompt so the model
-produces structured, billing-grounded answers instead of generic advice.
+### Recommended response contract
 
-Recommended contract (model-agnostic):
+For non-Claude models, prepend this contract to your system prompt to keep responses
+structured and grounded in the injected references:
 
 ```text
 # Cloud FinOps Response Contract - by OptimNow
@@ -209,31 +286,27 @@ Use headers:
 Do not output JSON unless requested.
 ```
 
-
----
-
-## Updating the skill
-
-```bash
-# Pull latest changes
-cd cloud-finops-skills
-git pull origin main
-
-# Re-copy to your skills directory
-cp -r cloud-finops ~/.claude/skills/
-```
-
-Or re-run the one-liner installer - it will replace the existing installation automatically.
-
 ---
 
 ## Troubleshooting
 
-**Skill not activating:** Check that the YAML frontmatter in `SKILL.md` is valid.
-The `name` and `description` fields are required.
+**Skill not activating in Claude Code:** check that the YAML frontmatter in `SKILL.md`
+is valid. The `name` and `description` fields are required.
 
-**References not loading:** Ensure all files in `references/` are readable and correctly
-named. The SKILL.md router references files by exact filename.
+**Cursor / Windsurf rule not triggering:** verify the rule's `description` field is
+specific enough that the model picks it up. The default description in the installer
+already covers the major FinOps query types.
 
-**Token budget exceeded:** Load only the relevant domain reference file rather than all
-references. For most queries, one reference file + `optimnow-methodology.md` is sufficient.
+**ChatGPT instructions exceed 8K limit:** the installer warns when the build crosses
+the limit. If it does, manually trim the routing table to only the providers you care
+about, or upload the trimmed routing as a knowledge file and keep instructions minimal.
+
+**ChatGPT only allows 20 knowledge files:** the installer merges `optimnow-methodology.md`
+into `finops-for-ai.md` to fit. If you have other custom knowledge files you want to
+keep, drop one of the references manually instead.
+
+**Token budget exceeded on system-prompt injection:** load only the domain references
+relevant to your query. For most use cases, `SKILL.md` + 1-2 references is enough.
+
+**Path issues on Windows:** the installer is bash-only. Use WSL2 (`wsl.exe`) or Git
+Bash. Native PowerShell is not supported.

--- a/README.md
+++ b/README.md
@@ -271,25 +271,41 @@ domain-specific content is shared.
 
 ## Installation
 
-See **[INSTALLATION.md](./INSTALLATION.md)** for step-by-step setup instructions
-covering Claude Code, Kiro IDE, Claude.ai, and API integration.
+The skill installs into 11 different tools via a single bash installer that converts
+the canonical Claude / Agent-Skills format into each target tool's expected shape.
+See **[INSTALLATION.md](./INSTALLATION.md)** for the full per-tool instructions.
 
-### Quick install: Claude Code plugin
+### One-liner (auto-detect)
 
-For Claude Code users, the skill is also distributed as a self-hosted plugin with
-auto-update support. Two commands:
+```bash
+curl -sL https://raw.githubusercontent.com/OptimNow/cloud-finops-skills/main/install.sh | bash
+```
 
-> **Where to type these:** at the **Claude Code prompt** - the chat input you see after
-> running `claude` in your terminal. They are slash commands, not shell commands. Pasting
-> them into PowerShell, bash, or zsh will fail.
+Auto-detects which tools you have installed (Claude Code, Cursor, Windsurf, Codex, etc.)
+and installs the skill for each, with the right per-tool conversion.
+
+### One specific tool
+
+```bash
+curl -sL https://raw.githubusercontent.com/OptimNow/cloud-finops-skills/main/install.sh | bash -s -- --tool <name>
+```
+
+Supported tools: `claude-code`, `claude-projects`, `cursor`, `windsurf`, `chatgpt`,
+`gemini`, `gemini-cli`, `codex`, `aider`, `copilot`, `kiro`. Run `./install.sh --list`
+to see them all.
+
+### Claude Code plugin (auto-updating alternative)
+
+For Claude Code specifically, the skill is also distributed as a self-hosted plugin
+with built-in update via `/plugin update`. Two commands at the **Claude Code prompt**
+(not your shell):
 
 ```text
 /plugin marketplace add https://github.com/OptimNow/cloud-finops-skills.git
 /plugin install cloud-finops@optimnow
 ```
 
-To pull the latest content (including the bi-monthly automated updates), run this at the
-same Claude Code prompt:
+To pull the latest content (including the bi-monthly automated updates):
 
 ```text
 /plugin update cloud-finops@optimnow
@@ -297,13 +313,18 @@ same Claude Code prompt:
 
 **Note on the URL form:** the explicit HTTPS URL above avoids an SSH-authentication
 prompt that some Claude Code installs hit when given the `OptimNow/cloud-finops-skills`
-shorthand (the shorthand can resolve to `git@github.com:` and require an SSH key
-on file with GitHub). The repository is fully public over HTTPS - no credentials
-needed.
+shorthand. The repository is fully public over HTTPS - no credentials needed.
 
-For Claude Desktop / claude.ai users, the manual zip-upload path stays as documented
-in `INSTALLATION.md` (Option 1). Both distribution channels share the same skill
-content - pick the one that matches how you use Claude.
+### Claude Desktop / claude.ai
+
+For the web / desktop apps, the installer can build a clean upload zip:
+
+```bash
+./install.sh --tool claude-projects
+```
+
+Then upload `dist/claude-projects/cloud-finops.zip` via Settings → Skills → Upload zip.
+The same zip is also attached to every [GitHub release](https://github.com/OptimNow/cloud-finops-skills/releases).
 
 ---
 

--- a/install.sh
+++ b/install.sh
@@ -1,87 +1,605 @@
 #!/usr/bin/env bash
-# Cloud FinOps Skill installer
+#
+# install.sh - Cross-tool installer for the Cloud FinOps Skill.
+#
 # Usage:
-#   curl -sL https://raw.githubusercontent.com/OptimNow/cloud-finops-skills/main/install.sh | bash
-#   curl -sL https://raw.githubusercontent.com/OptimNow/cloud-finops-skills/main/install.sh | bash -s -- --dir ~/my-project
+#   ./install.sh                       Auto-detect tools in cwd / $HOME and install for each
+#   ./install.sh --tool <name>         Install for one specific tool
+#   ./install.sh --tool all            Install for every supported tool
+#   ./install.sh --list                List supported tools
+#   ./install.sh --dry-run             Print what would happen, no writes
+#   ./install.sh --user                Install at user-level paths where supported (Claude Code)
+#   ./install.sh --dest <dir>          Override the project / target directory
+#   ./install.sh --help                Show this help
+#
+# Tools: claude-code, claude-projects, cursor, windsurf, chatgpt, gemini,
+#        gemini-cli, codex, aider, copilot, kiro
+#
+# This script only performs local file copies and writes. No network calls beyond
+# git clone (when run via curl), no sudo, no eval. macOS / Linux / WSL.
+#
+# Source: https://github.com/OptimNow/cloud-finops-skills (CC BY-SA 4.0)
 
 set -euo pipefail
 
-REPO="https://github.com/OptimNow/cloud-finops-skills.git"
-SKILL_FOLDER="cloud-finops"
-TARGET_DIR=""
-
-# Parse arguments
-while [[ $# -gt 0 ]]; do
-  case $1 in
-    --dir)
-      TARGET_DIR="$2"
-      shift 2
-      ;;
-    *)
-      echo "Unknown option: $1"
-      echo "Usage: install.sh [--dir /path/to/target]"
-      exit 1
-      ;;
-  esac
-done
-
-# If no target specified, try to detect a sensible default
-if [[ -z "$TARGET_DIR" ]]; then
-  if [[ -d ".claude" ]]; then
-    # We're inside a Claude Code project
-    TARGET_DIR="."
-  else
-    TARGET_DIR="."
-  fi
-fi
-
-echo ""
-echo "  Cloud FinOps Skill - installer"
-echo "  by OptimNow (https://optimnow.io)"
-echo "  ----------------------------------------"
-echo ""
-
-# Create a temporary directory for cloning
-TMPDIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'finops-skill')
-trap 'rm -rf "$TMPDIR"' EXIT
-
-echo "  Downloading skill from GitHub..."
-git clone --depth 1 --quiet "$REPO" "$TMPDIR/cloud-finops-skills"
-
-# Copy the skill folder to the target
-DEST="$TARGET_DIR/$SKILL_FOLDER"
-
-if [[ -d "$DEST" ]]; then
-  echo "  Existing installation found at $DEST"
-  echo "  Updating..."
-  rm -rf "$DEST"
-fi
-
-cp -r "$TMPDIR/cloud-finops-skills/$SKILL_FOLDER" "$DEST"
-
-# Count installed files
-FILE_COUNT=$(find "$DEST" -name "*.md" | wc -l | tr -d ' ')
-
-echo ""
-echo "  Installed to: $DEST"
-echo "  Files: $FILE_COUNT markdown files"
-echo ""
-
-# Verify
-if [[ -f "$DEST/SKILL.md" ]] && [[ -d "$DEST/references" ]]; then
-  echo "  Verification: OK"
+# ---- colours ----
+if [[ -t 1 && -z "${NO_COLOR:-}" && "${TERM:-}" != "dumb" ]]; then
+  C_GREEN=$'\033[0;32m'; C_YELLOW=$'\033[1;33m'; C_RED=$'\033[0;31m'
+  C_BLUE=$'\033[0;34m'; C_BOLD=$'\033[1m'; C_DIM=$'\033[2m'; C_RESET=$'\033[0m'
 else
-  echo "  Verification: FAILED - missing SKILL.md or references/"
-  exit 1
+  C_GREEN=''; C_YELLOW=''; C_RED=''; C_BLUE=''; C_BOLD=''; C_DIM=''; C_RESET=''
 fi
 
-echo ""
-echo "  Done. The skill is ready to use."
-echo ""
-echo "  If using Claude Code, add this to your project's .claude/settings.json:"
-echo ""
-echo "    { \"skills\": [\"$SKILL_FOLDER\"] }"
-echo ""
-echo "  Then test with:"
-echo "    \"What are the first steps to manage AI inference costs?\""
-echo ""
+ok()    { printf "${C_GREEN}[OK]${C_RESET}  %s\n" "$*"; }
+warn()  { printf "${C_YELLOW}[!!]${C_RESET}  %s\n" "$*"; }
+err()   { printf "${C_RED}[ERR]${C_RESET} %s\n" "$*" >&2; }
+info()  { printf "${C_BLUE}[..]${C_RESET}  %s\n" "$*"; }
+dim()   { printf "${C_DIM}%s${C_RESET}\n" "$*"; }
+
+# ---- constants ----
+REPO_URL="https://github.com/OptimNow/cloud-finops-skills.git"
+SKILL_NAME="cloud-finops"
+ALL_TOOLS=(claude-code claude-projects cursor windsurf chatgpt gemini gemini-cli codex aider copilot kiro)
+
+# ---- state ----
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd || pwd)"
+SRC_DIR=""
+TMPDIR=""
+TOOL=""
+DRY_RUN=""
+USER_LEVEL=""
+DEST_OVERRIDE=""
+
+cleanup() { [[ -n "$TMPDIR" ]] && rm -rf "$TMPDIR" 2>/dev/null || true; }
+trap cleanup EXIT
+
+# ---- helpers ----
+
+usage() {
+  sed -n '3,18p' "$0" | sed 's/^# \?//'
+  exit 0
+}
+
+resolve_source() {
+  if [[ -f "$SCRIPT_DIR/cloud-finops/SKILL.md" ]]; then
+    SRC_DIR="$SCRIPT_DIR"
+  elif [[ -f "$PWD/cloud-finops/SKILL.md" ]]; then
+    SRC_DIR="$PWD"
+  else
+    info "Source not found locally. Cloning repo..."
+    if ! command -v git >/dev/null 2>&1; then
+      err "git not found and no local source. Install git or run from a clone of the repo."
+      exit 1
+    fi
+    TMPDIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'finops-skill')
+    git clone --depth 1 --quiet "$REPO_URL" "$TMPDIR/cloud-finops-skills"
+    SRC_DIR="$TMPDIR/cloud-finops-skills"
+  fi
+}
+
+# Strip the YAML frontmatter (between the first two --- lines) from a markdown file.
+strip_frontmatter() {
+  awk 'BEGIN{f=0} /^---$/{f++; if(f<=2) next} f>=2{print}' "$1"
+}
+
+# Concatenated body: SKILL.md (no frontmatter) + every reference file
+write_concat_body() {
+  strip_frontmatter "$SRC_DIR/cloud-finops/SKILL.md"
+  echo
+  echo "---"
+  echo
+  echo "## Reference files"
+  echo
+  for ref in "$SRC_DIR/cloud-finops/references"/*.md; do
+    echo "### $(basename "$ref" .md)"
+    echo
+    cat "$ref"
+    echo
+    echo "---"
+    echo
+  done
+}
+
+# Idempotent file write with dry-run support
+do_write() {
+  local target="$1"
+  local content_fn="$2"
+  if [[ -n "$DRY_RUN" ]]; then
+    info "DRY-RUN would write: $target"
+    return
+  fi
+  mkdir -p "$(dirname "$target")"
+  $content_fn > "$target"
+}
+
+# Idempotent directory copy with dry-run support
+do_copy_dir() {
+  local src="$1" dest="$2"
+  if [[ -n "$DRY_RUN" ]]; then
+    info "DRY-RUN would copy: $src -> $dest"
+    return
+  fi
+  mkdir -p "$(dirname "$dest")"
+  rm -rf "$dest"
+  cp -r "$src" "$dest"
+}
+
+# ---- detection ----
+
+detect_claude_code()     { [[ -d ".claude" || -d "$HOME/.claude" ]]; }
+detect_claude_projects() { return 1; }   # web-only, never auto-detected
+detect_cursor()          { command -v cursor >/dev/null 2>&1 || [[ -d ".cursor" || -d "$HOME/.cursor" ]]; }
+detect_windsurf()        { command -v windsurf >/dev/null 2>&1 || [[ -d ".windsurf" || -d "$HOME/.codeium" ]]; }
+detect_chatgpt()         { return 1; }   # web-only
+detect_gemini()          { return 1; }   # web-only
+detect_gemini_cli()      { command -v gemini >/dev/null 2>&1 || [[ -d "$HOME/.gemini" ]]; }
+detect_codex()           { command -v codex >/dev/null 2>&1 || [[ -d ".codex" || -d "$HOME/.codex" ]]; }
+detect_aider()           { command -v aider >/dev/null 2>&1 || [[ -f "CONVENTIONS.md" ]]; }
+detect_copilot()         { command -v code >/dev/null 2>&1 || [[ -d ".github" ]]; }
+detect_kiro()            { command -v kiro >/dev/null 2>&1 || [[ -d ".kiro" ]]; }
+
+is_detected() {
+  case "$1" in
+    claude-code)     detect_claude_code ;;
+    claude-projects) detect_claude_projects ;;
+    cursor)          detect_cursor ;;
+    windsurf)        detect_windsurf ;;
+    chatgpt)         detect_chatgpt ;;
+    gemini)          detect_gemini ;;
+    gemini-cli)      detect_gemini_cli ;;
+    codex)           detect_codex ;;
+    aider)           detect_aider ;;
+    copilot)         detect_copilot ;;
+    kiro)            detect_kiro ;;
+    *)               return 1 ;;
+  esac
+}
+
+# ---- per-tool installers ----
+
+install_claude_code() {
+  local target
+  if [[ -n "$DEST_OVERRIDE" ]]; then
+    target="$DEST_OVERRIDE/$SKILL_NAME"
+  elif [[ -n "$USER_LEVEL" ]]; then
+    target="$HOME/.claude/skills/$SKILL_NAME"
+  elif [[ -d ".claude" ]]; then
+    target="$PWD/.claude/skills/$SKILL_NAME"
+  else
+    target="$PWD/$SKILL_NAME"
+  fi
+  do_copy_dir "$SRC_DIR/cloud-finops" "$target"
+  ok "Claude Code: skill copied -> $target"
+  dim "  Restart Claude Code or run /reload-plugins to pick up changes."
+}
+
+install_claude_projects() {
+  local outdir="${DEST_OVERRIDE:-$PWD}/dist/claude-projects"
+  if [[ -n "$DRY_RUN" ]]; then
+    info "DRY-RUN would build: $outdir/cloud-finops.zip"
+    return
+  fi
+  mkdir -p "$outdir"
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - "$SRC_DIR/cloud-finops" "$outdir/cloud-finops.zip" <<'PYEOF'
+import os, sys, zipfile
+src_dir, out_zip = sys.argv[1], sys.argv[2]
+src_root = os.path.dirname(os.path.abspath(src_dir))
+EXCLUDE = {".claude"}
+with zipfile.ZipFile(out_zip, 'w', zipfile.ZIP_DEFLATED) as z:
+    for root, dirs, files in os.walk(src_dir):
+        dirs[:] = [d for d in dirs if d not in EXCLUDE]
+        for f in files:
+            full = os.path.join(root, f)
+            arcname = os.path.relpath(full, src_root).replace(os.sep, '/')
+            z.write(full, arcname)
+PYEOF
+  elif command -v zip >/dev/null 2>&1; then
+    (cd "$SRC_DIR" && zip -r -q "$outdir/cloud-finops.zip" cloud-finops -x 'cloud-finops/.claude/*')
+  else
+    err "Neither python3 nor zip found. Cannot build claude-projects zip."
+    return 1
+  fi
+  ok "Claude Projects: zip built -> $outdir/cloud-finops.zip"
+  dim "  Manual upload: claude.ai or Claude Desktop -> Settings -> Skills -> Upload zip."
+}
+
+install_cursor() {
+  local target="${DEST_OVERRIDE:-$PWD}/.cursor/rules/cloud-finops.mdc"
+  do_write "$target" build_cursor_rule
+  ok "Cursor: rule written -> $target"
+  dim "  Cursor auto-loads .cursor/rules/. Trigger by asking a FinOps question in chat."
+}
+
+build_cursor_rule() {
+  cat <<'EOF'
+---
+description: Expert FinOps guidance for cloud, AI, SaaS, and data-platform spend (multi-provider, model-agnostic). Use for cost questions on AWS, Azure, GCP, Anthropic, Bedrock, Vertex AI, Azure OpenAI, Databricks, Microsoft Fabric, Snowflake, OCI, AI coding tools, GreenOps, FinOps Framework, SaaS asset management, ITAM.
+globs:
+  - "**/*"
+alwaysApply: false
+---
+
+EOF
+  write_concat_body
+}
+
+install_windsurf() {
+  local target="${DEST_OVERRIDE:-$PWD}/.windsurf/rules/cloud-finops.md"
+  do_write "$target" build_windsurf_rule
+  ok "Windsurf: rule written -> $target"
+}
+
+build_windsurf_rule() {
+  cat <<'EOF'
+---
+trigger: model_decision
+description: Expert FinOps guidance for cloud, AI, SaaS, and data-platform spend (multi-provider, model-agnostic).
+---
+
+EOF
+  write_concat_body
+}
+
+install_chatgpt() {
+  local outdir="${DEST_OVERRIDE:-$PWD}/dist/chatgpt"
+  local instructions_path="$outdir/instructions.md"
+  local knowledge_dir="$outdir/knowledge"
+
+  if [[ -n "$DRY_RUN" ]]; then
+    info "DRY-RUN would write: $instructions_path"
+    info "DRY-RUN would write: $knowledge_dir/*.md"
+    return
+  fi
+
+  mkdir -p "$knowledge_dir"
+  build_chatgpt_instructions > "$instructions_path"
+  local size
+  size=$(wc -c < "$instructions_path")
+
+  # Knowledge files: copy each reference, but merge optimnow-methodology into for-ai
+  local methodology="$SRC_DIR/cloud-finops/references/optimnow-methodology.md"
+  for ref in "$SRC_DIR/cloud-finops/references"/*.md; do
+    local name
+    name=$(basename "$ref")
+    if [[ "$name" == "optimnow-methodology.md" ]]; then
+      continue
+    fi
+    if [[ "$name" == "finops-for-ai.md" ]]; then
+      {
+        cat "$ref"
+        echo
+        echo "---"
+        echo
+        echo "## Reasoning Methodology Appendix"
+        echo
+        [[ -f "$methodology" ]] && cat "$methodology"
+      } > "$knowledge_dir/$name"
+    else
+      cp "$ref" "$knowledge_dir/$name"
+    fi
+  done
+
+  local file_count
+  file_count=$(find "$knowledge_dir" -maxdepth 1 -name "*.md" | wc -l | tr -d ' ')
+
+  ok "ChatGPT: instructions ($size chars) -> $instructions_path"
+  ok "ChatGPT: $file_count knowledge files -> $knowledge_dir/"
+  if [[ $size -gt 8000 ]]; then
+    warn "Instructions exceed ChatGPT's ~8000 char limit ($size chars). Manual trim needed."
+  fi
+  dim "  Manual upload steps:"
+  dim "    1. Open https://chatgpt.com/gpts/editor"
+  dim "    2. Paste $instructions_path into the Instructions field"
+  dim "    3. Upload all files from $knowledge_dir/ to Knowledge"
+  dim "    4. Note: methodology is merged into finops-for-ai.md to fit ChatGPT's 20-file cap"
+}
+
+build_chatgpt_instructions() {
+  cat <<'EOF'
+# Cloud FinOps Expert Assistant
+
+You are an expert FinOps practitioner. Help users understand and optimise spend on cloud (AWS / Azure / GCP / OCI), AI platforms (Anthropic, Bedrock, Azure OpenAI / Foundry, Vertex AI), data platforms (Databricks, Microsoft Fabric, Snowflake), AI coding tools (Cursor, Claude Code, Copilot, Codex, Windsurf, Gemini Code Assist), SaaS, and cross-cutting concerns (tagging, FinOps Framework, GreenOps, ITAM).
+
+Your knowledge files contain accurate, current billing mechanics and optimisation patterns refreshed bi-monthly. Always retrieve relevant knowledge files before answering - do not rely on general training data for billing specifics.
+
+## Domain routing
+
+Use these knowledge files for the following query types:
+
+| Query topic | Knowledge file |
+|---|---|
+| AWS cost management, EC2, RIs, Savings Plans, EDP, RDS | finops-aws.md |
+| AWS Bedrock model pricing, Application Inference Profiles, prompt caching | finops-bedrock.md |
+| Azure cost management, Reservations, Savings Plans, AHB, MACC, AKS, MCA | finops-azure.md |
+| Azure OpenAI / Foundry PTU reservations, locality | finops-azure-openai.md |
+| Anthropic Claude billing, Fast mode, prompt caching, long-context | finops-anthropic.md |
+| GCP cost management, BigQuery export, CUDs, SUDs, Spot, Carbon Footprint | finops-gcp.md |
+| Vertex AI pricing, Provisioned Throughput, Context Caching | finops-vertexai.md |
+| AI cost management, LLM economics, agentic patterns, ROI, methodology lens | finops-for-ai.md |
+| AI investment governance, Investment Council, stage gates | finops-ai-value-management.md |
+| GenAI capacity planning, provisioned vs shared, spillover | finops-genai-capacity.md |
+| AI coding tools (Cursor, Copilot, Claude Code, Codex, Windsurf, Gemini Code Assist) | finops-ai-dev-tools.md |
+| Databricks (system.billing.usage, DBCU, allocation, Photon) | finops-databricks.md |
+| Microsoft Fabric (F-SKUs, CU smoothing, pause/resume, governance trap) | finops-fabric.md |
+| Snowflake (QUERY_ATTRIBUTION_HISTORY, Budgets, Cortex, resource monitors) | finops-snowflake.md |
+| OCI (Cost Reports, FOCUS, cost-tracking tags, Universal Credits) | finops-oci.md |
+| FinOps Framework (4 domains 2024 + Executive Strategy Alignment 2026) | finops-framework.md |
+| Tagging strategy, naming conventions, IaC enforcement | finops-tagging.md |
+| SaaS management, license optimisation, shadow IT | finops-sam.md |
+| ITAM, BYOL, marketplace governance | finops-itam.md |
+| GreenOps, cloud carbon, sustainability | greenops-cloud-carbon.md |
+
+For multi-domain queries, retrieve all relevant files and synthesise.
+
+## Reasoning sequence
+
+1. Apply the methodology lens (see Reasoning Methodology Appendix in finops-for-ai.md): diagnose before prescribing, connect cost to value, recommend progressively.
+2. Retrieve the domain knowledge file(s) matching the query.
+3. Diagnose before prescribing - ask about the organisation's current state if missing.
+4. Connect cost recommendations to business outcomes.
+5. Recommend progressively - quick wins first, structural changes second.
+6. Reference open-source FinOps tools (FinOps Toolkit, OpenCost, Kubecost, Infracost, etc.) where they fit.
+
+## Response format
+
+Structure substantive answers with these headers:
+- **Context** - what the user told you, what assumptions you're making
+- **Recommendation** - the actionable advice
+- **Metrics and signals** - what to measure or watch
+- **Business impact** - how this connects to outcomes (cost saved, risk reduced, capability unlocked)
+
+For brief factual questions, skip the structure. Use it for advisory or strategy questions.
+
+## Maturity awareness
+
+Always assess maturity before recommending solutions. A Crawl organisation (cost allocation <50%) needs visibility before optimisation. Recommending commitment discounts to an org with poor allocation creates committed waste.
+
+## Source
+
+Cloud FinOps Skill by OptimNow (https://optimnow.io). Licensed CC BY-SA 4.0.
+Source: https://github.com/OptimNow/cloud-finops-skills
+EOF
+}
+
+install_gemini() {
+  local outdir="${DEST_OVERRIDE:-$PWD}/dist/gemini"
+  local instructions_path="$outdir/instructions.md"
+  local knowledge_dir="$outdir/knowledge"
+
+  if [[ -n "$DRY_RUN" ]]; then
+    info "DRY-RUN would write: $instructions_path"
+    info "DRY-RUN would write: $knowledge_dir/*.md"
+    return
+  fi
+
+  mkdir -p "$knowledge_dir"
+  # Same instructions content as ChatGPT - same cross-LLM contract
+  build_chatgpt_instructions > "$instructions_path"
+  build_gemini_grouped_knowledge "$knowledge_dir"
+
+  local file_count
+  file_count=$(find "$knowledge_dir" -maxdepth 1 -name "*.md" | wc -l | tr -d ' ')
+  ok "Gemini Gems: instructions -> $instructions_path"
+  ok "Gemini Gems: $file_count grouped knowledge files -> $knowledge_dir/"
+  dim "  Manual upload: https://gemini.google.com/gems/ - paste instructions, upload knowledge files."
+  dim "  Note: references are grouped by domain to fit Gemini's tighter file cap."
+}
+
+build_gemini_grouped_knowledge() {
+  local outdir="$1"
+  local refs="$SRC_DIR/cloud-finops/references"
+  cat "$refs/finops-aws.md" "$refs/finops-bedrock.md" 2>/dev/null > "$outdir/aws.md"
+  cat "$refs/finops-azure.md" "$refs/finops-azure-openai.md" 2>/dev/null > "$outdir/azure.md"
+  cat "$refs/finops-gcp.md" "$refs/finops-vertexai.md" 2>/dev/null > "$outdir/gcp.md"
+  cat "$refs/finops-for-ai.md" "$refs/finops-anthropic.md" "$refs/finops-ai-dev-tools.md" \
+      "$refs/finops-genai-capacity.md" "$refs/finops-ai-value-management.md" \
+      ${refs}/finops-ai-self-hosted-vs-managed.md 2>/dev/null > "$outdir/ai.md"
+  cat "$refs/finops-databricks.md" "$refs/finops-fabric.md" "$refs/finops-snowflake.md" 2>/dev/null > "$outdir/data-platforms.md"
+  [[ -f "$refs/finops-oci.md" ]] && cp "$refs/finops-oci.md" "$outdir/oci.md"
+  cat "$refs/finops-framework.md" "$refs/finops-tagging.md" "$refs/finops-sam.md" \
+      "$refs/finops-itam.md" "$refs/greenops-cloud-carbon.md" 2>/dev/null > "$outdir/cross-cutting.md"
+  [[ -f "$refs/optimnow-methodology.md" ]] && cp "$refs/optimnow-methodology.md" "$outdir/methodology.md"
+}
+
+install_gemini_cli() {
+  local target
+  if [[ -n "$DEST_OVERRIDE" ]]; then
+    target="$DEST_OVERRIDE/$SKILL_NAME"
+  else
+    target="$HOME/.gemini/skills/$SKILL_NAME"
+  fi
+  do_copy_dir "$SRC_DIR/cloud-finops" "$target"
+  ok "Gemini CLI: skill copied -> $target"
+}
+
+install_codex() {
+  local default_target="${DEST_OVERRIDE:-$PWD}/AGENTS.md"
+  local target="$default_target"
+  if [[ -f "$target" && -z "$DRY_RUN" ]]; then
+    warn "Codex: $target already exists. Writing to AGENTS-cloud-finops.md instead."
+    target="${DEST_OVERRIDE:-$PWD}/AGENTS-cloud-finops.md"
+  fi
+  do_write "$target" build_codex_agents_md
+  ok "Codex CLI: agent context written -> $target"
+  dim "  Codex reads AGENTS.md from project root. If AGENTS-cloud-finops.md was used,"
+  dim "  manually merge into your existing AGENTS.md (or rename when ready)."
+  dim "  An MCP server (planned) will be the cleaner cross-agent path - this is the"
+  dim "  interim option until then."
+}
+
+build_codex_agents_md() {
+  cat <<'EOF'
+# Cloud FinOps Skill - Codex CLI context
+
+This file injects Cloud FinOps expertise into your Codex CLI session. Source:
+https://github.com/OptimNow/cloud-finops-skills
+
+EOF
+  write_concat_body
+}
+
+install_aider() {
+  local default_target="${DEST_OVERRIDE:-$PWD}/CONVENTIONS.md"
+  local target="$default_target"
+  if [[ -f "$target" && -z "$DRY_RUN" ]]; then
+    warn "Aider: $target already exists. Writing to CONVENTIONS-cloud-finops.md instead."
+    target="${DEST_OVERRIDE:-$PWD}/CONVENTIONS-cloud-finops.md"
+  fi
+  do_write "$target" build_aider_conventions
+  ok "Aider: conventions written -> $target"
+  dim "  Aider auto-reads CONVENTIONS.md. For more references, add via --read flags:"
+  dim "    aider --read cloud-finops/references/finops-bedrock.md ..."
+}
+
+build_aider_conventions() {
+  cat <<'EOF'
+# Cloud FinOps Conventions
+
+When asked about cloud cost, AI cost, SaaS cost, commitment strategy, rightsizing,
+tagging, or FinOps practice questions, apply the guidance below. Default coverage
+is the four most general areas (AWS, Azure, GCP, AI). For richer coverage on
+Bedrock, Vertex AI, Databricks, Microsoft Fabric, Snowflake, OCI, etc., add the
+specific references via `aider --read cloud-finops/references/<file>.md`.
+
+EOF
+  strip_frontmatter "$SRC_DIR/cloud-finops/SKILL.md"
+  for ref in finops-aws.md finops-azure.md finops-gcp.md finops-for-ai.md; do
+    if [[ -f "$SRC_DIR/cloud-finops/references/$ref" ]]; then
+      echo
+      echo "---"
+      echo
+      echo "## Reference: $ref"
+      echo
+      cat "$SRC_DIR/cloud-finops/references/$ref"
+    fi
+  done
+}
+
+install_copilot() {
+  local target="${DEST_OVERRIDE:-$PWD}/.github/copilot-instructions.md"
+  do_write "$target" build_copilot_instructions
+  ok "Copilot: instructions written -> $target"
+  warn "Copilot fit is limited - the instruction surface is shallow. The skill informs"
+  warn "  code-suggestion context but won't power deep FinOps Q&A like Claude / Cursor do."
+}
+
+build_copilot_instructions() {
+  cat <<'EOF'
+# Cloud FinOps - Copilot Custom Instructions
+
+When suggesting code or answering questions involving cloud cost, AI inference cost,
+commitment strategy (Reserved Instances, Savings Plans, CUDs), rightsizing, tagging,
+or FinOps practices, apply the guidance below.
+
+EOF
+  strip_frontmatter "$SRC_DIR/cloud-finops/SKILL.md"
+  echo
+  echo "## Available reference files (for deeper context, see source repo)"
+  echo
+  for ref in "$SRC_DIR/cloud-finops/references"/*.md; do
+    local fname
+    fname=$(basename "$ref")
+    local desc
+    desc=$(awk '/^>/{sub(/^> ?/,""); print; exit}' "$ref" | head -c 180)
+    echo "- \`$fname\` - $desc"
+  done
+  echo
+  echo "Source: https://github.com/OptimNow/cloud-finops-skills"
+}
+
+install_kiro() {
+  local target="${DEST_OVERRIDE:-$PWD}/.kiro/powers/$SKILL_NAME"
+  do_copy_dir "$SRC_DIR/cloud-finops" "$target"
+  ok "Kiro IDE: power copied -> $target"
+  dim "  Kiro reads POWER.md as the entry point."
+}
+
+install_tool() {
+  case "$1" in
+    claude-code)     install_claude_code ;;
+    claude-projects) install_claude_projects ;;
+    cursor)          install_cursor ;;
+    windsurf)        install_windsurf ;;
+    chatgpt)         install_chatgpt ;;
+    gemini)          install_gemini ;;
+    gemini-cli)      install_gemini_cli ;;
+    codex)           install_codex ;;
+    aider)           install_aider ;;
+    copilot)         install_copilot ;;
+    kiro)            install_kiro ;;
+    *)               err "Unknown tool: $1"; return 1 ;;
+  esac
+}
+
+list_tools() {
+  echo "Supported tools:"
+  for t in "${ALL_TOOLS[@]}"; do
+    echo "  - $t"
+  done
+}
+
+main() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --tool)     TOOL="${2:?--tool requires a value}"; shift 2 ;;
+      --dry-run)  DRY_RUN=1; shift ;;
+      --user)     USER_LEVEL=1; shift ;;
+      --dest)     DEST_OVERRIDE="${2:?--dest requires a value}"; shift 2 ;;
+      --dir)      DEST_OVERRIDE="${2:?--dir requires a value}"; shift 2 ;;  # legacy alias
+      --list)     list_tools; exit 0 ;;
+      --help|-h)  usage ;;
+      *)          err "Unknown option: $1"; echo; usage ;;
+    esac
+  done
+
+  resolve_source
+
+  printf "\n${C_BOLD}Cloud FinOps Skill - cross-tool installer${C_RESET}\n"
+  dim "  Source: $SRC_DIR/cloud-finops/"
+  printf "\n"
+
+  local selected=()
+  if [[ -n "$TOOL" && "$TOOL" != "all" ]]; then
+    local valid=false t
+    for t in "${ALL_TOOLS[@]}"; do
+      [[ "$t" == "$TOOL" ]] && valid=true && break
+    done
+    if ! $valid; then
+      err "Unknown tool: $TOOL"
+      list_tools
+      exit 1
+    fi
+    selected=("$TOOL")
+  elif [[ "$TOOL" == "all" ]]; then
+    selected=("${ALL_TOOLS[@]}")
+  else
+    local t
+    for t in "${ALL_TOOLS[@]}"; do
+      if is_detected "$t" 2>/dev/null; then
+        selected+=("$t")
+        printf "  ${C_GREEN}[*]${C_RESET} %s detected\n" "$t"
+      else
+        printf "  ${C_DIM}[ ] %s not detected${C_RESET}\n" "$t"
+      fi
+    done
+    if [[ ${#selected[@]} -eq 0 ]]; then
+      printf "\n"
+      warn "No tools auto-detected. Use --tool <name> or --tool all."
+      dim "  Run --list to see supported tools."
+      exit 0
+    fi
+    printf "\n"
+  fi
+
+  local t
+  for t in "${selected[@]}"; do
+    install_tool "$t"
+  done
+
+  printf "\n"
+  ok "Done. Installed for: ${selected[*]}"
+  dim "  Source: https://github.com/OptimNow/cloud-finops-skills (CC BY-SA 4.0)"
+}
+
+main "$@"


### PR DESCRIPTION
Replaces the existing single-purpose `install.sh` with a multi-tool dispatcher that converts the canonical Claude / Agent-Skills format on the fly into each target tool's expected shape.

## Supported tools (11)

`claude-code`, `claude-projects`, `cursor`, `windsurf`, `chatgpt`, `gemini`, `gemini-cli`, `codex`, `aider`, `copilot`, `kiro`

## CLI

```bash
./install.sh                    # auto-detect tools in cwd / $HOME
./install.sh --tool <name>      # install for one tool
./install.sh --tool all         # install for every tool
./install.sh --list             # list supported tools
./install.sh --dry-run          # print what would happen
./install.sh --user             # install at $HOME paths where supported
./install.sh --dest <dir>       # override the project / target directory
```

## Per-tool conversions

- **Cursor / Windsurf**: single `.mdc` / `.md` rule with rewritten frontmatter, full skill body concatenated
- **ChatGPT Custom GPT**: `dist/chatgpt/{instructions.md (target ~8K), knowledge/*.md}` with `optimnow-methodology.md` merged into `finops-for-ai.md` to fit the 20-file Knowledge cap. Trade-off explicit in installer output.
- **Gemini Gems**: `dist/gemini/` with references grouped by domain to fit Gemini's tighter file cap
- **Codex CLI**: `AGENTS.md` (or `AGENTS-cloud-finops.md` if `AGENTS.md` exists, to avoid clobbering)
- **Aider**: `CONVENTIONS.md` with 4 default references (aws/azure/gcp/for-ai); `--read` for more
- **Copilot**: `.github/copilot-instructions.md` with explicit limited-fit warning printed by the installer
- **Claude Projects**: builds the upload zip via `python3` or `zip` CLI

## Docs updated

- `INSTALLATION.md` rewritten with one copy-pasteable block per tool
- `README.md` install section leads with the unified installer; the Claude Code plugin path stays as the auto-updating alternative

## Properties

- Idempotent (re-run safe)
- Dry-run flag
- No network beyond optional `git clone` (when run via curl)
- macOS / Linux / WSL
- No `sudo`, no `eval`, no third-party deps beyond `bash 4+`, `git`, `cp`, `sed`, `awk` (and `python3` or `zip` for the Claude Projects zip)

## Verification

- `bash -n install.sh` parses cleanly
- `./install.sh --list` prints the 11 tools
- `./install.sh --help` prints usage
- `./install.sh --dry-run --tool cursor` previews `.cursor/rules/cloud-finops.mdc`
- `./install.sh --dry-run --tool chatgpt` previews `dist/chatgpt/instructions.md` + `dist/chatgpt/knowledge/*.md`

Tag v1.12 after merge.