### PR TITLE
Add finops-chargeback reference - allocation methodology + Finance/accounting prerequisites

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "cloud-finops",
-      "description": "Expert FinOps guidance for cloud, AI, SaaS, and data-platform spend. 23 reference files spanning AWS, Azure, GCP, Anthropic, Bedrock, Azure OpenAI, Vertex AI, Databricks, Microsoft Fabric, Snowflake, OCI, AI coding tools, FinOps Framework 2024+2026, GreenOps (AWS Sustainability Console, CSRD engagement framing), self-hosted vs managed AI inference decisioning, anomaly management, SaaS asset management, and ITAM. Open source, model-agnostic, refreshed bi-monthly.",
+      "description": "Expert FinOps guidance for cloud, AI, SaaS, and data-platform spend. 24 reference files spanning AWS, Azure, GCP, Anthropic, Bedrock, Azure OpenAI, Vertex AI, Databricks, Microsoft Fabric, Snowflake, OCI, AI coding tools, FinOps Framework 2024+2026, GreenOps (AWS Sustainability Console, CSRD engagement framing), self-hosted vs managed AI inference decisioning, anomaly management, chargeback and showback, SaaS asset management, and ITAM. Open source, model-agnostic, refreshed bi-monthly.",
       "author": {
         "name": "OptimNow",
         "url": "https://optimnow.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloud-finops",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "Expert FinOps guidance for cloud, AI, SaaS, and data-platform spend (multi-provider, model-agnostic).",
   "author": {
     "name": "OptimNow",

--- a/README.md
+++ b/README.md
@@ -103,6 +103,13 @@ The skill provides accurate, framework-aligned guidance across the following dom
   philosophy (absolute dollars plus percentage), layered detection across service,
   region, account, and tag scopes, the masked-anomaly failure mode, new-region
   detection, integration with Security
+- **Chargeback and showback** - four-tier maturity ladder (no visibility to
+  showback to soft chargeback to hard chargeback), `EffectiveCost`-based
+  allocation methodology, `InvoiceId` reconciliation, defensible allocation
+  keys, shared-services hard cases (network, observability, security, ingress),
+  monthly with quarterly true-up cadence, dispute process design, and the
+  chargeback-revolt anti-pattern that costs organisations 12-18 months of
+  credibility when skipped
 
 All guidance is framed through OptimNow's methodology: connecting cost to business value,
 diagnosing before prescribing, and recommending actions matched to organisational maturity.
@@ -266,7 +273,8 @@ cloud-finops-skills/
         ├── finops-sam.md                       ← SaaS asset management (SAM)
         ├── finops-itam.md                     ← ITAM collaboration (BYOL, marketplace, entitlements)
         ├── greenops-cloud-carbon.md            ← GreenOps and cloud carbon
-        └── finops-anomaly-management.md        ← Anomaly management (standalone Inform-phase capability)
+        ├── finops-anomaly-management.md        ← Anomaly management (standalone Inform-phase capability)
+        └── finops-chargeback.md                ← Chargeback and showback maturity ladder
 ```
 
 The `SKILL.md` file is the entry point for Claude Code and generic agents. `POWER.md` is

--- a/README.md
+++ b/README.md
@@ -105,11 +105,14 @@ The skill provides accurate, framework-aligned guidance across the following dom
   detection, integration with Security
 - **Chargeback and showback** - four-tier maturity ladder (no visibility to
   showback to soft chargeback to hard chargeback), `EffectiveCost`-based
-  allocation methodology, `InvoiceId` reconciliation, defensible allocation
-  keys, shared-services hard cases (network, observability, security, ingress),
-  monthly with quarterly true-up cadence, dispute process design, and the
-  chargeback-revolt anti-pattern that costs organisations 12-18 months of
-  credibility when skipped
+  allocation methodology with explicit AWS legacy column mapping (amortised /
+  unblended / blended-trap warning), `InvoiceId` reconciliation, defensible
+  allocation keys, shared-services hard cases (network, observability, security,
+  ingress), and the Finance and accounting prerequisites that determine whether
+  hard chargeback is operationally possible at all (ERP readiness, inter-BU
+  P&L impact and incentive alignment, transfer pricing for intercompany
+  recharges, cross-border tax mechanics including VAT, Pillar 2 minimum tax,
+  GILTI, and SOX-equivalent controls)
 
 All guidance is framed through OptimNow's methodology: connecting cost to business value,
 diagnosing before prescribing, and recommending actions matched to organisational maturity.

--- a/cloud-finops/POWER.md
+++ b/cloud-finops/POWER.md
@@ -106,9 +106,17 @@ keywords:
   - hard chargeback
   - allocation methodology
   - effectivecost
+  - amortised vs unblended
   - invoiceid reconciliation
   - shared services allocation
   - chargeback dispute process
+  - erp readiness
+  - inter-bu p&l
+  - transfer pricing
+  - intercompany cloud recharge
+  - cross-border tax
+  - pillar 2 minimum tax
+  - sox chargeback controls
 ---
 
 # Cloud FinOps - Expert Guidance
@@ -160,7 +168,7 @@ matching the query.
 | SaaS management, licence optimisation, shadow IT, SaaS sprawl, renewal governance, SMP, SAM | `references/finops-sam.md` |
 | ITAM, IT asset management, BYOL, marketplace channel governance, licence compliance, vendor negotiation, FinOps-ITAM collaboration, entitlement management, consumption-based SaaS overages | `references/finops-itam.md` |
 | Cost anomaly management, anomaly detection, masked anomalies, layered detection, threshold tuning, AWS Cost Anomaly Detection config, Azure anomaly detection, GCP budget anomaly alerts, new-region detection, security integration | `references/finops-anomaly-management.md` |
-| Chargeback, showback, soft chargeback, hard chargeback, allocation methodology, EffectiveCost vs BilledCost, InvoiceId reconciliation, defensible allocation keys, shared-services allocation (network, observability, ingress), chargeback maturity, dispute process, financial accountability | `references/finops-chargeback.md` |
+| Chargeback, showback, soft chargeback, hard chargeback, allocation methodology, EffectiveCost vs BilledCost (FOCUS), amortised vs unblended (AWS legacy), InvoiceId reconciliation, defensible allocation keys, shared-services allocation (network, observability, ingress), Finance and accounting prerequisites, ERP readiness, inter-BU P&L impact, transfer pricing, cross-border tax (VAT, Pillar 2, GILTI), SOX controls, chargeback maturity, dispute process | `references/finops-chargeback.md` |
 | Multi-domain query | Load all relevant references, synthesise |
 
 ### Reasoning sequence (apply to every response)

--- a/cloud-finops/POWER.md
+++ b/cloud-finops/POWER.md
@@ -101,6 +101,14 @@ keywords:
   - layered detection
   - threshold tuning
   - new-region detection
+  - chargeback maturity
+  - soft chargeback
+  - hard chargeback
+  - allocation methodology
+  - effectivecost
+  - invoiceid reconciliation
+  - shared services allocation
+  - chargeback dispute process
 ---
 
 # Cloud FinOps - Expert Guidance
@@ -152,6 +160,7 @@ matching the query.
 | SaaS management, licence optimisation, shadow IT, SaaS sprawl, renewal governance, SMP, SAM | `references/finops-sam.md` |
 | ITAM, IT asset management, BYOL, marketplace channel governance, licence compliance, vendor negotiation, FinOps-ITAM collaboration, entitlement management, consumption-based SaaS overages | `references/finops-itam.md` |
 | Cost anomaly management, anomaly detection, masked anomalies, layered detection, threshold tuning, AWS Cost Anomaly Detection config, Azure anomaly detection, GCP budget anomaly alerts, new-region detection, security integration | `references/finops-anomaly-management.md` |
+| Chargeback, showback, soft chargeback, hard chargeback, allocation methodology, EffectiveCost vs BilledCost, InvoiceId reconciliation, defensible allocation keys, shared-services allocation (network, observability, ingress), chargeback maturity, dispute process, financial accountability | `references/finops-chargeback.md` |
 | Multi-domain query | Load all relevant references, synthesise |
 
 ### Reasoning sequence (apply to every response)

--- a/cloud-finops/SKILL.md
+++ b/cloud-finops/SKILL.md
@@ -54,6 +54,7 @@ matching the query.
 | SaaS management, licence optimisation, shadow IT, SaaS sprawl, renewal governance, SMP, SAM | `references/finops-sam.md` |
 | ITAM, IT asset management, BYOL, marketplace channel governance, licence compliance, vendor negotiation, FinOps-ITAM collaboration, entitlement management, consumption-based SaaS overages | `references/finops-itam.md` |
 | Cost anomaly management, anomaly detection, masked anomalies, layered detection, threshold tuning, AWS Cost Anomaly Detection config, Azure anomaly detection, GCP budget anomaly alerts, new-region detection, security integration | `references/finops-anomaly-management.md` |
+| Chargeback, showback, soft chargeback, hard chargeback, allocation methodology, EffectiveCost vs BilledCost, InvoiceId reconciliation, defensible allocation keys, shared-services allocation (network, observability, ingress), chargeback maturity, dispute process, financial accountability | `references/finops-chargeback.md` |
 | Multi-domain query | Load all relevant references, synthesize |
 
 ### Reasoning sequence (apply to every response)
@@ -146,7 +147,8 @@ premature - they risk committing to waste.
 | `finops-sam.md` | SaaS asset management: discovery, licence optimisation, renewal governance, SMPs, shadow IT, AI transition | ~210 |
 | `finops-itam.md` | FinOps-ITAM collaboration: BYOL mechanics, marketplace channel governance, vendor co-management, consumption monitoring, joint operating model | ~320 |
 | `greenops-cloud-carbon.md` | GreenOps: carbon measurement, carbon-aware workloads, region selection, GHG Protocol | ~330 |
-| `finops-anomaly-management.md` | Cost anomaly management as a standalone Inform-phase capability: native tooling per cloud (AWS Cost Anomaly Detection, Azure Cost Management, GCP Budgets), threshold philosophy (absolute dollars + percentage), layered detection across service / region / account / tag, the masked-anomaly failure mode, new-region detection, Security integration, Crawl/Walk/Run progression | ~270 |
+| `finops-anomaly-management.md` | Cost anomaly management as a standalone Inform-phase capability: native tooling per cloud (AWS Cost Anomaly Detection, Azure Cost Management, GCP Budgets), threshold philosophy (absolute dollars + percentage), layered detection across service / region / account / tag, the masked-anomaly failure mode, new-region detection, Security integration, Crawl/Walk/Run progression | ~325 |
+| `finops-chargeback.md` | Chargeback and showback operational treatment: four-tier maturity ladder (no visibility / showback / soft chargeback / hard chargeback), EffectiveCost-based allocation methodology, InvoiceId reconciliation, defensible allocation keys, shared-services hard cases (network, observability, security, ingress), monthly + quarterly true-up cadence, dispute process, the chargeback-revolt anti-pattern | ~310 |
 
 ---
 

--- a/cloud-finops/SKILL.md
+++ b/cloud-finops/SKILL.md
@@ -54,7 +54,7 @@ matching the query.
 | SaaS management, licence optimisation, shadow IT, SaaS sprawl, renewal governance, SMP, SAM | `references/finops-sam.md` |
 | ITAM, IT asset management, BYOL, marketplace channel governance, licence compliance, vendor negotiation, FinOps-ITAM collaboration, entitlement management, consumption-based SaaS overages | `references/finops-itam.md` |
 | Cost anomaly management, anomaly detection, masked anomalies, layered detection, threshold tuning, AWS Cost Anomaly Detection config, Azure anomaly detection, GCP budget anomaly alerts, new-region detection, security integration | `references/finops-anomaly-management.md` |
-| Chargeback, showback, soft chargeback, hard chargeback, allocation methodology, EffectiveCost vs BilledCost, InvoiceId reconciliation, defensible allocation keys, shared-services allocation (network, observability, ingress), chargeback maturity, dispute process, financial accountability | `references/finops-chargeback.md` |
+| Chargeback, showback, soft chargeback, hard chargeback, allocation methodology, EffectiveCost vs BilledCost (FOCUS), amortised vs unblended (AWS legacy), InvoiceId reconciliation, defensible allocation keys, shared-services allocation (network, observability, ingress), Finance and accounting prerequisites, ERP readiness, inter-BU P&L impact, transfer pricing, cross-border tax (VAT, Pillar 2, GILTI), SOX controls, chargeback maturity, dispute process | `references/finops-chargeback.md` |
 | Multi-domain query | Load all relevant references, synthesize |
 
 ### Reasoning sequence (apply to every response)
@@ -148,7 +148,7 @@ premature - they risk committing to waste.
 | `finops-itam.md` | FinOps-ITAM collaboration: BYOL mechanics, marketplace channel governance, vendor co-management, consumption monitoring, joint operating model | ~320 |
 | `greenops-cloud-carbon.md` | GreenOps: carbon measurement, carbon-aware workloads, region selection, GHG Protocol | ~330 |
 | `finops-anomaly-management.md` | Cost anomaly management as a standalone Inform-phase capability: native tooling per cloud (AWS Cost Anomaly Detection, Azure Cost Management, GCP Budgets), threshold philosophy (absolute dollars + percentage), layered detection across service / region / account / tag, the masked-anomaly failure mode, new-region detection, Security integration, Crawl/Walk/Run progression | ~325 |
-| `finops-chargeback.md` | Chargeback and showback operational treatment: four-tier maturity ladder (no visibility / showback / soft chargeback / hard chargeback), EffectiveCost-based allocation methodology, InvoiceId reconciliation, defensible allocation keys, shared-services hard cases (network, observability, security, ingress), monthly + quarterly true-up cadence, dispute process, the chargeback-revolt anti-pattern | ~310 |
+| `finops-chargeback.md` | Chargeback and showback operational treatment: four-tier maturity ladder (no visibility / showback / soft chargeback / hard chargeback), EffectiveCost-based allocation with AWS legacy column mapping (amortised / unblended / blended-trap warning), InvoiceId reconciliation, defensible allocation keys, shared-services hard cases (network, observability, security, ingress), Finance and accounting prerequisites for hard chargeback (ERP readiness, inter-BU P&L impact, transfer pricing, cross-border tax incl. Pillar 2 and GILTI, SOX controls), monthly + quarterly true-up cadence, dispute process | ~480 |
 
 ---
 

--- a/cloud-finops/references/finops-chargeback.md
+++ b/cloud-finops/references/finops-chargeback.md
@@ -75,12 +75,31 @@ capacity in March should be allocated 10% of the cluster's cost for March,
 even if the cluster runs on a Reservation that was paid in full in January.
 
 - **`EffectiveCost`** spreads prepaid commitment costs across the periods of
-  consumption. Use it for showback, chargeback, trend analysis, and team
-  attribution.
-- **`BilledCost`** ties to the invoice. Use it for invoice reconciliation
-  against `InvoiceId`. Do not use it for chargeback - it would attribute a
-  $1M annual prepay entirely to whoever consumed the first kilowatt-hour after
-  the purchase.
+  consumption. This is the **amortised** view. Use it for showback, chargeback,
+  trend analysis, and team attribution.
+- **`BilledCost`** ties to the invoice (cash-basis). Use it for invoice
+  reconciliation against `InvoiceId`. Do not use it for chargeback - it would
+  attribute a $1M annual prepay entirely to whoever consumed the first
+  kilowatt-hour after the purchase.
+
+**Mapping to AWS legacy cost columns** (the most common point of confusion):
+
+| FOCUS column | What it is | AWS legacy analogue |
+|---|---|---|
+| `EffectiveCost` | All discounts applied, prepaid commitments amortised across the consumption period | `line_item_amortized_cost` (CUR), Cost Explorer "Amortized" view |
+| `BilledCost` | Cash-basis invoice view; Reservation purchases land as a Purchase row in their billing month | `line_item_unblended_cost` (CUR), Cost Explorer "Unblended" view |
+| `ListCost` | List rate × Pricing Quantity, no discounts | (no direct CUR column - compute as `pricing_public_on_demand_cost`) |
+| `ContractedCost` | Negotiated rate × Pricing Quantity, before commitment discounts | (no direct CUR column - compute from EDP / private pricing rate sheet) |
+
+**Avoid `blended_cost` (AWS) entirely for chargeback.** Blended cost is a
+payer-account averaging artefact: it averages Reservation-discounted rates
+across all linked accounts that consumed the same instance type, regardless
+of which account actually owns the Reservation. FOCUS deliberately has no
+equivalent column because the concept is misleading - it does not reflect
+either invoice reality (use `BilledCost`) or true accrual attribution
+(use `EffectiveCost`). Teams that build chargeback on `blended_cost`
+discover the error the first time a controller asks "why does our
+Reservation appear to discount another team's spend?"
 
 If your billing pipeline only exposes one cost column, configure it to surface
 the amortised view (Azure: amortized cost export; AWS: Cost Explorer amortised
@@ -192,6 +211,167 @@ Allocate by request count if the gateway has per-route or per-client
 attribution. If it does not, configure that attribution before chargeback
 moves past showback. An ingress allocation that cannot survive a "where did
 this number come from?" question will be the first chargeback dispute.
+
+---
+
+## Finance and accounting prerequisites for hard chargeback
+
+Allocation methodology is the FinOps half of chargeback. The Finance, Controller,
+and Tax half determines whether hard chargeback is operationally possible at all.
+A FinOps team that designs an elegant allocation model and hands it to Finance
+only to discover the ERP cannot post the journals has burned six to nine months.
+Surface these questions early - ideally before showback hits month four - so the
+hard-chargeback go-live date is set against real operational constraints rather
+than aspiration.
+
+### Accounting system readiness
+
+Hard chargeback is an accounting transaction. The receiving cost centre's P&L
+takes a charge; the source cost centre's P&L sees the offsetting credit. The
+ERP has to support this:
+
+- **Chart of accounts** - is there an account code for cloud-cost recharges?
+  Some organisations need to create one. Some need to split it (compute /
+  storage / network / managed services) for downstream reporting.
+- **Cost-centre setup** - every receiving team needs a cost centre that exists
+  in the ERP, is open for posting, and is mapped to the right legal entity
+  and reporting hierarchy. Acquired or recently-renamed teams often fail this
+  check.
+- **Inter-cost-centre transfer mechanism** - in SAP, this is CO module
+  configuration (KSU3 cycles, SKF statistical key figures, or distribution
+  cycles). In Oracle / Workday / NetSuite, the equivalents exist but require
+  configuration. The FinOps team almost never owns this; the Controller does.
+- **Posting cadence** - hard chargeback journals need to post inside the
+  monthly close window (typically days 3-5 after period end). A FinOps
+  allocation pipeline that delivers on day 10 is useless for hard chargeback
+  regardless of how good the methodology is. Confirm the close calendar with
+  Finance and engineer the pipeline backwards from it.
+
+A practical first step: have FinOps and the Controller's office walk through
+one mock chargeback journal end-to-end before any commitment is made on
+go-live timing. Block-and-tackle issues (missing cost centre, account code
+not yet created, cycle not configured) surface in hours instead of months.
+
+### Inter-business-unit P&L impact
+
+When Engineering's cloud spend gets recharged to Product Line A, A's operating
+margin drops. A central IT cost line shrinks correspondingly. This is the
+intended outcome - that is the entire point of hard chargeback. But the
+side-effects need executive alignment before the first quarterly close lands:
+
+- **Bonus and incentive plans** - division GMs whose bonuses are tied to
+  operating margin will see margin move from causes outside their control
+  unless their plan is updated to either (a) include cloud spend in their
+  budget envelope, or (b) measure them on a margin metric that excludes
+  recharged IT cost
+- **Segment reporting** - public companies that report by segment need the
+  CFO and Controller aligned on whether recharged cloud cost shows up in
+  segment cost or as a corporate allocation. The choice affects analyst-facing
+  metrics
+- **Board-level reporting** - if board metrics include divisional gross or
+  operating margin, the first quarter of chargeback will move those numbers
+  in ways that need to be explained in advance, not discovered in a board
+  pack
+- **Budget process integration** - hard chargeback only works if the recharged
+  cost is included in the receiving team's budget for the year. Otherwise the
+  team posts variance every month against a budget that ignored the line.
+  Hard chargeback go-live should align with the start of a fiscal year, not
+  mid-year
+
+The CFO has to be the executive sponsor of hard chargeback for this reason.
+FinOps owns the methodology; the CFO owns the accounting and incentive
+implications. Hard chargeback without CFO sponsorship reverts to soft
+chargeback within two quarters.
+
+### Transfer pricing (multi-entity groups)
+
+Intercompany cloud recharges between legal entities are transfer-pricing
+transactions. They need an arm's-length basis, supporting documentation, and
+tax-team review. Most groups land on a cost-plus methodology (cost + 5-7%
+margin) for centrally-procured cloud recharged to operating subsidiaries, but
+the right answer depends on the local tax authority's expectations and the
+group's existing transfer-pricing policy.
+
+The pattern that breaks: a US parent procures cloud centrally and recharges
+to a French operating subsidiary at exact cost. The French tax authority
+re-characterises the transaction under their transfer-pricing rules, imputes
+a margin, and assesses tax on the imputed amount. The remediation cost is
+typically 2-4x the original tax delta.
+
+Engage the tax team before chargeback crosses a legal-entity boundary. They
+will tell you which methodology applies, what documentation is needed, and
+whether an existing transfer-pricing study covers the new recharge or
+requires an update.
+
+### Cross-border tax mechanics
+
+Cross-border intercompany services have additional considerations:
+
+- **VAT / GST treatment** - in the EU, intercompany services across borders
+  typically use the reverse-charge mechanism (the receiving entity self-assesses
+  VAT and recovers it on the same return), but the rules vary by jurisdiction
+  and by what the service is classified as. UK / EU / APAC each have their
+  own treatments
+- **Withholding tax** - some jurisdictions impose withholding on intercompany
+  service payments; bilateral tax treaties usually provide relief but require
+  documentation
+- **Permanent establishment risk** - aggressive recharging from one entity to
+  another can, in some structures, create PE exposure for the source entity
+  in the destination country
+- **Pillar 2 minimum tax (EU + OECD)** - for groups subject to the global
+  minimum tax (revenue > €750M), the effective tax rate calculation in each
+  jurisdiction picks up intercompany cost allocations. Material chargeback
+  flows can shift jurisdictional ETRs and trigger top-up tax in unexpected
+  places
+- **US GILTI / FDII / BEAT** - for US-parented groups, intercompany cloud
+  recharges interact with the international tax provisions in ways that are
+  rarely intuitive
+
+None of these are FinOps decisions. All of them mean "tax has to be in the
+room before hard chargeback crosses a border."
+
+### Audit trail and controls
+
+Hard chargeback creates accounting transactions that auditors will sample.
+The control framework needs evidence:
+
+- **Source data immutability** - the FOCUS dataset (or equivalent) used for
+  allocation must be archived in a form that cannot be altered after the
+  close; auditors need to be able to reproduce the chargeback calculation
+  for any closed period
+- **Approval workflow** - the chargeback methodology and the monthly journals
+  need documented approval before posting; "FinOps decided" is not an
+  audit-acceptable approval chain
+- **Segregation of duties** - the team that designs allocation keys should
+  not be the team that posts the journals. In small organisations this is
+  hard but achievable through ERP-level approver roles
+- **Exception logging** - any manual override (e.g. correcting a previous
+  month's chargeback in the current month) must be logged with rationale
+  and approver
+- **SOX or equivalent (US public, large EU) ** - if the recharged amounts
+  are material to a public company's segment reporting, the chargeback
+  process becomes a SOX-relevant control. ICFR documentation, walkthroughs,
+  and annual testing apply
+
+Engage Internal Audit at the soft-chargeback stage, not at hard-chargeback
+go-live. They will surface control gaps that take months to remediate.
+
+### When to involve which Finance role
+
+| Decision | Owner / co-owner |
+|---|---|
+| Allocation methodology design | FinOps + Controller |
+| Cost-centre and chart-of-accounts setup | Controller |
+| ERP transfer-mechanism configuration | Controller + IT-Finance |
+| Inter-BU P&L impact and incentive-plan alignment | CFO + HR |
+| Transfer pricing methodology | Tax team + external advisor (rarely Internal) |
+| Cross-border tax treatment (VAT, withholding, PE) | Tax team + external advisor |
+| Audit and SOX-relevant controls | Internal Audit + Controller |
+| Budget process integration | FP&A + receiving-team Finance partners |
+
+The FinOps practitioner's job is not to answer these questions; it is to
+surface them at the right moment so the right Finance role can address them
+before the chargeback go-live commitment is made.
 
 ---
 

--- a/cloud-finops/references/finops-chargeback.md
+++ b/cloud-finops/references/finops-chargeback.md
@@ -1,0 +1,343 @@
+---
+name: finops-chargeback
+description: The operational treatment behind the "showback before chargeback" principle. Maturity ladder (no visibility to showback to soft chargeback to hard chargeback), EffectiveCost-based allocation methodology, InvoiceId reconciliation, defensible allocation keys, shared-services hard cases, timing cadence, and the chargeback-revolt anti-pattern.
+fcp_domain: "Manage the FinOps Practice"
+fcp_capability: "Invoicing & Chargeback"
+fcp_capabilities_secondary: ["Allocation"]
+fcp_phases: ["Inform", "Operate"]
+fcp_personas_primary: ["FinOps Practitioner"]
+fcp_personas_collaborating: ["Finance", "Engineering", "Leadership"]
+fcp_maturity_entry: "Walk"
+---
+
+# FinOps Chargeback and Showback
+
+> The "showback before chargeback" principle is named in
+> `optimnow-methodology.md`. This file is the operational treatment behind it:
+> the maturity ladder, the allocation methodology, the cost-column choices, the
+> shared-services hard cases, and the failure modes that catch organisations
+> trying to skip steps.
+
+---
+
+## Why showback comes before chargeback
+
+Showback distributes cost visibility. Chargeback distributes financial
+accountability. The first requires data and tooling. The second requires
+organisational readiness, cultural change, and executive sponsorship.
+
+Skipping the showback phase is the most expensive recoverable mistake in FinOps
+practice maturity. The failure shape is consistent:
+
+- Finance imposes chargeback on engineering teams that have never seen their
+  costs broken down before. Numbers feel arbitrary because the methodology has
+  not been socialised.
+- Engineering disputes the allocation keys because no one has explained how
+  shared services were attributed.
+- The first wave of disputes lands on FinOps as a noise tax, not a useful
+  signal. FinOps spends weeks defending the model rather than improving it.
+- Leadership sponsorship erodes. Chargeback is paused, sometimes permanently.
+  Twelve to eighteen months of credibility takes another two years to rebuild.
+
+The cost of this failure is not the engineering time spent on disputes. It is
+the organisational unwillingness to attempt chargeback again for a generation
+of leadership. The recovery path is to restart at showback and earn the
+upgrade.
+
+---
+
+## The four maturity tiers
+
+| Tier | What it is | What teams see | Financial effect | Maturity gate |
+|---|---|---|---|---|
+| **No visibility** | Cost data exists in billing systems but is not distributed | Aggregate spend at most | None | Tagging > 50%, FOCUS or native exports configured |
+| **Showback** | Per-team cost reports distributed regularly | Costs by team, environment, product | None (informational only) | At least two quarters of stable showback reports with disputes resolved on data quality, not methodology |
+| **Soft chargeback** | Costs affect team budgets but do not flow to P&L | Budget variances driven by their own spend | Budget pressure, not financial pressure | At least two quarters of soft chargeback with allocation keys unchanged, dispute rate trending down |
+| **Hard chargeback** | Costs hit team P&L and feed into headcount and capacity decisions | Direct accountability for financial outcomes | Real | Annual financial cycle includes chargeback as a planning input; no methodology disputes outstanding |
+
+**Cadence guideline:** plan one tier upgrade per year for organisations starting
+from no visibility. Faster timelines are usually a sign of leadership pressure
+that engineering will push back against once the numbers become real.
+
+**Hard chargeback is not the goal for every organisation.** Many organisations
+operate at soft chargeback indefinitely because the political cost of hard
+chargeback exceeds the value it delivers. Default to "advance the next tier
+when the current one is stable", not "always be advancing".
+
+---
+
+## Allocation methodology
+
+### Use `EffectiveCost` for allocation, not `BilledCost`
+
+Allocation is an accrual concept. A workload that consumes 10% of cluster
+capacity in March should be allocated 10% of the cluster's cost for March,
+even if the cluster runs on a Reservation that was paid in full in January.
+
+- **`EffectiveCost`** spreads prepaid commitment costs across the periods of
+  consumption. Use it for showback, chargeback, trend analysis, and team
+  attribution.
+- **`BilledCost`** ties to the invoice. Use it for invoice reconciliation
+  against `InvoiceId`. Do not use it for chargeback - it would attribute a
+  $1M annual prepay entirely to whoever consumed the first kilowatt-hour after
+  the purchase.
+
+If your billing pipeline only exposes one cost column, configure it to surface
+the amortised view (Azure: amortized cost export; AWS: Cost Explorer amortised
+view or CUR `line_item_amortized_cost`; GCP: BigQuery export's amortised cost
+columns). FOCUS-conformant exports surface both `EffectiveCost` and
+`BilledCost` natively.
+
+### Reconcile to invoice via `InvoiceId`
+
+The sum of `BilledCost` for a given `InvoiceId` must match the corresponding
+provider invoice to the penny. Use this as the integrity check on the
+allocation pipeline:
+
+- Run a monthly reconciliation: `SUM(BilledCost) GROUP BY InvoiceId` against
+  the invoice line items
+- Any drift > 0.5% is a data-quality issue worth investigating before it
+  compounds
+- Showback to teams uses allocated `EffectiveCost`; the invoice anchor is
+  `BilledCost` × `InvoiceId`. Both views are correct, for different audiences
+
+This is the part Finance cares most about. Get it right early.
+
+### Defensible allocation keys
+
+Every allocation key will be audited the moment chargeback becomes real. The
+test for a defensible key: can the team being charged trace the dollar amount
+back to a metric they can independently verify?
+
+| Key class | Example | Defensible? | Notes |
+|---|---|---|---|
+| Direct attribution | Resource has the team's tag | Yes | Strongest. Make this the default whenever physical tagging supports it. |
+| Operational metric | CPU-hours from Prometheus, request count from product telemetry | Yes | Strong for shared services. The metric must come from a system the team trusts. |
+| Header / authentication | API gateway request counts by client ID | Yes | Strong for multi-tenant platforms. |
+| Budget / headcount weighting | Team A is 60% of engineering, gets 60% of shared cost | Defensible at Walk, fragile at Run | Works while the org structure is stable. Fails at reorganisations. |
+| Even-split | Six teams use the platform, each gets 1/6 | Indefensible past showback | Triggers disputes immediately. Use only when no better key exists, and document the reason. |
+| Manual override | "We agreed Team B gets allocated less because they're a strategic priority" | Indefensible | Encodes politics into the data. Surface the politics elsewhere; keep the methodology clean. |
+
+**Rule of thumb:** build allocation keys from authoritative operational systems
+(Prometheus, Thanos, product telemetry, API gateway logs) for shared platform
+costs, not just from labels. Labels miss what teams actually consume; metrics
+do not.
+
+---
+
+## Shared-services hard cases
+
+The simple cases (resource has the team's tag, allocate to that team) work for
+roughly 70% of cloud spend. The remaining 30% is shared services, and that is
+where allocation methodology earns its credibility.
+
+### Network cost
+
+Network cost is the single hardest shared-services allocation problem. Cost
+hides across many `ServiceCategory` values:
+
+- Cross-zone data transfer between EC2 instances of two different teams (shows
+  up under `ServiceCategory='Compute'`, not `'Networking'`)
+- Database replica replication traffic (shows up under `'Databases'`)
+- Storage egress for a team's S3 reads from a service in another region
+  (shows up under `'Storage'`)
+- Managed-service traffic (CloudFront, API Gateway, Application Gateway,
+  Cloud CDN) that serves multiple teams' workloads
+- NAT Gateway and Transit Gateway processing fees
+
+Recommended allocation pattern:
+1. Tag the network appliances themselves (NAT, ALB, TGW, ExpressRoute) where
+   tagging is supported
+2. For untaggable inter-resource traffic, allocate by **traffic share** measured
+   from VPC Flow Logs, Application Gateway logs, or equivalent
+3. For genuinely shared infrastructure (CDN, edge), use a tiered approach:
+   first attribute to product through the CDN's request logs; then fall back
+   to revenue-weighted or even-split for the residual
+
+Document the methodology before publishing. Network allocation disputes are
+guaranteed; the documentation pre-empts the worst of them.
+
+### Observability and platform tooling
+
+Logging pipelines, metrics platforms, distributed tracing, and CI/CD systems
+serve every team. Three patterns that work:
+
+- **Volume-weighted**: ingestion bytes per team for log platforms, span counts
+  for tracing, build minutes for CI/CD. The metric is the bill driver.
+- **Capacity-share**: for tools billed by capacity (Splunk indexers, Datadog
+  hosts), allocate by team consumption of that capacity measured at a fixed
+  cadence
+- **Tiered floor**: every team pays a minimum platform fee for participation
+  (covers the fixed cost of running the platform), and the variable cost is
+  allocated by usage
+
+The tiered-floor pattern is what most mature organisations land on. It avoids
+the failure mode where a small team using one log line per minute pays a
+microscopic share of a $100K/month log platform.
+
+### Security tooling
+
+Security tools serve the organisation, not individual teams. Default to
+allocating their cost to the central security cost centre, not to engineering
+teams. Engineering teams cannot opt out of security tooling, so charging them
+for it creates noise without improving accountability.
+
+The exception: per-team security workloads (e.g. WAF rules specific to one
+team's app, secrets-manager entries owned by one team) can and should be
+attributed to that team.
+
+### Ingress / API gateway
+
+Allocate by request count if the gateway has per-route or per-client
+attribution. If it does not, configure that attribution before chargeback
+moves past showback. An ingress allocation that cannot survive a "where did
+this number come from?" question will be the first chargeback dispute.
+
+---
+
+## Timing cadence
+
+| Frequency | Activity | Audience |
+|---|---|---|
+| Daily | Anomaly review (see `finops-anomaly-management.md`) | FinOps + Engineering owners |
+| Weekly | Showback variance vs forecast at team level | Engineering team leads |
+| Monthly | Showback or chargeback close, including invoice reconciliation | Finance + Engineering |
+| Quarterly | True-ups: corrections to allocation methodology applied retroactively | Finance + FinOps |
+| Annually | Methodology review: are the keys still defensible? Has the org structure changed? | FinOps + Finance + Leadership |
+
+**Critical:** monthly with quarterly true-ups, never quarterly with annual
+surprises. A team that learns it overspent its budget in January when the
+quarterly close lands in April has lost three months of correction time. The
+shorter the cycle, the smaller each correction needs to be.
+
+True-ups are not optional. Allocation methodology imperfections compound
+silently if not corrected on a fixed cadence. Run the quarterly true-up even
+when nothing visible has changed - the discipline is what makes the methodology
+trustworthy.
+
+---
+
+## Unallocated spend is a tagging signal
+
+If more than 10% of spend cannot be allocated to a team or product, the
+problem is upstream of chargeback. The allocation pipeline is not broken;
+tagging is.
+
+The temptation when unallocated spend is high is to redistribute it across
+known teams (e.g. proportional to their allocated spend). Resist this. It
+penalises teams that tag well and rewards teams that do not. It also hides
+the tagging problem from leadership, which makes the underlying fix less
+likely to happen.
+
+Better: surface unallocated spend as a discrete line item. Make it visible to
+leadership. Drive the tagging programme on the back of it. See `finops-tagging.md`
+for the enforcement work that brings unallocated spend below the 10% threshold.
+
+---
+
+## Dispute process
+
+Disputes are inevitable. A working dispute process:
+
+1. **Single intake channel** (Slack, ticket queue, or email alias) with a
+   templated form: which line item, which team, what is being disputed, what
+   the team thinks the correct allocation is
+2. **Triage SLA**: 5 business days to first response, 15 to resolution
+3. **Methodology disputes vs data-quality disputes**:
+   - Data-quality disputes (the resource ID is wrong, the tag is missing, the
+     metric is stale) are FinOps's job to fix and the team's job to confirm
+   - Methodology disputes (the allocation key itself is wrong) escalate to a
+     quarterly methodology review, not a per-dispute fix
+4. **Decision log**: every methodology dispute that closes either with a
+   change or a "no change" decision is logged with the rationale. Future
+   disputes citing the same issue get pointed at the log
+5. **Quarterly retrospective**: dispute count, resolution time, top dispute
+   categories. A rising dispute rate is a methodology problem, not a personnel
+   problem
+
+Treat disputes as data-quality feedback, not as complaints. A team that bothers
+to dispute is a team that read the report.
+
+---
+
+## Anti-patterns
+
+- **Jumping straight to hard chargeback**. The "chargeback revolt" failure
+  mode. Cost: 12-18 months of credibility, recovery measured in years.
+- **Allocating `BilledCost` to teams**. Causes spike-and-trough chargeback
+  charges aligned to commitment purchase dates rather than consumption. Always
+  use `EffectiveCost` for allocation.
+- **Hiding unallocated spend**. Redistributing it across known teams penalises
+  good tagging and removes the lever to fix the underlying problem.
+- **Even-split allocation past showback**. "Six teams use the platform, each
+  gets 1/6" works only when the platform's cost is small and the teams are
+  similar in size. Past showback, this triggers disputes that consume more
+  FinOps time than building a real key would have.
+- **Manual overrides for political reasons**. Encoding "Team A pays less
+  because they're strategic" into the data corrupts the methodology and
+  destroys credibility. Surface the strategic subsidy elsewhere; keep the
+  allocation clean.
+- **Methodology changes mid-quarter**. Changes apply at quarterly true-ups,
+  not in real time. Real-time methodology changes break trust in the numbers.
+- **No invoice reconciliation**. If `SUM(BilledCost) GROUP BY InvoiceId` does
+  not match the invoice, every other number is suspect. Run the reconciliation
+  monthly without exception.
+
+---
+
+## Maturity progression
+
+### Crawl
+
+- Tagging at >50% allocation is the prerequisite. Below that, even showback is
+  premature - see `finops-tagging.md` first.
+- Manual cost reports per team, distributed monthly via email or shared
+  dashboard
+- No formal dispute process; ad hoc clarification requests
+- Allocation keys are simple: direct attribution from tags, even-split for
+  unattributed shared services
+
+### Walk
+
+- Automated showback reports at fixed cadence (monthly minimum, weekly
+  preferred)
+- Documented allocation methodology: which key applies to which cost class,
+  why
+- Defensible keys for the top three shared-services categories (network,
+  observability, ingress)
+- Soft chargeback active: budget variances driven by allocated spend, no P&L
+  impact
+- Dispute process running with a triage SLA
+- Quarterly true-ups for methodology corrections
+
+### Run
+
+- Hard chargeback in production: allocated cost feeds team P&L and headcount
+  decisions
+- Allocation keys driven by authoritative operational metrics (Prometheus,
+  product telemetry), not just tags
+- Methodology version-controlled and reviewed annually with explicit
+  stakeholder sign-off
+- Dispute rate trending down year over year; each dispute either improves the
+  methodology or is closed against the decision log
+- Showback and chargeback views integrated into the team's existing tools
+  (Slack, JIRA, Grafana), not a standalone FinOps dashboard nobody opens
+
+---
+
+## Cross-references
+
+- `optimnow-methodology.md` - "Showback before chargeback" principle (the
+  framing this file builds on)
+- `finops-tagging.md` - allocation foundation; chargeback maturity depends on
+  tagging maturity
+- `finops-anomaly-management.md` - daily anomaly review feeds the same
+  allocation pipeline; shares the FOCUS dataset
+- `finops-itam.md` - vendor co-management for chargeback decisions that span
+  cloud-marketplace purchases
+- `finops-framework.md` - Invoicing & Chargeback capability in the FinOps
+  Framework
+
+---
+
+> *Cloud FinOps Skill by [OptimNow](https://optimnow.io) - licensed under [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/).*


### PR DESCRIPTION
## Summary

Closes the **Invoicing & Chargeback** capability gap. The "showback before chargeback" principle was already named in `optimnow-methodology.md` but had no operational treatment - clients had the principle but no path from principle to implementation. This file is the operational layer behind it.

> **Updated 2026-05-03** (commit `6a7487c`): added explicit FOCUS-to-AWS-legacy cost column mapping (with a `blended_cost` warning), and added a new section on the Finance, Controller, and Tax prerequisites that determine whether hard chargeback is operationally possible at all. File grew 343 → 523 lines.

### What's in the new file

**Allocation methodology (FinOps half):**
- **Four-tier maturity ladder** with characteristics, exit criteria, and one-tier-per-year cadence guidance:
  - No visibility → Showback → Soft chargeback → Hard chargeback
  - Hard chargeback is explicitly not the goal for every organisation; many operate at soft chargeback indefinitely
- **Allocation methodology** — `EffectiveCost` for showback and chargeback (accrual; the amortised view), `BilledCost` for invoice reconciliation via `InvoiceId` (cash-basis). Now includes an explicit FOCUS-to-AWS-legacy mapping table:
  - `EffectiveCost` ≈ `line_item_amortized_cost` (Cost Explorer "Amortized")
  - `BilledCost` ≈ `line_item_unblended_cost` (Cost Explorer "Unblended")
  - Plus a warning: **avoid AWS `blended_cost` for chargeback entirely** - it is a payer-account averaging artefact that reflects neither invoice reality nor true accrual attribution; FOCUS deliberately has no equivalent column
- **Defensible allocation keys** — table with explicit defensibility ratings: direct attribution (yes), operational metric from Prometheus / product telemetry (yes), header / auth from API gateway (yes), budget weighting (defensible at Walk, fragile at Run), even-split (indefensible past showback), manual political override (indefensible)
- **Shared-services hard cases** — the 30% of cloud spend where allocation methodology earns its credibility:
  - Network cost (hidden across `ServiceCategory='Compute'/'Databases'/'Storage'`, not just `'Networking'`)
  - Observability and platform tooling (volume-weighted, capacity-share, tiered-floor patterns)
  - Security (default to central cost centre; engineering teams cannot opt out)
  - Ingress and API gateway (per-route attribution required before chargeback past showback)

**Finance and accounting prerequisites (Finance / Controller / Tax half — NEW):**
- **Accounting system readiness** — chart of accounts, cost-centre setup, ERP transfer mechanism (SAP CO cycles, Oracle / Workday / NetSuite equivalents), posting-cadence alignment with the monthly close window. The "FinOps designs the model and discovers the ERP cannot post the journals" failure mode.
- **Inter-business-unit P&L impact** — incentive plans, segment reporting, board metrics, fiscal-year alignment, why CFO sponsorship is required. Hard chargeback without CFO sponsorship reverts to soft within two quarters.
- **Transfer pricing for multi-entity groups** — cost-plus methodology, the re-characterisation risk pattern (US parent recharging French subsidiary at exact cost gets imputed margin assessed), when to engage tax + external advisor.
- **Cross-border tax mechanics** — VAT reverse-charge in EU intercompany services, withholding tax and treaty relief, permanent-establishment risk, EU/OECD Pillar 2 minimum tax (revenue > €750M), US GILTI / FDII / BEAT.
- **Audit trail and SOX-equivalent controls** — source-data immutability, approval workflows, segregation of duties between methodology and posting, exception logging, ICFR documentation for material amounts.
- **Decision-owner table** — maps each prerequisite to the right Finance role (Controller, CFO, Tax, Internal Audit, FP&A) so FinOps surfaces them at the right moment to the right person.

**Operating cadence and process:**
- **Timing cadence** — monthly with quarterly true-ups, never quarterly with annual surprises
- **Unallocated > 10% as a tagging signal**, not a presentation problem to redistribute
- **Dispute process** — methodology vs data-quality split, decision log, quarterly retrospective
- **Anti-patterns** including the chargeback-revolt failure mode (12-18 months of credibility loss, recovery measured in years)
- **Crawl/Walk/Run progression** with explicit prerequisites (e.g. tagging > 50% allocation is the prerequisite before even showback is meaningful)

### Why now

- Chargeback design is a Walk → Run engagement question that comes up in nearly every assessment
- The principle was already in the methodology file; this file is the missing operational treatment
- `EffectiveCost` vs `BilledCost` confusion is the most common allocation error in the field; making the prescription explicit (with the AWS-legacy mapping and the `blended_cost` warning) prevents it
- The Finance prerequisites are the half that determines whether hard chargeback is even possible; treating chargeback as purely a FinOps problem leaves clients stuck at soft chargeback indefinitely

### Routing and packaging

- Added router row to `SKILL.md` and `POWER.md` (now mentions the AWS-legacy mapping and the Finance prerequisites)
- Added 14 keywords to `POWER.md` frontmatter (chargeback maturity, ERP readiness, transfer pricing, Pillar 2, SOX, etc.)
- Added entry to SKILL.md "Reference files" table (line count 480 reflects the expanded file)
- Added "What this skill covers" bullet and Directory structure entry in `README.md`
- Bumped plugin version 1.13.0 → 1.14.0 in `.claude-plugin/plugin.json`
- Marketplace description: "23 reference files" → "24 reference files" + "chargeback and showback" added to topic list

### Verification

- File: 523 lines (expanded from 343 to cover Finance prerequisites at appropriate depth)
- No em dashes in any changed file (CLAUDE.md hard rule)
- SKILL.md description: 1016 chars (under 1024 limit, unchanged)
- Routing tables consistent: 23 routing rows + 24 reference table rows
- British spelling used for public-facing content
- Cross-references to `optimnow-methodology.md`, `finops-tagging.md`, `finops-anomaly-management.md`, `finops-itam.md`, `finops-framework.md`

## Test plan

- [ ] Ask: "Our engineers see costs but finance wants P&L impact - where do we start?" — should prescribe the maturity ladder, not skip straight to hard chargeback
- [ ] Ask: "We're allocating cluster costs by team but the team disputes the methodology - what should our key be?" — should recommend operational-metric keys over even-split
- [ ] Ask: "We charged engineering teams 500K last quarter and the dispute volume is overwhelming us" — should surface the chargeback-revolt anti-pattern and the showback-restart recovery path
- [ ] Ask: "How do we allocate network cost across teams?" — should explain that network cost hides across `ServiceCategory` values and prescribe traffic-share allocation from VPC Flow Logs
- [ ] Ask: "Our French subsidiary uses cloud paid by US parent - any tax issues with chargeback?" — should surface transfer-pricing re-characterisation risk and recommend tax-team engagement
- [ ] Ask: "Why shouldn't I use AWS blended cost for chargeback?" — should explain the payer-account averaging artefact and direct to amortised cost
- [ ] Ask: "We're going live with hard chargeback in Q3 - what does Finance need to be ready?" — should walk through ERP readiness, cost-centre setup, posting-cadence alignment, and CFO sponsorship

Generated with Claude Code.
