### PR TITLE
Add YAML FCP frontmatter to all existing reference files (no content change)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloud-finops",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "description": "Expert FinOps guidance for cloud, AI, SaaS, and data-platform spend (multi-provider, model-agnostic).",
   "author": {
     "name": "OptimNow",

--- a/cloud-finops/references/finops-ai-dev-tools.md
+++ b/cloud-finops/references/finops-ai-dev-tools.md
@@ -1,3 +1,14 @@
+---
+name: finops-ai-dev-tools
+fcp_domain: "Optimize Usage & Cost"
+fcp_capability: "Workload Optimization"
+fcp_capabilities_secondary: ["Allocation", "Licensing & SaaS"]
+fcp_phases: ["Optimize"]
+fcp_personas_primary: ["FinOps Practitioner", "Engineering"]
+fcp_personas_collaborating: ["Procurement", "Finance"]
+fcp_maturity_entry: "Walk"
+---
+
 # FinOps for AI Coding Tools
 
 > Cost governance for AI-assisted development tools - covering seat-based IDE assistants

--- a/cloud-finops/references/finops-ai-self-hosted-vs-managed.md
+++ b/cloud-finops/references/finops-ai-self-hosted-vs-managed.md
@@ -1,3 +1,14 @@
+---
+name: finops-ai-self-hosted-vs-managed
+fcp_domain: "Optimize Usage & Cost"
+fcp_capability: "Architecting for Cloud"
+fcp_capabilities_secondary: ["Workload Optimization", "Rate Optimization"]
+fcp_phases: ["Inform", "Optimize"]
+fcp_personas_primary: ["FinOps Practitioner", "Engineering"]
+fcp_personas_collaborating: ["Product", "Leadership", "Finance"]
+fcp_maturity_entry: "Walk"
+---
+
 # AI inference: self-hosted vs managed APIs - a FinOps perspective
 
 > FinOps decision framework for AI inference: self-hosted vLLM/SGLang/llama.cpp on rented or

--- a/cloud-finops/references/finops-ai-value-management.md
+++ b/cloud-finops/references/finops-ai-value-management.md
@@ -1,3 +1,14 @@
+---
+name: finops-ai-value-management
+fcp_domain: "Quantify Business Value"
+fcp_capability: "Planning & Estimating"
+fcp_capabilities_secondary: ["Forecasting", "FinOps Practice Operations"]
+fcp_phases: ["Inform", "Operate"]
+fcp_personas_primary: ["FinOps Practitioner", "Leadership"]
+fcp_personas_collaborating: ["Engineering", "Product", "Finance"]
+fcp_maturity_entry: "Walk"
+---
+
 # FinOps for AI: Managing Value and Practice Operations
 
 > Guidance on how FinOps practices should evolve to manage AI investments at scale.

--- a/cloud-finops/references/finops-anthropic.md
+++ b/cloud-finops/references/finops-anthropic.md
@@ -1,3 +1,13 @@
+---
+name: finops-anthropic
+fcp_domain: "Optimize Usage & Cost"
+fcp_capability: "Workload Optimization"
+fcp_phases: ["Optimize"]
+fcp_personas_primary: ["FinOps Practitioner", "Engineering"]
+fcp_personas_collaborating: ["Product", "Finance"]
+fcp_maturity_entry: "Walk"
+---
+
 # FinOps on Anthropic
 
 > Anthropic-specific guidance covering the billing model changes introduced in February 2026,

--- a/cloud-finops/references/finops-aws.md
+++ b/cloud-finops/references/finops-aws.md
@@ -1,3 +1,14 @@
+---
+name: finops-aws
+fcp_domain: "Optimize Usage & Cost"
+fcp_capability: "Rate Optimization"
+fcp_capabilities_secondary: ["Workload Optimization", "Data Ingestion"]
+fcp_phases: ["Optimize", "Operate"]
+fcp_personas_primary: ["FinOps Practitioner", "Engineering"]
+fcp_personas_collaborating: ["Finance", "Procurement"]
+fcp_maturity_entry: "Walk"
+---
+
 # FinOps on AWS
 
 > AWS-specific guidance covering cost management tools, commitment discounts, compute

--- a/cloud-finops/references/finops-azure-openai.md
+++ b/cloud-finops/references/finops-azure-openai.md
@@ -1,3 +1,14 @@
+---
+name: finops-azure-openai
+fcp_domain: "Optimize Usage & Cost"
+fcp_capability: "Rate Optimization"
+fcp_capabilities_secondary: ["Workload Optimization"]
+fcp_phases: ["Optimize"]
+fcp_personas_primary: ["FinOps Practitioner", "Engineering"]
+fcp_personas_collaborating: ["Product", "Finance"]
+fcp_maturity_entry: "Walk"
+---
+
 # FinOps on Azure OpenAI Service
 
 > Azure OpenAI Service-specific guidance covering the billing model, PTU (Provisioned

--- a/cloud-finops/references/finops-azure.md
+++ b/cloud-finops/references/finops-azure.md
@@ -1,3 +1,14 @@
+---
+name: finops-azure
+fcp_domain: "Optimize Usage & Cost"
+fcp_capability: "Rate Optimization"
+fcp_capabilities_secondary: ["Workload Optimization", "Data Ingestion"]
+fcp_phases: ["Optimize", "Operate"]
+fcp_personas_primary: ["FinOps Practitioner", "Engineering"]
+fcp_personas_collaborating: ["Finance", "Procurement"]
+fcp_maturity_entry: "Walk"
+---
+
 # FinOps on Azure
 
 > Azure-specific guidance covering cost management tools, commitment discounts, compute

--- a/cloud-finops/references/finops-bedrock.md
+++ b/cloud-finops/references/finops-bedrock.md
@@ -1,3 +1,14 @@
+---
+name: finops-bedrock
+fcp_domain: "Optimize Usage & Cost"
+fcp_capability: "Workload Optimization"
+fcp_capabilities_secondary: ["Rate Optimization"]
+fcp_phases: ["Optimize"]
+fcp_personas_primary: ["FinOps Practitioner", "Engineering"]
+fcp_personas_collaborating: ["Product", "Finance"]
+fcp_maturity_entry: "Walk"
+---
+
 # FinOps on AWS Bedrock
 
 > AWS Bedrock-specific guidance covering the billing model, model pricing, provisioned

--- a/cloud-finops/references/finops-databricks.md
+++ b/cloud-finops/references/finops-databricks.md
@@ -1,3 +1,14 @@
+---
+name: finops-databricks
+fcp_domain: "Optimize Usage & Cost"
+fcp_capability: "Workload Optimization"
+fcp_capabilities_secondary: ["Rate Optimization", "Allocation"]
+fcp_phases: ["Optimize", "Operate"]
+fcp_personas_primary: ["FinOps Practitioner", "Engineering"]
+fcp_personas_collaborating: ["Product", "Finance"]
+fcp_maturity_entry: "Walk"
+---
+
 # FinOps on Databricks
 
 > Databricks-specific FinOps guidance covering cost data foundations (system tables,

--- a/cloud-finops/references/finops-fabric.md
+++ b/cloud-finops/references/finops-fabric.md
@@ -1,3 +1,14 @@
+---
+name: finops-fabric
+fcp_domain: "Optimize Usage & Cost"
+fcp_capability: "Rate Optimization"
+fcp_capabilities_secondary: ["Workload Optimization", "Onboarding Workloads"]
+fcp_phases: ["Optimize"]
+fcp_personas_primary: ["FinOps Practitioner", "Engineering"]
+fcp_personas_collaborating: ["Product", "Finance"]
+fcp_maturity_entry: "Walk"
+---
+
 # FinOps on Microsoft Fabric
 
 > Microsoft Fabric capacity FinOps: F-SKU model, Capacity Units (CU) and the 24-hour

--- a/cloud-finops/references/finops-for-ai.md
+++ b/cloud-finops/references/finops-for-ai.md
@@ -1,3 +1,14 @@
+---
+name: finops-for-ai
+fcp_domain: "Quantify Business Value"
+fcp_capability: "Unit Economics"
+fcp_capabilities_secondary: ["Workload Optimization", "Allocation"]
+fcp_phases: ["Inform", "Optimize"]
+fcp_personas_primary: ["FinOps Practitioner", "Engineering", "Product"]
+fcp_personas_collaborating: ["Finance", "Leadership"]
+fcp_maturity_entry: "Walk"
+---
+
 # FinOps for AI
 
 > AI workloads do not behave like infrastructure workloads. The tools, processes, and

--- a/cloud-finops/references/finops-framework.md
+++ b/cloud-finops/references/finops-framework.md
@@ -1,3 +1,14 @@
+---
+name: finops-framework
+fcp_domain: "Manage the FinOps Practice"
+fcp_capability: "FinOps Practice Operations"
+fcp_capabilities_secondary: ["FinOps Assessment"]
+fcp_phases: ["Inform", "Optimize", "Operate"]
+fcp_personas_primary: ["FinOps Practitioner"]
+fcp_personas_collaborating: ["Engineering", "Finance", "Product", "Procurement", "Leadership"]
+fcp_maturity_entry: "Crawl"
+---
+
 # FinOps Framework Reference
 
 > Source: FinOps Foundation (finops.org/framework). The structure documented below is the

--- a/cloud-finops/references/finops-gcp.md
+++ b/cloud-finops/references/finops-gcp.md
@@ -1,3 +1,14 @@
+---
+name: finops-gcp
+fcp_domain: "Optimize Usage & Cost"
+fcp_capability: "Rate Optimization"
+fcp_capabilities_secondary: ["Workload Optimization", "Data Ingestion"]
+fcp_phases: ["Optimize", "Operate"]
+fcp_personas_primary: ["FinOps Practitioner", "Engineering"]
+fcp_personas_collaborating: ["Finance", "Procurement"]
+fcp_maturity_entry: "Walk"
+---
+
 # FinOps on GCP
 
 > GCP-specific guidance covering cost data foundations, commitment discounts, carbon

--- a/cloud-finops/references/finops-genai-capacity.md
+++ b/cloud-finops/references/finops-genai-capacity.md
@@ -1,3 +1,14 @@
+---
+name: finops-genai-capacity
+fcp_domain: "Optimize Usage & Cost"
+fcp_capability: "Rate Optimization"
+fcp_capabilities_secondary: ["Workload Optimization", "Architecting for Cloud"]
+fcp_phases: ["Optimize"]
+fcp_personas_primary: ["FinOps Practitioner", "Engineering"]
+fcp_personas_collaborating: ["Product", "Finance"]
+fcp_maturity_entry: "Walk"
+---
+
 # FinOps for GenAI: Capacity Models
 
 > Cross-provider reference covering provisioned vs shared (pay-as-you-go) capacity for

--- a/cloud-finops/references/finops-itam.md
+++ b/cloud-finops/references/finops-itam.md
@@ -1,3 +1,14 @@
+---
+name: finops-itam
+fcp_domain: "Optimize Usage & Cost"
+fcp_capability: "Licensing & SaaS"
+fcp_capabilities_secondary: ["Intersecting Disciplines"]
+fcp_phases: ["Optimize", "Operate"]
+fcp_personas_primary: ["FinOps Practitioner", "Procurement"]
+fcp_personas_collaborating: ["Engineering", "Finance", "Leadership"]
+fcp_maturity_entry: "Walk"
+---
+
 # FinOps and ITAM - Collaborating Across the Technology Estate
 
 > Where FinOps and ITAM intersect: shared governance, marketplace channel strategy,

--- a/cloud-finops/references/finops-oci.md
+++ b/cloud-finops/references/finops-oci.md
@@ -1,3 +1,14 @@
+---
+name: finops-oci
+fcp_domain: "Understand Usage & Cost"
+fcp_capability: "Data Ingestion"
+fcp_capabilities_secondary: ["Anomaly Management", "Workload Optimization"]
+fcp_phases: ["Inform", "Optimize"]
+fcp_personas_primary: ["FinOps Practitioner", "Engineering"]
+fcp_personas_collaborating: ["Finance"]
+fcp_maturity_entry: "Crawl"
+---
+
 # FinOps on OCI
 
 > Oracle Cloud Infrastructure FinOps guidance covering cost data foundations

--- a/cloud-finops/references/finops-sam.md
+++ b/cloud-finops/references/finops-sam.md
@@ -1,3 +1,13 @@
+---
+name: finops-sam
+fcp_domain: "Optimize Usage & Cost"
+fcp_capability: "Licensing & SaaS"
+fcp_phases: ["Optimize", "Operate"]
+fcp_personas_primary: ["FinOps Practitioner", "Procurement"]
+fcp_personas_collaborating: ["Engineering", "Finance", "Leadership"]
+fcp_maturity_entry: "Walk"
+---
+
 # FinOps for SaaS Asset Management (SAM)
 
 > SaaS management as a FinOps capability: discovery, license optimisation, renewal governance,

--- a/cloud-finops/references/finops-snowflake.md
+++ b/cloud-finops/references/finops-snowflake.md
@@ -1,3 +1,14 @@
+---
+name: finops-snowflake
+fcp_domain: "Optimize Usage & Cost"
+fcp_capability: "Workload Optimization"
+fcp_capabilities_secondary: ["Rate Optimization"]
+fcp_phases: ["Optimize"]
+fcp_personas_primary: ["FinOps Practitioner", "Engineering"]
+fcp_personas_collaborating: ["Product", "Finance"]
+fcp_maturity_entry: "Walk"
+---
+
 # FinOps on Snowflake
 
 > Snowflake-specific optimization patterns covering warehouse sizing, query efficiency, storage, and governance. 13 inefficiency patterns for diagnosing waste and building optimization roadmaps.

--- a/cloud-finops/references/finops-tagging.md
+++ b/cloud-finops/references/finops-tagging.md
@@ -1,3 +1,14 @@
+---
+name: finops-tagging
+fcp_domain: "Understand Usage & Cost"
+fcp_capability: "Allocation"
+fcp_capabilities_secondary: ["Policy & Governance"]
+fcp_phases: ["Inform", "Operate"]
+fcp_personas_primary: ["FinOps Practitioner", "Engineering"]
+fcp_personas_collaborating: ["Security", "Finance"]
+fcp_maturity_entry: "Crawl"
+---
+
 # FinOps Tagging and Naming Governance
 
 > Tagging is the foundation of cost allocation, accountability, and automation.

--- a/cloud-finops/references/finops-vertexai.md
+++ b/cloud-finops/references/finops-vertexai.md
@@ -1,3 +1,14 @@
+---
+name: finops-vertexai
+fcp_domain: "Optimize Usage & Cost"
+fcp_capability: "Rate Optimization"
+fcp_capabilities_secondary: ["Workload Optimization"]
+fcp_phases: ["Optimize"]
+fcp_personas_primary: ["FinOps Practitioner", "Engineering"]
+fcp_personas_collaborating: ["Product", "Finance"]
+fcp_maturity_entry: "Walk"
+---
+
 # FinOps on GCP Vertex AI
 
 > GCP Vertex AI-specific guidance covering the billing model, model pricing, provisioned

--- a/cloud-finops/references/greenops-cloud-carbon.md
+++ b/cloud-finops/references/greenops-cloud-carbon.md
@@ -1,3 +1,14 @@
+---
+name: greenops-cloud-carbon
+fcp_domain: "Optimize Usage & Cost"
+fcp_capability: "Cloud Sustainability"
+fcp_capabilities_secondary: ["Architecting for Cloud", "Workload Optimization"]
+fcp_phases: ["Inform", "Optimize", "Operate"]
+fcp_personas_primary: ["FinOps Practitioner", "Engineering"]
+fcp_personas_collaborating: ["Sustainability", "Leadership", "Finance"]
+fcp_maturity_entry: "Walk"
+---
+
 # GreenOps & Cloud Carbon Optimization
 
 > Practical guidance for measuring, reducing, and governing cloud carbon emissions.

--- a/cloud-finops/references/optimnow-methodology.md
+++ b/cloud-finops/references/optimnow-methodology.md
@@ -1,3 +1,13 @@
+---
+name: optimnow-methodology
+fcp_domain: "Manage the FinOps Practice"
+fcp_capability: "FinOps Practice Operations"
+fcp_phases: ["Inform", "Optimize", "Operate"]
+fcp_personas_primary: ["FinOps Practitioner"]
+fcp_personas_collaborating: ["Engineering", "Finance", "Leadership"]
+fcp_maturity_entry: "Crawl"
+---
+
 # OptimNow Methodology
 
 > This file defines how OptimNow approaches customer problems. It is a reasoning lens,


### PR DESCRIPTION
## Summary

Adds structured YAML FCP frontmatter to the 22 existing reference files that were missing it. The 4 most recent reference files (`finops-anomaly-management.md`, `finops-allocation-showback.md`, `finops-chargeback.md`, `finops-onboarding-workloads.md`) already shipped with this frontmatter, so the new files plus this PR bring all 26 reference files to a uniform metadata convention.

Purely additive — no existing content changed. Each file gains a 9-line YAML block prepended above the existing H1 title. The change is machine-readable metadata that downstream routing, tooling, and search can consume.

### What's in the frontmatter

```yaml
---
name: {file identifier}
fcp_domain: {one of 4 FCP domains}
fcp_capability: {primary capability}
fcp_capabilities_secondary: [{optional secondary capabilities}]
fcp_phases: [{Inform / Optimize / Operate}]
fcp_personas_primary: [{intended audience}]
fcp_personas_collaborating: [{collaborating audiences}]
fcp_maturity_entry: {Crawl / Walk / Run}
---
```

### Capability mapping summary

| File class | Primary FCP capability |
|---|---|
| AWS / Azure / GCP | Rate Optimization (with Workload Optimization + Data Ingestion as secondary) |
| OCI | Data Ingestion (with Anomaly Management + Workload Optimization as secondary) |
| Anthropic / Bedrock / Azure OpenAI / Vertex AI | Workload Optimization or Rate Optimization (per platform billing model) |
| AI cross-cutting (`for-ai`, `value-management`, `genai-capacity`, `ai-dev-tools`, `self-hosted-vs-managed`) | Vary by focus: Unit Economics, Planning & Estimating, Architecting for Cloud |
| Data platforms (Databricks, Snowflake, Fabric) | Workload Optimization or Rate Optimization |
| `finops-tagging.md` | Allocation (with Policy & Governance secondary) |
| `finops-itam.md` / `finops-sam.md` | Licensing & SaaS |
| `greenops-cloud-carbon.md` | Cloud Sustainability |
| `finops-framework.md` / `optimnow-methodology.md` | FinOps Practice Operations |

### Why this matters

- **Programmatic routing** — future SKILL.md routing logic can filter "load all references where `fcp_capability=Anomaly Management`" without parsing free-form text
- **Maturity gates** — readers (and downstream tools) can check `fcp_maturity_entry` to detect when a reference is premature for their organisation's stage
- **Persona awareness** — `fcp_personas_primary` makes it explicit who each reference is written for, useful when curating subsets for specific audiences
- **Author discipline** — declaring the FCP capability forces a check on whether the file actually serves what it claims to serve
- **Future-proofing for downstream tooling** — agents that consume FCP-aware metadata can route, filter, and surface references more accurately

### Verification

- All 26 reference files now have YAML frontmatter (verified)
- No content changes anywhere; diff is purely additive headers
- No em dashes introduced (CLAUDE.md hard rule)
- 22 files modified (the existing references); the 4 new references already shipped with frontmatter
- Plugin bumped 1.16.0 → 1.17.0
- No marketplace description change (reference file count unchanged at 26)

### Choices made and why

- **No `description` field** in the frontmatter for the existing files. They already have a visible blockquote description on line 3 (after the H1). Adding a frontmatter `description` would be redundant and risks rendering twice in some tools. The 4 new files do have `description` because they were written that way; this inconsistency is acceptable for now and can be normalised later if it matters.
- **No `license` field** — explicitly forbidden by CLAUDE.md (renders as visible text in Claude.ai)
- **`fcp_*` fields are custom** — they are not part of any official Skills spec but follow the convention I used in the new reference files. Downstream tooling that doesn't recognise them ignores them; tooling that does (or will) can use them

## Test plan

- [ ] After merge, verify the skill still loads correctly in Claude Code (frontmatter is YAML; if any file's frontmatter is malformed, the file would fail to load)
- [ ] Smoke test: ask "What's in the OptimNow methodology?" → should still load `optimnow-methodology.md` and respond normally
- [ ] Smoke test: ask "How do AWS Reserved Instances work?" → should still load `finops-aws.md` and respond normally
- [ ] No regression test needed for the new files (they already had this frontmatter on merge)

Generated with Claude Code.
