### PR TITLE
CLAUDE.md: refresh directory listing, add Roadmap section, document FCP frontmatter convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,24 +34,35 @@ cloud-finops-skills/
 ├── cloud-finops/          <- The skill (this is what gets installed)
 │   ├── SKILL.md           <- Entry point + domain router
 │   ├── POWER.md           <- Kiro IDE entry point
-│   └── references/
-│       ├── optimnow-methodology.md
-│       ├── finops-for-ai.md
-│       ├── finops-ai-value-management.md
-│       ├── finops-genai-capacity.md
-│       ├── finops-anthropic.md
-│       ├── finops-aws.md
-│       ├── finops-bedrock.md
-│       ├── finops-azure.md
-│       ├── finops-azure-openai.md
-│       ├── finops-gcp.md
-│       ├── finops-vertexai.md
-│       ├── finops-tagging.md
-│       ├── finops-framework.md
-│       ├── finops-databricks.md
-│       ├── finops-snowflake.md
-│       ├── finops-oci.md
-│       └── greenops-cloud-carbon.md
+│   └── references/        <- 28 reference files, all with YAML FCP frontmatter
+│       ├── optimnow-methodology.md         <- OptimNow reasoning lens, 4 pillars
+│       ├── finops-framework.md             <- FinOps Foundation framework reference
+│       ├── finops-for-ai.md                <- AI cost management discipline
+│       ├── finops-ai-value-management.md   <- AI Investment Council, stage gates
+│       ├── finops-genai-capacity.md        <- Provisioned vs shared capacity
+│       ├── finops-ai-self-hosted-vs-managed.md  <- Self-host vs managed inference
+│       ├── finops-ai-dev-tools.md          <- Cursor / Claude Code / Copilot / Windsurf / Codex
+│       ├── finops-anthropic.md             <- Anthropic billing
+│       ├── finops-aws.md                   <- AWS FinOps + commitment portfolio
+│       ├── finops-bedrock.md               <- AWS Bedrock
+│       ├── finops-azure.md                 <- Azure FinOps + commitment portfolio
+│       ├── finops-azure-openai.md          <- Azure OpenAI / PTUs
+│       ├── finops-gcp.md                   <- GCP FinOps
+│       ├── finops-vertexai.md              <- GCP Vertex AI
+│       ├── finops-oci.md                   <- OCI
+│       ├── finops-databricks.md            <- Databricks (DBCU, allocation)
+│       ├── finops-fabric.md                <- Microsoft Fabric (F-SKU, CU)
+│       ├── finops-snowflake.md             <- Snowflake
+│       ├── finops-tagging.md               <- Tagging governance + MCP automation
+│       ├── finops-itam.md                  <- ITAM / BYOL / marketplace
+│       ├── finops-sam.md                   <- SaaS asset management
+│       ├── greenops-cloud-carbon.md        <- GreenOps + cloud carbon
+│       ├── finops-anomaly-management.md    <- Anomaly management (standalone Inform-phase)
+│       ├── finops-allocation-showback.md   <- Allocation methodology + showback
+│       ├── finops-chargeback.md            <- Chargeback + Finance/accounting prerequisites
+│       ├── finops-onboarding-workloads.md  <- Migration-time cost hygiene + M&A
+│       ├── finops-kubernetes.md            <- K8s cross-cluster discipline (EKS/GKE/AKS)
+│       └── finops-waste-detection-playbooks.md  <- Seven-category waste taxonomy + WasteLine
 └── pipeline/              <- Content update pipeline (gitignored, private)
     ├── run_scan.py        <- Weekly scan entry point
     ├── run_apply.py       <- Review and apply entry point
@@ -78,7 +89,22 @@ reference file. See `pipeline/README.md` for the full workflow.
 
 ---
 
-## Pending follow-ups
+## Roadmap
+
+This section lists work that is intentionally not shipped and the trigger to revisit. It is
+the durable record of "what's deliberately out of scope right now and why" - distinct from
+GitHub issues, which track in-flight work.
+
+### In-flight (write when prerequisites land)
+
+- **WasteLine extension to Azure and GCP.** `finops-waste-detection-playbooks.md` covers the
+  seven-category waste taxonomy and references the WasteLine appliance for AWS automation;
+  Azure and GCP coverage currently routes to the in-cloud pattern catalogues
+  (`finops-azure.md` 48-pattern, `finops-gcp.md` 26-pattern). When WasteLine ships Azure and
+  GCP providers, update the operational tooling section to reflect the broader coverage and
+  remove the "for Azure and GCP, see in-cloud catalogues" caveat.
+
+### Depth passes (extend existing files when bandwidth allows)
 
 - **Extend GreenOps depth to Azure and GCP.** The May 2026 GreenOps pass added AWS-specific
   depth to `references/greenops-cloud-carbon.md` (Sustainability Console v2 with Methodology v3
@@ -96,6 +122,40 @@ reference file. See `pipeline/README.md` for the full workflow.
   - Keep the engagement-framing section vendor-agnostic - it does not need to be duplicated
     per provider. The trade-off tables, four-quadrant cost-vs-carbon framework, and CSRD
     stakeholder roles already apply across all three providers.
+
+### Deferred reference files
+
+These files were identified in the white-space analysis (May 2026) and explicitly deferred,
+with the rationale captured here so future work picks them up at the right moment rather
+than re-litigating priority. Tracking issue: `OptimNow/cloud-finops-skills#55`.
+
+| Proposed file | Priority | Trigger to revisit | Why deferred |
+|---|---|---|---|
+| `finops-tools-services.md` | P2 | Next engagement raises a vendor-evaluation question | OptimNow has implicit views (FinOps Toolkit, MCP, OpenCost) but no formal write-up; better to write against a real client question than a generic checklist |
+| `finops-practice-operations.md` | P2 | Next Walk to Run client engagement starts | `optimnow-methodology.md` covers the consultancy-positioning lens; this would be the operator-grade discipline below it (three-cadence operating model, per-Capability scorecard, allied-discipline integration charter) |
+| `finops-forecasting.md` | P2 | Non-AI forecasting demand emerges | `finops-ai-value-management.md` covers AI forecasting; non-AI demand has not surfaced in current engagements |
+| `finops-unit-economics.md` | P2 | Non-AI unit-economics demand emerges | Same reasoning as forecasting; AI-side covered by AI value management and finops-for-ai files |
+| `finops-education-enablement.md` | P2 | Demand emerges; consider folding into practice-operations | Smaller scope than the other P2 files; could double as a section in practice-operations |
+| `finops-benchmarking.md` | P3 | Client engagement specifically requires it | Clients rarely ask; external benchmarking has well-known data-quality issues. Could be a section in `finops-framework.md` |
+| `finops-cost-warehouse.md` | P3 | Engagement requires it (e.g. Snowflake-FinOps integration) | Heavy lift, specialist content (FOCUS conformed-dim modelling, dbt + semantic layer, CUR2 / Azure Cost Mgmt / BigQuery loading patterns, late-binding analytics) |
+
+When picking up a deferred item: read the rationale above, check the white-space analysis
+context (Cletrics comparison report dated 2026-05-03 in `~/Downloads/`, plus implementation
+plan in `~/.claude/plans/optimnow-cloud-finops-recommendations-followup.md`), and confirm
+the trigger is real before starting the file.
+
+### Closed gaps (May 2026 batch)
+
+These files shipped during the white-space analysis follow-up (PRs #48, #50, #51, #52, #54,
+#56) and now exist in the catalogue. Listed here for the record:
+
+- `finops-anomaly-management.md` (PR #48) - Anomaly Management as standalone Inform capability
+- `finops-allocation-showback.md` (PR #50) - Allocation methodology + showback delivery
+- `finops-chargeback.md` (PR #51) - Chargeback + Finance/accounting prerequisites
+- `finops-onboarding-workloads.md` (PR #52) - Migration-time cost hygiene + M&A
+- `finops-kubernetes.md` (PR #54) - Cross-cluster K8s discipline (EKS/GKE/AKS)
+- `finops-waste-detection-playbooks.md` (PR #56) - Seven-category waste taxonomy + WasteLine
+- YAML FCP frontmatter pass across all 22 pre-existing references (PR #53)
 
 ---
 
@@ -117,12 +177,13 @@ discount mechanics.
 
 ## How to add a new reference file
 
-Follow these four steps whenever you add a new domain:
+Follow these five steps whenever you add a new domain:
 
 1. **Create the reference file** in `cloud-finops/references/`
    - Name it `finops-{domain}.md` (or `{category}-{domain}.md` for non-FinOps topics like `greenops-cloud-carbon.md`)
    - Follow the structure of an existing reference file as a template
    - Include practical guidance, not abstract theory
+   - **Open the file with YAML FCP frontmatter** (see "Reference-file frontmatter" section below)
 
 2. **Add a routing entry in SKILL.md**
    - Add a row to the "Domain routing" table with the query topic and file path
@@ -136,6 +197,45 @@ Follow these four steps whenever you add a new domain:
    - Add a bullet under "What this skill covers"
    - Add the file to the "Directory structure" listing
    - Add usage examples if applicable
+
+5. **Bump the plugin version**
+   - `.claude-plugin/plugin.json` minor version (e.g. 1.19.0 to 1.20.0) for user-visible feature changes
+   - `.claude-plugin/marketplace.json` description (update the reference file count and topic list)
+
+---
+
+## Reference-file frontmatter
+
+All 28 reference files carry YAML FCP frontmatter that maps the file to the FinOps Framework
+Capability it serves. New files must follow the same convention. Minimum schema:
+
+```yaml
+---
+name: {file-identifier}                              # e.g. finops-aws
+fcp_domain: "{one of 4 FCP domains}"                 # Understand Usage & Cost / Quantify Business Value / Optimize Usage & Cost / Manage the FinOps Practice
+fcp_capability: "{primary capability}"               # the capability the file serves first
+fcp_capabilities_secondary: ["{cap}", "{cap}"]       # optional - other capabilities the file touches
+fcp_phases: ["{Inform}" or "{Optimize}" or "{Operate}", ...]   # one or more
+fcp_personas_primary: ["{persona}", ...]             # FinOps Practitioner / Engineering / Finance / Product / Procurement / Leadership / SRE / Platform Engineering / Sustainability / Security / ITAM / etc.
+fcp_personas_collaborating: ["{persona}", ...]       # optional
+fcp_maturity_entry: "Crawl" | "Walk" | "Run"         # the gate below which the file is premature
+---
+```
+
+Why this matters:
+- Programmatic routing (future "load all references where fcp_capability=Anomaly Management"
+  filter is feasible)
+- Maturity gates (downstream tools and readers can detect when a reference is premature for
+  their organisation's stage)
+- Persona awareness (makes it explicit who each reference is written for, useful when
+  curating subsets for specific audiences)
+- Author discipline (declaring the FCP capability forces a check on whether the file
+  actually serves what it claims to serve)
+
+Do **not** add a `description` field to reference-file frontmatter. The visible blockquote
+description on line 3 (after the H1) already serves that role; a frontmatter description
+would render twice in some tools. The exception is `cloud-finops/SKILL.md` which DOES need
+a `description` field for the Claude.ai upload skill loader (see "Content rules" below).
 
 ---
 
@@ -178,9 +278,16 @@ Good test patterns:
 ## Pull request checklist
 
 - [ ] New reference file follows the `finops-{domain}.md` naming convention
+- [ ] YAML FCP frontmatter included on the new file (see "Reference-file frontmatter")
 - [ ] Routing table updated in both SKILL.md and POWER.md
-- [ ] README directory listing and coverage section updated
+- [ ] README directory listing and "What this skill covers" section updated
+- [ ] CLAUDE.md "Repository structure" directory listing updated
+- [ ] Plugin version bumped in `.claude-plugin/plugin.json` (minor for user-visible feature)
+- [ ] Marketplace description in `.claude-plugin/marketplace.json` reflects the new
+      reference file count and topic list
 - [ ] SKILL.md description stays under 1024 characters
 - [ ] No em dashes in any public content
 - [ ] No sensitive or internal files included
 - [ ] Content is practical and based on how billing actually works, not on documentation summaries
+- [ ] If the file deferred or replaced is in the Roadmap section, the Roadmap section is
+      updated accordingly


### PR DESCRIPTION
## Summary

Brings `CLAUDE.md` in line with the current state of the catalogue (28 reference files, all with YAML FCP frontmatter) and adds an explicit **Roadmap** section that documents what's deliberately deferred and the trigger to revisit each item.

The previous CLAUDE.md had a directory listing showing only 17 reference files (out of 28) and a narrow "Pending follow-ups" section that mentioned only the GreenOps Azure/GCP depth pass. The May 2026 batch shipped six new reference files plus a frontmatter pass across all existing references; this PR catches CLAUDE.md up.

### Three coordinated updates

**1. Repository structure**
- Directory listing brought up to date: 17 → 28 reference files
- Each file now has a one-line description in the listing
- Notes that all 28 references carry YAML FCP frontmatter

**2. New Roadmap section** (replaces narrow "Pending follow-ups")

Three subsections, each with explicit revisit triggers:
- **In-flight:** WasteLine extension to Azure and GCP (update the playbooks file's operational-tooling section when the appliance ships those providers)
- **Depth passes:** Extend GreenOps depth to Azure and GCP (preserved verbatim from previous CLAUDE.md; the only existing pending item)
- **Deferred reference files:** table with seven proposed files (P2/P3) and explicit revisit triggers per item, plus rationale for why each was deliberately deferred. Tracks issue #55 for in-flight visibility.
- **Closed gaps:** list of the six new files that shipped in the May 2026 batch (PRs #48, #50, #51, #52, #54, #56) plus the frontmatter pass (#53), for the record

The deferred-files table:

| Proposed file | Priority | Trigger to revisit | Why deferred |
|---|---|---|---|
| `finops-tools-services.md` | P2 | Next engagement raises a vendor-evaluation question | OptimNow has implicit views; better to write against a real client question |
| `finops-practice-operations.md` | P2 | Next Walk → Run client engagement starts | Methodology covers consultancy positioning; this would be operator-grade |
| `finops-forecasting.md` | P2 | Non-AI forecasting demand emerges | AI value management covers the AI case |
| `finops-unit-economics.md` | P2 | Non-AI unit-economics demand emerges | Same reasoning |
| `finops-education-enablement.md` | P2 | Demand emerges; consider folding into practice-operations | Smaller scope than other P2 files |
| `finops-benchmarking.md` | P3 | Client engagement specifically requires it | Clients rarely ask; data-quality issues |
| `finops-cost-warehouse.md` | P3 | Engagement requires it | Heavy lift, specialist content |

**3. Reference-file frontmatter section** (new)

Documents the YAML FCP frontmatter convention every new reference file must follow. Includes:
- The schema (`name`, `fcp_domain`, `fcp_capability`, optional secondary capabilities, phases, primary and collaborating personas, maturity entry)
- The rationale (programmatic routing, maturity gates, persona awareness, author discipline)
- The explicit "do not add `description` field to reference-file frontmatter" rule (mirrors the existing rule for SKILL.md `license`)

### Other updates

- **"How to add a new reference file"** updated from 4 steps to 5 — added the version bump step that has been implicit in recent PRs but never documented explicitly
- **PR checklist** expanded to include: frontmatter check, CLAUDE.md directory listing update, plugin version bump, marketplace description update, roadmap-update check

### What did not change

- The "What this repo is" section is unchanged
- The "Content update pipeline" section is unchanged
- The "Model compatibility" section is unchanged
- The "Content rules" section is unchanged
- The license rules are unchanged
- The "Testing changes" section is unchanged

### Verification

- File: 187 → 293 lines (purely additive and corrective; no content removed)
- No em dashes introduced
- All section headers preserve the existing convention
- Cross-reference to issue #55 included for the deferred items
- Cross-references to PR numbers included for the closed gaps

This update is intentionally not a content change to any reference file — it documents the state and the convention rather than modifying behaviour.

Generated with Claude Code.
