### PR TITLE
Codex follow-up #3: grouped routing, GCP CUD contradiction, AWS Config pattern, cadence wording

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "cloud-finops",
-      "description": "Expert FinOps guidance for cloud, AI, SaaS, and data-platform spend. 28 reference files spanning AWS, Azure, GCP, Anthropic, Bedrock, Azure OpenAI, Vertex AI, Databricks, Microsoft Fabric, Snowflake, OCI, AI coding tools, FinOps Framework 2024+2026, GreenOps (AWS Sustainability Console, CSRD engagement framing), self-hosted vs managed AI inference decisioning, anomaly management, allocation and showback, chargeback (incl. Finance and accounting prerequisites), onboarding workloads (migration-time cost hygiene + M&A), Kubernetes (cross-cluster EKS/GKE/AKS discipline), waste-detection playbooks (seven-category taxonomy backed by OptimNow's WasteLine appliance), SaaS asset management, and ITAM. Open source, model-agnostic, refreshed bi-monthly.",
+      "description": "Expert FinOps guidance for cloud, AI, SaaS, and data-platform spend. 28 reference files spanning AWS, Azure, GCP, Anthropic, Bedrock, Azure OpenAI, Vertex AI, Databricks, Microsoft Fabric, Snowflake, OCI, AI coding tools, FinOps Framework 2024+2026, GreenOps (AWS Sustainability Console, CSRD engagement framing), self-hosted vs managed AI inference decisioning, anomaly management, allocation and showback, chargeback (incl. Finance and accounting prerequisites), onboarding workloads (migration-time cost hygiene + M&A), Kubernetes (cross-cluster EKS/GKE/AKS discipline), waste-detection playbooks (seven-category taxonomy backed by OptimNow's WasteLine appliance), SaaS asset management, and ITAM. Open source, model-agnostic, refreshed twice a month.",
       "author": {
         "name": "OptimNow",
         "url": "https://optimnow.io"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,9 +52,10 @@ sub-modules, see CLAUDE.md.
 
 ## Content update pipeline
 
-The `pipeline/` folder contains a bi-monthly content scanner that detects
-FinOps-relevant changes across 29 sources and proposes updates to the reference
-files. It is gitignored and not part of the public distribution.
+The `pipeline/` folder contains a twice-monthly content scanner (around the 1st
+and the 15th) that detects FinOps-relevant changes across 29 sources and proposes
+updates to the reference files. It is gitignored and not part of the public
+distribution.
 
 The pipeline is human-in-the-loop: nothing is changed automatically. Every
 proposed update goes through review (list, preview diffs, approve/reject) before

--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ with built-in update via `/plugin update`. Two commands at the **Claude Code pro
 /plugin install cloud-finops@optimnow
 ```
 
-To pull the latest content (including the bi-monthly automated updates):
+To pull the latest content (including the twice-monthly automated updates):
 
 ```text
 /plugin update cloud-finops@optimnow
@@ -398,10 +398,11 @@ users who prefer downloading over building locally.
 
 ## This skill is actively maintained
 
-This is a living repository. Reference files are updated on the 15th of every month,
-driven by an automated scan of 29 data sources - cloud provider pricing pages, release
-notes, billing changelogs, and FinOps community publications. Changes are reviewed
-before being applied, so the content reflects verified updates rather than raw feed output.
+This is a living repository. Reference files are refreshed twice a month (around the
+1st and the 15th), driven by an automated scan of 29 data sources - cloud provider
+pricing pages, release notes, billing changelogs, and FinOps community publications.
+Changes are reviewed before being applied, so the content reflects verified updates
+rather than raw feed output.
 
 AI cost management is moving particularly fast - new model releases, capacity options, and
 billing mechanics appear every few weeks. Watch or star this repo to be notified when

--- a/cloud-finops/references/finops-aws.md
+++ b/cloud-finops/references/finops-aws.md
@@ -2489,9 +2489,9 @@ VPC Flow Logs configured with the ALL filter and delivered to CloudWatch Logs of
 - Implement periodic audits of logging configurations to catch overly verbose setups
 
 **Unfiltered Recording Of High Churn Resource Types In Aws Config**
-Service: Inefficiency Type | Type: Explanation
+Service: AWS Config | Type: Inefficient Configuration
 
-By default, AWS Config can be set to record changes across all supported resource types, including those that change frequently, such as security group rules, IAM role policies, route tables, or network interfaces frequent ephemeral resources in containerized or auto-scaling setupsThese high-churn resources can generate an outsized number of configuration items and inflate costs  - especially in dynamic or large-scale environments. This inefficiency arises when recording is enabled indiscriminately across all resources without evaluating whether the data is necessary.
+By default, AWS Config can be set to record changes across all supported resource types, including those that change frequently, such as security group rules, IAM role policies, route tables, or network interfaces - frequent ephemeral resources in containerized or auto-scaling setups. These high-churn resources can generate an outsized number of configuration items and inflate costs - especially in dynamic or large-scale environments. This inefficiency arises when recording is enabled indiscriminately across all resources without evaluating whether the data is necessary.
 
 - Limit AWS Config recording to only essential resource types using resource recording groups
 - Exclude high-churn resource types that provide minimal compliance or operational value

--- a/cloud-finops/references/finops-gcp.md
+++ b/cloud-finops/references/finops-gcp.md
@@ -373,7 +373,7 @@ VM-based Committed Use Discounts in GCP offer cost savings for predictable workl
 
 - Consolidate workloads onto committed VM types where feasible
 - Avoid renewing commitments for workloads that are scaling down or migrating
-- Use Resource-based CUDs when architectural flexibility is needed
+- For workloads where architecture is still evolving, prefer Flexible / spend-based CUDs (Compute Engine Flex CUDs) over Resource-based CUDs - they trade a few percentage points of discount depth for the freedom to move across machine families and regions without stranding commitments. Resource-based CUDs are the right fit only when the workload, family, and region are genuinely stable for the full term.
 
 ---
 

--- a/install.sh
+++ b/install.sh
@@ -270,14 +270,21 @@ install_chatgpt() {
   # Wipe any previous build so renamed/removed references don't linger
   rm -rf "$knowledge_dir"
   mkdir -p "$knowledge_dir"
-  build_chatgpt_instructions > "$instructions_path"
+  if [[ -n "$GROUPED" ]]; then
+    # Grouped build emits a routing contract that points at the 9 grouped
+    # filenames (aws.md, azure.md, ai.md, ...) rather than per-reference names.
+    build_grouped_instructions > "$instructions_path"
+  else
+    build_chatgpt_instructions > "$instructions_path"
+  fi
   local size
   size=$(wc -c < "$instructions_path")
 
   if [[ -n "$GROUPED" ]]; then
-    # Grouped build (default for fresh installs): same domain bundling as Gemini.
-    # Produces 9 knowledge files instead of 27 - well under any historical
-    # ChatGPT Custom GPT cap and easier to upload reliably.
+    # Grouped build: same domain bundling as Gemini. Produces 9 knowledge
+    # files instead of 27 - well under any historical ChatGPT Custom GPT
+    # cap and easier to upload reliably. Routing contract above already
+    # points at the grouped filenames.
     build_gemini_grouped_knowledge "$knowledge_dir"
   else
     # Per-reference build: one knowledge file per reference, methodology merged
@@ -404,6 +411,63 @@ Source: https://github.com/OptimNow/cloud-finops-skills
 EOF
 }
 
+build_grouped_instructions() {
+  cat <<'EOF'
+# Cloud FinOps Expert Assistant
+
+You are an expert FinOps practitioner. Help users understand and optimise spend on cloud (AWS / Azure / GCP / OCI), AI platforms (Anthropic, Bedrock, Azure OpenAI / Foundry, Vertex AI), data platforms (Databricks, Microsoft Fabric, Snowflake), AI coding tools (Cursor, Claude Code, Copilot, Codex, Windsurf, Gemini Code Assist), SaaS, and cross-cutting concerns (tagging, FinOps Framework, GreenOps, ITAM, anomaly management, allocation/showback, chargeback, onboarding, Kubernetes, waste detection).
+
+Your knowledge files are grouped thematically. Always retrieve the relevant grouped file before answering - do not rely on general training data for billing specifics.
+
+## Domain routing (grouped layout)
+
+Use these knowledge files for the following query types:
+
+| Query topic | Knowledge file |
+|---|---|
+| AWS cost management, EC2, RIs, Savings Plans, EDP, RDS, Bedrock pricing, Application Inference Profiles | aws.md |
+| Azure cost management, Reservations, Savings Plans, AHB, MACC, AKS, MCA, Azure OpenAI / Foundry PTUs | azure.md |
+| GCP cost management, BigQuery export, CUDs, SUDs, Spot, Carbon Footprint, Vertex AI, Gemini pricing | gcp.md |
+| AI cost management, LLM economics, agentic patterns, ROI, Anthropic billing, AI coding tools (Cursor / Copilot / Claude Code / Codex / Windsurf), GenAI capacity, AI Investment Council, self-hosted vs managed inference | ai.md |
+| Databricks (DBCU, allocation, Photon), Microsoft Fabric (F-SKUs, CU smoothing), Snowflake (QUERY_ATTRIBUTION_HISTORY, Cortex) | data-platforms.md |
+| OCI (Cost Reports, FOCUS, cost-tracking tags, Universal Credits) | oci.md |
+| FinOps Framework (4 domains 2024 + Executive Strategy Alignment 2026), tagging, SaaS management, ITAM, GreenOps, Kubernetes FinOps, waste detection playbooks | cross-cutting.md |
+| Anomaly management, allocation and showback, chargeback (incl. Finance / accounting prerequisites), onboarding workloads (migration-time cost hygiene + M&A) | finops-discipline.md |
+| Reasoning methodology lens (diagnose before prescribing, connect cost to value, recommend progressively) | methodology.md |
+
+For multi-domain queries, retrieve all relevant grouped files and synthesise.
+
+## Reasoning sequence
+
+1. Apply the methodology lens (methodology.md): diagnose before prescribing, connect cost to value, recommend progressively.
+2. Retrieve the grouped knowledge file(s) matching the query.
+3. Diagnose before prescribing - ask about the organisation's current state if missing.
+4. Connect cost recommendations to business outcomes.
+5. Recommend progressively - quick wins first, structural changes second.
+6. Reference open-source FinOps tools (FinOps Toolkit, OpenCost, Kubecost, Infracost, etc.) where they fit.
+
+## Response format
+
+Structure substantive answers with these headers:
+- **Context** - what the user told you, what assumptions you're making
+- **Recommendation** - the actionable advice
+- **Metrics and signals** - what to measure or watch
+- **Business impact** - how this connects to outcomes (cost saved, risk reduced, capability unlocked)
+
+For brief factual questions, skip the structure. Use it for advisory or strategy questions.
+
+## Maturity awareness
+
+Always assess maturity before recommending solutions. A Crawl organisation (cost allocation <50%) needs visibility before optimisation. Recommending commitment discounts to an org with poor allocation creates committed waste.
+
+## Source
+
+Cloud FinOps Skill by OptimNow (https://optimnow.io). Licensed CC BY-SA 4.0.
+Source: https://github.com/OptimNow/cloud-finops-skills
+EOF
+}
+
+
 install_gemini() {
   local outdir="${DEST_OVERRIDE:-$PWD}/dist/gemini"
   local instructions_path="$outdir/instructions.md"
@@ -418,8 +482,10 @@ install_gemini() {
   # Wipe any previous build so renamed/removed references don't linger
   rm -rf "$knowledge_dir"
   mkdir -p "$knowledge_dir"
-  # Same instructions content as ChatGPT - same cross-LLM contract
-  build_chatgpt_instructions > "$instructions_path"
+  # Gemini always uses the grouped knowledge layout, so the routing contract
+  # must point at the grouped filenames - not the per-reference names that
+  # the ChatGPT default uses.
+  build_grouped_instructions > "$instructions_path"
   build_gemini_grouped_knowledge "$knowledge_dir"
 
   local file_count


### PR DESCRIPTION
## Summary
Four findings from the third Codex audit, all addressed:

- **[P1] Grouped builds shipped routing for files that do not exist** ([install.sh:421-423](install.sh:421)). Gemini and `--grouped` ChatGPT both produced grouped knowledge files (aws.md, azure.md, ai.md, ...) but emitted the per-reference routing contract telling the model to retrieve `finops-aws.md`, `finops-bedrock.md`, etc. Added `build_grouped_instructions` whose routing table points at the 9 grouped filenames; `install_gemini` always uses it, `install_chatgpt` uses it with `--grouped`.
- **[P2] GCP CUD recommendation contradicted the same reference** ([finops-gcp.md:369-376](cloud-finops/references/finops-gcp.md:369)). Pattern said "Use Resource-based CUDs when architectural flexibility is needed" - the opposite of the file's main guidance. Reversed to recommend Flexible / spend-based CUDs when architecture is still evolving.
- **[P3] AWS pattern had generated placeholder metadata** ([finops-aws.md:2491-2494](cloud-finops/references/finops-aws.md:2491)). "Service: Inefficiency Type | Type: Explanation" replaced with "Service: AWS Config | Type: Inefficient Configuration"; "setupsThese" run-on fixed.
- **[P3] Maintenance cadence ambiguous across distribution docs** ([README.md:374-401](README.md:374)). "bi-monthly" (ambiguous: twice a month or every two months?) replaced with "twice a month (around the 1st and 15th)" everywhere public-facing (README, AGENTS.md, marketplace.json).

## Test plan
- [x] `grep -c "^build_grouped_instructions" install.sh` = 1
- [x] Gemini path always emits grouped instructions; ChatGPT path emits grouped only with --grouped
- [x] `grep "Resource-based CUDs when architectural flexibility" cloud-finops/references/finops-gcp.md` = 0
- [x] `grep "Service: Inefficiency Type\|setupsThese" cloud-finops/references/finops-aws.md` = 0
- [x] `grep -i "bi-monthly" README.md AGENTS.md .claude-plugin/marketplace.json` = 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)