### PR TITLE
Codex follow-up #4: ChatGPT cap path, cadence in instructions, grouped validation, markdown artefacts

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -111,8 +111,11 @@ Builds two artefacts in `dist/chatgpt/`:
   `optimnow-methodology.md` is **merged into `finops-for-ai.md`**). ChatGPT
   historically capped Custom GPT Knowledge at 20 files. If your upload is
   rejected, drop the references that are least relevant to your use case, or
-  switch to the Gemini-style grouped build (`./install.sh --tool gemini`) which
-  packs everything into 9 grouped files.
+  re-run the installer with the grouped flag:
+  `./install.sh --tool chatgpt --grouped`. The grouped build still writes to
+  `dist/chatgpt/` (so all the upload steps below still apply) but emits a
+  9-file thematic bundle with a routing contract that points at the grouped
+  filenames.
 
 Then manually:
 
@@ -307,11 +310,12 @@ already covers the major FinOps query types.
 the limit. If it does, manually trim the routing table to only the providers you care
 about, or upload the trimmed routing as a knowledge file and keep instructions minimal.
 
-**ChatGPT rejects the knowledge upload (file count):** the build currently produces 27
+**ChatGPT rejects the knowledge upload (file count):** the default build produces 27
 knowledge files (methodology merged into `finops-for-ai.md`). If ChatGPT enforces a
-lower cap, either drop the references least relevant to your use case, or use the
-Gemini-style grouped build (`./install.sh --tool gemini`) which packs the same content
-into 9 files.
+lower cap, either drop the references least relevant to your use case, or re-run with
+the grouped flag: `./install.sh --tool chatgpt --grouped`. The grouped build packs the
+same content into 9 thematic files in `dist/chatgpt/` and emits a matching routing
+contract.
 
 **Token budget exceeded on system-prompt injection:** load only the domain references
 relevant to your query. For most use cases, `SKILL.md` + 1-2 references is enough.

--- a/cloud-finops/references/finops-aws.md
+++ b/cloud-finops/references/finops-aws.md
@@ -1217,7 +1217,7 @@ Some Lambda functions perform synchronous calls to other services, APIs, or inte
 **Idle Ecs Container Instances Due To Asg Minimum Capacity**
 Service: AWS ECS | Type: Inefficient Configuration
 
-When ECS clusters are configured with an Auto Scaling Group that maintains a minimum number of EC2 instances (e.g., min = 1 or higher), the instances remain active even when there are no tasks scheduled. This leads to idle compute capacity and unnecessary EC2 charges.Instead, ECS Capacity Providers support target tracking scaling policies that can scale the ASG to zero when idle and automatically increase capacity when new tasks or services are scheduled.
+When ECS clusters are configured with an Auto Scaling Group that maintains a minimum number of EC2 instances (e.g., min = 1 or higher), the instances remain active even when there are no tasks scheduled. This leads to idle compute capacity and unnecessary EC2 charges. Instead, ECS Capacity Providers support target tracking scaling policies that can scale the ASG to zero when idle and automatically increase capacity when new tasks or services are scheduled.
 
 - Configure an ECS Capacity Provider for the cluster and attach a target tracking scaling policy
 - Set the ASG minimum capacity to 0 to allow scale-down during idle periods
@@ -1271,7 +1271,7 @@ When the EC2 instance types used for EKS node groups have a memory-to-CPU ratio 
 **Inefficient Workflow Design In Aws Step Functions**
 Service: AWS Step Functions | Type: Misconfiguration
 
-Improper design choices in AWS Step Functions can lead to unnecessary charges. For example: * Using Standard Workflows for short-lived, high-frequency executions leads to excessive per-transition charges.
+Improper design choices in AWS Step Functions can lead to unnecessary charges. For example, using Standard Workflows for short-lived, high-frequency executions leads to excessive per-transition charges, while complex workflows with many state transitions multiply per-transition cost across the lifetime of the application.
 
 - Choose Express workflows for short-lived, high-volume executions
 - Use Standard workflows for long-running, infrequent executions
@@ -2223,7 +2223,7 @@ Many workloads default to using Redis or Memcached without evaluating whether a 
 **Non Graviton Elasticache Node On Eligible Workload**
 Service: AWS ElastiCache | Type: Suboptimal Instance Family Selection
 
-Many Redis and Memcached clusters still use legacy x86-based node types (e.g., cache.r5, cache.m5) even though Graviton-based alternatives are available. In-memory workloads tend to be highly compatible with Graviton due to their simplicity and reliance on standard CPU and memory usage patterns.Unless constrained by architecture-specific extensions or strict compliance requirements, most ElastiCache clusters can be transitioned with no application-level changes.
+Many Redis and Memcached clusters still use legacy x86-based node types (e.g., cache.r5, cache.m5) even though Graviton-based alternatives are available. In-memory workloads tend to be highly compatible with Graviton due to their simplicity and reliance on standard CPU and memory usage patterns. Unless constrained by architecture-specific extensions or strict compliance requirements, most ElastiCache clusters can be transitioned with no application-level changes.
 
 - Switch node types to cache.r6g, cache.m6g, or cache.t4g equivalents
 - Update provisioning logic to default to Graviton families for new clusters
@@ -2232,7 +2232,7 @@ Many Redis and Memcached clusters still use legacy x86-based node types (e.g., c
 **Non Graviton Rds Instance On Eligible Workload**
 Service: AWS RDS | Type: Suboptimal Instance Family Selection
 
-Many RDS workloads continue to run on older x86 instance types (e.g., db.m5, db.r5) even though compatible Graviton-based options (e.g., db.m6g, db.r6g) are widely available. These newer families deliver improved performance per vCPU and lower hourly costs, yet are often not adopted due to legacy defaults, inertia, or lack of awareness.When workloads are not tightly bound to architecture-specific extensions (e.g., x86-specific binaries or drivers), switching to Graviton typically requires no application changes and results in immediate savings.
+Many RDS workloads continue to run on older x86 instance types (e.g., db.m5, db.r5) even though compatible Graviton-based options (e.g., db.m6g, db.r6g) are widely available. These newer families deliver improved performance per vCPU and lower hourly costs, yet are often not adopted due to legacy defaults, inertia, or lack of awareness. When workloads are not tightly bound to architecture-specific extensions (e.g., x86-specific binaries or drivers), switching to Graviton typically requires no application changes and results in immediate savings.
 
 - Evaluate performance requirements and test Graviton-backed RDS instances in staging
 - Modify instance class to a db.*g Graviton-based equivalent (e.g., db.r6g.large)
@@ -2536,7 +2536,7 @@ Spot Instances are designed to be short-lived, with frequent interruptions and r
 **Duplicate Or Overlapping Aws Cloudtrail Trails**
 Service: AWS CloudTrail | Type: Redundant Configuration
 
-AWS CloudTrail enables event logging across AWS services, but when multiple trails are configured to log overlapping events  - especially data events  - it can result in redundant charges and unnecessary storage or ingestion costs. This commonly occurs in decentralized environments where teams create trails independently, unaware of existing coverage or shared logging destinations.Each trail that records data events contributes to billing on a per-event basis, even if the same activity is logged by multiple trails.
+AWS CloudTrail enables event logging across AWS services, but when multiple trails are configured to log overlapping events - especially data events - it can result in redundant charges and unnecessary storage or ingestion costs. This commonly occurs in decentralised environments where teams create trails independently, unaware of existing coverage or shared logging destinations. Each trail that records data events contributes to billing on a per-event basis, even if the same activity is logged by multiple trails.
 
 - Delete or disable redundant trails that provide no unique audit or compliance value
 - Consolidate overlapping trails into a single unified configuration where feasible

--- a/cloud-finops/references/finops-gcp.md
+++ b/cloud-finops/references/finops-gcp.md
@@ -458,7 +458,17 @@ Highly compressible datasets, such as those with repeated string fields, nested 
 **Excessive Data Scanned Due To Unpartitioned Tables In Bigquery**
 Service: GCP BigQuery | Type: Suboptimal Configuration
 
-If a table is not partitioned by a relevant column (typically a timestamp), every query scans the entire dataset, even if filtering by date. This leads to: * High costs per query * Long execution times * Inefficient use of resources when querying recent or small subsets of data This inefficiency is especially common in: * Event or log data stored in raw, unpartitioned form Historical data migrations without schema optimization * Workloads developed without awareness of BigQuery’s scanning model.
+If a table is not partitioned by a relevant column (typically a timestamp), every query scans the entire dataset, even if filtering by date. This leads to:
+
+- High costs per query
+- Long execution times
+- Inefficient use of resources when querying recent or small subsets of data
+
+This inefficiency is especially common in:
+
+- Event or log data stored in raw, unpartitioned form
+- Historical data migrations without schema optimisation
+- Workloads developed without awareness of BigQuery's scanning model
 
 - Enable time-based partitioning on large fact or event tables
 - Retrofit existing tables with ingestion- or column-based partitioning

--- a/install.sh
+++ b/install.sh
@@ -343,7 +343,7 @@ build_chatgpt_instructions() {
 
 You are an expert FinOps practitioner. Help users understand and optimise spend on cloud (AWS / Azure / GCP / OCI), AI platforms (Anthropic, Bedrock, Azure OpenAI / Foundry, Vertex AI), data platforms (Databricks, Microsoft Fabric, Snowflake), AI coding tools (Cursor, Claude Code, Copilot, Codex, Windsurf, Gemini Code Assist), SaaS, and cross-cutting concerns (tagging, FinOps Framework, GreenOps, ITAM).
 
-Your knowledge files contain accurate, current billing mechanics and optimisation patterns refreshed bi-monthly. Always retrieve relevant knowledge files before answering - do not rely on general training data for billing specifics.
+Your knowledge files contain accurate, current billing mechanics and optimisation patterns refreshed twice a month (around the 1st and the 15th). Always retrieve relevant knowledge files before answering - do not rely on general training data for billing specifics.
 
 ## Domain routing
 
@@ -417,7 +417,7 @@ build_grouped_instructions() {
 
 You are an expert FinOps practitioner. Help users understand and optimise spend on cloud (AWS / Azure / GCP / OCI), AI platforms (Anthropic, Bedrock, Azure OpenAI / Foundry, Vertex AI), data platforms (Databricks, Microsoft Fabric, Snowflake), AI coding tools (Cursor, Claude Code, Copilot, Codex, Windsurf, Gemini Code Assist), SaaS, and cross-cutting concerns (tagging, FinOps Framework, GreenOps, ITAM, anomaly management, allocation/showback, chargeback, onboarding, Kubernetes, waste detection).
 
-Your knowledge files are grouped thematically. Always retrieve the relevant grouped file before answering - do not rely on general training data for billing specifics.
+Your knowledge files are grouped thematically and refreshed twice a month (around the 1st and the 15th). Always retrieve the relevant grouped file before answering - do not rely on general training data for billing specifics.
 
 ## Domain routing (grouped layout)
 
@@ -499,20 +499,47 @@ install_gemini() {
 build_gemini_grouped_knowledge() {
   local outdir="$1"
   local refs="$SRC_DIR/cloud-finops/references"
-  cat "$refs/finops-aws.md" "$refs/finops-bedrock.md" 2>/dev/null > "$outdir/aws.md"
-  cat "$refs/finops-azure.md" "$refs/finops-azure-openai.md" 2>/dev/null > "$outdir/azure.md"
-  cat "$refs/finops-gcp.md" "$refs/finops-vertexai.md" 2>/dev/null > "$outdir/gcp.md"
-  cat "$refs/finops-for-ai.md" "$refs/finops-anthropic.md" "$refs/finops-ai-dev-tools.md" \
-      "$refs/finops-genai-capacity.md" "$refs/finops-ai-value-management.md" \
-      "$refs/finops-ai-self-hosted-vs-managed.md" 2>/dev/null > "$outdir/ai.md"
-  cat "$refs/finops-databricks.md" "$refs/finops-fabric.md" "$refs/finops-snowflake.md" 2>/dev/null > "$outdir/data-platforms.md"
-  [[ -f "$refs/finops-oci.md" ]] && cp "$refs/finops-oci.md" "$outdir/oci.md"
-  cat "$refs/finops-framework.md" "$refs/finops-tagging.md" "$refs/finops-sam.md" \
-      "$refs/finops-itam.md" "$refs/greenops-cloud-carbon.md" \
-      "$refs/finops-kubernetes.md" "$refs/finops-waste-detection-playbooks.md" 2>/dev/null > "$outdir/cross-cutting.md"
-  cat "$refs/finops-anomaly-management.md" "$refs/finops-allocation-showback.md" \
-      "$refs/finops-chargeback.md" "$refs/finops-onboarding-workloads.md" 2>/dev/null > "$outdir/finops-discipline.md"
-  [[ -f "$refs/optimnow-methodology.md" ]] && cp "$refs/optimnow-methodology.md" "$outdir/methodology.md"
+
+  # cat_required <output> <input1> [<input2> ...]
+  # Concatenates the inputs into the output. Fails loudly if any input is
+  # missing - silent omission would let a renamed reference disappear from a
+  # grouped artefact without the maintainer noticing, defeating the purpose
+  # of the grouped build as a fallback path for capped uploads.
+  cat_required() {
+    local out="$1"; shift
+    local f
+    for f in "$@"; do
+      if [[ ! -f "$f" ]]; then
+        err "build_gemini_grouped_knowledge: missing input '$f' for $(basename "$out")"
+        return 1
+      fi
+    done
+    cat "$@" > "$out"
+  }
+
+  cat_required "$outdir/aws.md" \
+    "$refs/finops-aws.md" "$refs/finops-bedrock.md"
+  cat_required "$outdir/azure.md" \
+    "$refs/finops-azure.md" "$refs/finops-azure-openai.md"
+  cat_required "$outdir/gcp.md" \
+    "$refs/finops-gcp.md" "$refs/finops-vertexai.md"
+  cat_required "$outdir/ai.md" \
+    "$refs/finops-for-ai.md" "$refs/finops-anthropic.md" "$refs/finops-ai-dev-tools.md" \
+    "$refs/finops-genai-capacity.md" "$refs/finops-ai-value-management.md" \
+    "$refs/finops-ai-self-hosted-vs-managed.md"
+  cat_required "$outdir/data-platforms.md" \
+    "$refs/finops-databricks.md" "$refs/finops-fabric.md" "$refs/finops-snowflake.md"
+  cat_required "$outdir/oci.md" \
+    "$refs/finops-oci.md"
+  cat_required "$outdir/cross-cutting.md" \
+    "$refs/finops-framework.md" "$refs/finops-tagging.md" "$refs/finops-sam.md" \
+    "$refs/finops-itam.md" "$refs/greenops-cloud-carbon.md" \
+    "$refs/finops-kubernetes.md" "$refs/finops-waste-detection-playbooks.md"
+  cat_required "$outdir/finops-discipline.md" \
+    "$refs/finops-anomaly-management.md" "$refs/finops-allocation-showback.md" \
+    "$refs/finops-chargeback.md" "$refs/finops-onboarding-workloads.md"
+  cat_required "$outdir/methodology.md" \
+    "$refs/optimnow-methodology.md"
 }
 
 install_gemini_cli() {


### PR DESCRIPTION
## Summary
Five findings from the post-PR-#64 Codex audit, all addressed:

- **[P2] ChatGPT cap path** ([INSTALLATION.md:110-115](INSTALLATION.md:110)). Capped users were told to switch to `./install.sh --tool gemini`, which writes to `dist/gemini/` and emits Gemini upload steps - confusing because the surrounding section is about `dist/chatgpt/`. Replaced with the correct command: `./install.sh --tool chatgpt --grouped` (which writes to `dist/chatgpt/` with the 9-file thematic bundle and matching routing contract). Fixed in both the per-tool section and the troubleshooting block.
- **[P3] Cadence wording in generated instructions** ([install.sh:344-346](install.sh:344)). Both `build_chatgpt_instructions` and `build_grouped_instructions` embedded the old "refreshed bi-monthly" wording in the assistant instructions, while public docs had moved to "twice a month (around the 1st and 15th)". Aligned both inline blocks.
- **[P3] Grouped build silent omission** ([install.sh:502-514](install.sh:502)). `build_gemini_grouped_knowledge` suppressed `cat` errors with `2>/dev/null`, so a renamed source would disappear from a grouped artefact without failing the build. Replaced with a `cat_required` helper that validates every expected input and fails loudly with a named error otherwise.
- **[P3] GCP catalogue malformed bullets** ([finops-gcp.md:458-461](cloud-finops/references/finops-gcp.md:458)). BigQuery unpartitioned-tables pattern had collapsed inline bullets (`This leads to: * High costs * Long execution times`) and a run-on list of examples. Reformatted as proper Markdown bullet lists.
- **[P3] AWS catalogue generated-text artefacts** ([finops-aws.md:1217-1220](cloud-finops/references/finops-aws.md:1217)). Four run-on sentences with missing spaces (`charges.Instead`, `patterns.Unless`, `awareness.When`, `destinations.Each`) and one inline `For example: * Using` bullet pattern. Cleaned up; also fixed minor US-spelling drift in the same paragraphs.

## Test plan
- [x] `grep -c "tool gemini" INSTALLATION.md` only matches the legitimate `--tool gemini` block (not the cap path)
- [x] `grep -c "bi-monthly" install.sh` = 0
- [x] `grep -c "cat_required" install.sh` = 11 (one helper definition + 9 invocations + 1 reference in the comment)
- [x] `grep -nE "[a-z]\.[A-Z][a-z]" cloud-finops/references/finops-aws.md` returns no run-on sentences
- [x] `grep -c "leads to: \*\|including: \*\|example: \*" cloud-finops/references/finops-gcp.md` = 0
- [x] `grep -c "leads to: \*\|including: \*\|example: \*" cloud-finops/references/finops-aws.md` = 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)