### PR TITLE
Codex follow-up #6: playbooks in ChatGPT/Gemini builds + Azure feature accuracy + concat README skip

### DIFF
--- a/cloud-finops/playbooks/azure-app-service-overprovisioned.md
+++ b/cloud-finops/playbooks/azure-app-service-overprovisioned.md
@@ -62,13 +62,20 @@ AzureMetrics
 ## Fix
 
 1. **Right-size SKU first.** Compare the workload's actual feature use
-   against the SKU's feature set:
-   - P1v3 -> S1 typically saves $60-90/month per instance, but loses
-     Premium-only features (deployment slots count, VNet integration,
-     larger autoscale ceiling). Validate the app does not depend on any.
-   - P1v3 -> P0v3 stays in Premium tier (preserves all Premium features)
+   against the SKU's feature set. The big tier-jump trade-offs are:
+   - P1v3 -> S1 typically saves $60-90/month per instance. Standard
+     keeps deployment slots (5 vs Premium v3's 20), keeps regional VNet
+     integration, keeps custom domains and SSL, keeps daily backups.
+     What it loses: the larger autoscale ceiling (Standard caps at 10
+     instances vs Premium v3 at 30), private endpoint support on the
+     plan itself, the v3 generation's per-vCPU performance gain,
+     zone-redundant deployments, and the higher memory ratio. Validate
+     against the app's real ceiling needs and security posture, not
+     against an assumed Premium-only feature list.
+   - P1v3 -> P0v3 stays in Premium v3 tier (preserves all Premium v3
+     features including the higher autoscale ceiling and zone redundancy)
      and saves roughly $70/month per instance via halving the vCPU /
-     memory footprint - the right move when the app needs Premium
+     memory footprint - the right move when the app needs Premium v3
      features but not the headroom.
    - P1v3 -> P1v2 (older Premium generation) is rarely the right move
      because v3 is faster per-vCPU and the per-month delta is small.

--- a/install.sh
+++ b/install.sh
@@ -110,7 +110,13 @@ write_concat_body() {
     echo "## Playbooks"
     echo
     for pb in "$SRC_DIR/cloud-finops/playbooks"/*.md; do
-      echo "### playbooks/$(basename "$pb")"
+      local pb_name
+      pb_name=$(basename "$pb")
+      # Skip the directory's own README - it documents the format /
+      # convention for human contributors, not a runbook the model
+      # should retrieve as a pattern.
+      [[ "$pb_name" == "README.md" ]] && continue
+      echo "### playbooks/$pb_name"
       echo
       cat "$pb"
       echo
@@ -326,6 +332,18 @@ install_chatgpt() {
         cp "$ref" "$knowledge_dir/$name"
       fi
     done
+    # Playbooks: SKILL.md routes named-pattern queries to playbooks/<slug>.md,
+    # so each playbook must be uploadable as a knowledge file too. Prefix
+    # the filename so they group together in the GPT Knowledge UI and don't
+    # collide with reference filenames.
+    if [[ -d "$SRC_DIR/cloud-finops/playbooks" ]]; then
+      for pb in "$SRC_DIR/cloud-finops/playbooks"/*.md; do
+        local pb_name
+        pb_name=$(basename "$pb")
+        [[ "$pb_name" == "README.md" ]] && continue
+        cp "$pb" "$knowledge_dir/playbook-$pb_name"
+      done
+    fi
   fi
 
   local file_count
@@ -338,7 +356,7 @@ install_chatgpt() {
   fi
   if [[ $file_count -gt 20 ]]; then
     warn "ChatGPT historically capped Custom GPT Knowledge at 20 files. Current build is $file_count files."
-    dim "  If your upload is rejected, re-run with --grouped to produce a 9-file"
+    dim "  If your upload is rejected, re-run with --grouped to produce a smaller"
     dim "  bundled build (same content, fewer files): ./install.sh --tool chatgpt --grouped"
   fi
   dim "  Manual upload steps:"
@@ -346,10 +364,11 @@ install_chatgpt() {
   dim "    2. Paste $instructions_path into the Instructions field"
   dim "    3. Upload all files from $knowledge_dir/ to Knowledge"
   if [[ -z "$GROUPED" ]]; then
-    dim "    4. Note: methodology is merged into finops-for-ai.md to keep file count down"
+    dim "    4. Note: methodology is merged into finops-for-ai.md to keep file count down."
+    dim "       Playbook files are prefixed playbook-* so they sort together in the GPT UI."
   else
-    dim "    4. Grouped mode: 9 thematic files (aws, azure, gcp, ai, data-platforms,"
-    dim "       oci, cross-cutting, finops-discipline, methodology)"
+    dim "    4. Grouped mode: 10 thematic files (aws, azure, gcp, ai, data-platforms,"
+    dim "       oci, cross-cutting, finops-discipline, playbooks, methodology)"
   fi
 }
 
@@ -394,8 +413,10 @@ Use these knowledge files for the following query types:
 | Onboarding workloads, migration-time cost hygiene, intake gate, 60-90 day forecast-then-commit rule, double-bubble cost, M&A integration | finops-onboarding-workloads.md |
 | Kubernetes FinOps (EKS / GKE / AKS), OpenCost / Kubecost, FOCUS-emitting K8s allocation, container rightsizing, Karpenter, Spot diversification | finops-kubernetes.md |
 | Waste detection playbooks, seven-category waste taxonomy, two-signal classification, WasteLine appliance | finops-waste-detection-playbooks.md |
+| Named waste pattern (zombie NAT, snapshot sprawl, idle ELB, cross-AZ egress, oversized RDS, orphan EBS, orphan Azure disks, App Service overprovisioning, Log Analytics ingestion sprawl, idle Azure SQL, idle GKE Autopilot, orphan Persistent Disks, Cloud Functions cold starts, schedule blindness, untagged spend drift) | playbook-<slug>.md (e.g. playbook-aws-zombie-nat-gateway.md) |
 
-For multi-domain queries, retrieve all relevant files and synthesise.
+For multi-domain queries, retrieve all relevant files and synthesise. For named
+waste patterns, retrieve the matching `playbook-<slug>.md` knowledge file.
 
 ## Reasoning sequence
 
@@ -449,9 +470,12 @@ Use these knowledge files for the following query types:
 | OCI (Cost Reports, FOCUS, cost-tracking tags, Universal Credits) | oci.md |
 | FinOps Framework (4 domains 2024 + Executive Strategy Alignment 2026), tagging, SaaS management, ITAM, GreenOps, Kubernetes FinOps, waste detection playbooks | cross-cutting.md |
 | Anomaly management, allocation and showback, chargeback (incl. Finance / accounting prerequisites), onboarding workloads (migration-time cost hygiene + M&A) | finops-discipline.md |
+| Named waste pattern (zombie NAT, snapshot sprawl, idle ELB, cross-AZ egress, oversized RDS, orphan EBS, orphan Azure disks, App Service overprovisioning, Log Analytics ingestion sprawl, idle Azure SQL, idle GKE Autopilot, orphan Persistent Disks, Cloud Functions cold starts, schedule blindness, untagged spend drift) | playbooks.md |
 | Reasoning methodology lens (diagnose before prescribing, connect cost to value, recommend progressively) | methodology.md |
 
-For multi-domain queries, retrieve all relevant grouped files and synthesise.
+For multi-domain queries, retrieve all relevant grouped files and synthesise. For
+named waste patterns, look up the matching `## playbook: <slug>` section inside
+`playbooks.md`.
 
 ## Reasoning sequence
 
@@ -556,6 +580,35 @@ build_gemini_grouped_knowledge() {
     "$refs/finops-chargeback.md" "$refs/finops-onboarding-workloads.md"
   cat_required "$outdir/methodology.md" \
     "$refs/optimnow-methodology.md"
+
+  # Playbooks bundle: SKILL.md routes named-pattern queries to
+  # playbooks/<slug>.md, so the grouped artefact must include the
+  # playbook content too. Bundled into a single playbooks.md to keep
+  # the grouped layout's 1-bundle-per-domain shape.
+  local playbooks="$SRC_DIR/cloud-finops/playbooks"
+  if [[ -d "$playbooks" ]]; then
+    {
+      echo "# Cloud FinOps Playbooks Bundle"
+      echo
+      echo "Each section below is a self-contained named-pattern runbook."
+      echo "When SKILL.md routes a 'named waste pattern X' query to"
+      echo "\`playbooks/<slug>.md\`, look up the section here whose title"
+      echo "matches the slug."
+      echo
+      for pb in "$playbooks"/*.md; do
+        local pb_name
+        pb_name=$(basename "$pb")
+        # README.md is the format / contributor guide, not a runbook
+        [[ "$pb_name" == "README.md" ]] && continue
+        echo "---"
+        echo
+        echo "## playbook: ${pb_name%.md}"
+        echo
+        cat "$pb"
+        echo
+      done
+    } > "$outdir/playbooks.md"
+  fi
 }
 
 install_gemini_cli() {


### PR DESCRIPTION
## Summary

Three findings from the post-PR-#66 Codex audit, all addressed:

- **[P2] ChatGPT/Gemini builds did not embed playbooks** ([install.sh:299-309](install.sh:299)). The previous fix added playbooks to concat installs (Cursor/Windsurf/Codex/Aider/Copilot) and to the API loader example, but missed the two web RAG paths. Now:
  - **ChatGPT per-reference build** copies every playbook into `dist/chatgpt/knowledge/` with a `playbook-<slug>.md` filename prefix. Total: 27 references + 15 playbooks = 42 knowledge files. Routing table in `build_chatgpt_instructions` gains a row for named patterns.
  - **Gemini grouped build** emits a new `playbooks.md` bundle (10 grouped files now, with `## playbook: <slug>` sections). Routing table in `build_grouped_instructions` gains a row pointing named patterns at it.

- **[P2] azure-app-service playbook overstated S1 feature loss** ([azure-app-service-overprovisioned.md:66-68](cloud-finops/playbooks/azure-app-service-overprovisioned.md:66)). Microsoft documents deployment slots and VNet integration from Standard upward, not Premium-only. The previous fix would have blocked legitimate P1v3 -> S1 right-sizing. Rewrote the trade-off to name the actual losses: smaller autoscale ceiling (10 vs 30 instances), no plan-level private endpoint support, the v3 per-vCPU performance gain, zone-redundant deployments, higher memory ratio.

- **[P3] write_concat_body included `playbooks/README.md`** ([install.sh:108-114](install.sh:108)). The new playbook loop iterated `*.md` blindly, embedding the format / contributor guide as if it were a runbook. The API loader excludes README.md; the bash concat now does too.

## Test plan
- [x] `bash install.sh --tool chatgpt --dest /tmp/...` -> 42 knowledge files (27 ref + 15 playbook-*), no README leak
- [x] `bash install.sh --tool gemini --dest /tmp/...` -> 10 grouped files including `playbooks.md` (1520 lines)
- [x] `bash install.sh --tool cursor --dest /tmp/...` -> 15 `### playbooks/` entries, 0 README content
- [x] `grep -c "playbooks.md\|playbook-<slug>" install.sh` finds the routing rows in both per-reference and grouped instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)