### PR TITLE
Codex follow-up #7 (PR A: quick fixes): zip, install.sh help, cadence, broken placeholders

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,8 @@ cloud-finops-skills/
 
 ## Content update pipeline
 
-The `pipeline/` folder contains a weekly content scanner that detects FinOps-relevant
+The `pipeline/` folder contains a twice-monthly content scanner (around the 1st
+and 15th) that detects FinOps-relevant
 changes across 29 sources and proposes updates to the reference files. It is gitignored
 and not part of the public distribution.
 
@@ -286,7 +287,9 @@ GitHub issues, which track in-flight work.
   for ChatGPT / Gemini / generic LLM retrieval. Routing rule to add to SKILL.md and
   POWER.md: "named waste pattern X -> `playbooks/X.md`". Drift risk to manage: changes
   to a pattern must be applied in both places, or the reference file should be updated
-  to reference the playbook by `[file](path)` instead of duplicating the content.
+  to reference the playbook by an inline Markdown link (e.g.
+  `[aws-zombie-nat-gateway](../playbooks/aws-zombie-nat-gateway.md)`) instead of
+  duplicating the content.
 
 - **FCP coverage matrix tooling.** Adapt the approach from Cletrics' `fcp-coverage.sh`:
   a small bash script that parses `fcp_domain` / `fcp_capability` /

--- a/cloud-finops/playbooks/README.md
+++ b/cloud-finops/playbooks/README.md
@@ -86,8 +86,9 @@ drift, the recommended workflow is:
    playbook
 3. When a pattern's *core economics* change (e.g. AWS halves NAT Gateway
    pricing), update both - the reference file's pattern catalogue entry
-   should ideally `[link to the playbook](path)` rather than repeat all
-   the detail
+   should ideally link to the matching playbook (e.g.
+   `[aws-zombie-nat-gateway](../playbooks/aws-zombie-nat-gateway.md)`)
+   rather than repeat all the detail
 
 The `cloud-finops/references/finops-waste-detection-playbooks.md` file is
 the canonical taxonomy and confidence rubric; playbooks instantiate it.

--- a/install.sh
+++ b/install.sh
@@ -9,9 +9,9 @@
 #   ./install.sh --list                List supported tools
 #   ./install.sh --dry-run             Print what would happen, no writes
 #   ./install.sh --user                Install at user-level paths where supported (Claude Code)
-#   ./install.sh --grouped             ChatGPT only: produce a 9-file grouped build
+#   ./install.sh --grouped             ChatGPT only: produce a 10-file grouped build
 #                                      (same content bundled by domain) instead of
-#                                      27 per-reference files. Easier to upload.
+#                                      42 per-reference files. Easier to upload.
 #   ./install.sh --dest <dir>          Override the project / target directory
 #   ./install.sh --help                Show this help
 #


### PR DESCRIPTION
## Summary

PR A of three from the latest Codex audit - the mechanical batch.

- **[P1] cloud-finops.zip at repo root deleted** ([cloud-finops.zip]). The file was gitignored but present locally (30 .backups, 21 references, no playbooks). Anyone who uploaded it instead of the version-tagged release zip would get an incomplete and stale skill.
- **[P2] install.sh --help text** ([install.sh:12-14](install.sh:12)) said "9-file grouped build / 27 per-reference files". Updated to match the current build output: **10 / 42**. INSTALLATION.md was already correct; only the inline `--help` block was stale.
- **CLAUDE.md cadence** said "weekly content scanner". Aligned with everything else: "twice-monthly content scanner (around the 1st and 15th)".
- **pipeline/README.md FROZEN block** added at the top so a maintainer reading the file in their checkout sees the freeze status and the pointer to Roadmap > P1 for the un-freeze plan. Note: pipeline/ is gitignored so this change is local-only and not in this PR's diff.
- **Two broken `[file](path)` / `[link to the playbook](path)` placeholders** in CLAUDE.md and cloud-finops/playbooks/README.md replaced with concrete examples that resolve to real files.

PRs B and C (FCP 2026 taxonomy migration, pricing/Anthropic refresh) are separate and need editorial work against fresh primary sources.

## Test plan
- [x] `[ -f cloud-finops.zip ]` returns false (zip deleted from local disk)
- [x] `grep -c "9-file\|27 per-reference" install.sh` = 0 (stale help text gone)
- [x] `grep -c "weekly content scanner" CLAUDE.md` = 0 (cadence aligned)
- [x] `grep -nE "\[file\]\(path\)|\[link to the playbook\]\(path\)" *.md cloud-finops/playbooks/README.md` returns no matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)