### PR TITLE
FCP coverage: fix false negatives (Budgeting + Automation Tools) + ESA deliberately not covering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -298,11 +298,13 @@ GitHub issues, which track in-flight work.
   them. Adds three benefits: (1) honesty signal vis-a-vis the framework - the matrix
   computes coverage from the actual repo, not from claims; (2) PR check - new
   references with a non-canonical capability or a missing frontmatter trip the script;
-  (3) Roadmap-driven view - the matrix shows which capabilities are deferred (currently
-  Budgeting, KPIs & Benchmarking, Executive Strategy Alignment, FinOps Education &
-  Enablement, and Automation Tools & Services) so the gap is auto-rendered, not buried
-  in this Roadmap section. Trigger to build: shipped in PR #64 and migrated to the
-  2026 taxonomy in the FCP-2026 follow-up PR.
+  (3) Roadmap-driven view - the matrix shows which capabilities have no primary owner
+  yet. Current true gaps after the frontmatter-truth pass: KPIs & Benchmarking,
+  Executive Strategy Alignment, FinOps Education & Enablement (all in the deferred
+  table below). Budgeting and Automation Tools & Services were initially flagged
+  as gaps but are covered dispersed - the matrix now renders them as `[~]`
+  secondary-only after the frontmatter was updated to reflect that reality (PR
+  following the FCP-2026 migration).
 
 - **Public Custom GPT for ChatGPT users.** The current ChatGPT install path is
   self-host: `./install.sh --tool chatgpt --grouped` produces 10 grouped knowledge
@@ -359,6 +361,25 @@ than re-litigating priority. Tracking issue: `OptimNow/cloud-finops-skills#55`.
 | `finops-education-enablement.md` | P2 | Demand emerges; consider folding into practice-operations | Smaller scope than the other P2 files; could double as a section in practice-operations |
 | `finops-benchmarking.md` | P3 | Client engagement specifically requires it | Clients rarely ask; external benchmarking has well-known data-quality issues. Could be a section in `finops-framework.md` |
 | `finops-cost-warehouse.md` | P3 | Engagement requires it (e.g. Snowflake-FinOps integration) | Heavy lift, specialist content (FOCUS conformed-dim modelling, dbt + semantic layer, CUR2 / Azure Cost Mgmt / BigQuery loading patterns, late-binding analytics) |
+| `finops-executive-strategy-alignment.md` | **Will not write** | (no trigger - deliberately not covering) | The 2026 FCP added "Executive Strategy Alignment" as a capability. The OptimNow doctrine ("connect cost to business value", the CFO test) already covers the practitioner-grade version of executive engagement; the FCP framing reads as a positioning concept rather than an operating discipline. If a client engagement specifically asks for the FCP-aligned executive-strategy artefact, it can be written then; the Roadmap-default position is not to ship it as a separate reference. |
+
+**Note on Budgeting**: Budgeting is NOT a deferred capability. It is covered as a
+secondary in `finops-anomaly-management.md`, `finops-allocation-showback.md`,
+`finops-chargeback.md`, and `finops-onboarding-workloads.md` because each of
+those files has a substantive Budgeting section (AWS Budgets, Azure Budgets and
+Alerts, GCP budget anomaly alerts, OCI Budgets, Snowflake Budgets, Databricks
+budget policies, AI investment budgets, the 60-90 day forecast-then-commit rule
+at intake, the soft-to-hard chargeback budget enforcement). The FCP coverage
+matrix renders Budgeting as `[~]` (any-coverage via secondary) rather than
+`[ ]` (true gap) once the frontmatter declares it. There is no plan to ship a
+dedicated `finops-budgeting.md` because the cross-cutting nature of budgeting
+is better served by the dispersed coverage.
+
+**Note on Automation, Tools & Services**: same shape as Budgeting. Covered as
+secondary in `finops-tagging.md` (MCP automation, IaC enforcement) and
+`finops-waste-detection-playbooks.md` (WasteLine appliance). Plus the
+`finops-tools-services.md` deferred entry above which would be the dedicated
+write-up if engagement demand emerges.
 
 When picking up a deferred item: read the rationale above, check the white-space analysis
 context (Cletrics comparison report dated 2026-05-03 in `~/Downloads/`, plus implementation

--- a/cloud-finops/references/finops-allocation-showback.md
+++ b/cloud-finops/references/finops-allocation-showback.md
@@ -2,7 +2,7 @@
 name: finops-allocation-showback
 fcp_domain: "Understand Usage & Cost"
 fcp_capability: "Allocation"
-fcp_capabilities_secondary: ["Reporting & Analytics"]
+fcp_capabilities_secondary: ["Reporting & Analytics", "Budgeting"]
 fcp_phases: ["Inform"]
 fcp_personas_primary: ["FinOps Practitioner"]
 fcp_personas_collaborating: ["Engineering", "Finance"]

--- a/cloud-finops/references/finops-anomaly-management.md
+++ b/cloud-finops/references/finops-anomaly-management.md
@@ -2,6 +2,7 @@
 name: finops-anomaly-management
 fcp_domain: "Understand Usage & Cost"
 fcp_capability: "Anomaly Management"
+fcp_capabilities_secondary: ["Budgeting"]
 fcp_phases: ["Inform", "Operate"]
 fcp_personas_primary: ["FinOps Practitioner"]
 fcp_personas_collaborating: ["Engineering", "Finance", "Security"]

--- a/cloud-finops/references/finops-chargeback.md
+++ b/cloud-finops/references/finops-chargeback.md
@@ -2,6 +2,7 @@
 name: finops-chargeback
 fcp_domain: "Manage the FinOps Practice"
 fcp_capability: "Invoicing & Chargeback"
+fcp_capabilities_secondary: ["Budgeting"]
 fcp_phases: ["Operate"]
 fcp_personas_primary: ["FinOps Practitioner"]
 fcp_personas_collaborating: ["Finance", "Leadership", "Tax", "Internal Audit"]

--- a/cloud-finops/references/finops-onboarding-workloads.md
+++ b/cloud-finops/references/finops-onboarding-workloads.md
@@ -2,7 +2,7 @@
 name: finops-onboarding-workloads
 fcp_domain: "Optimize Usage & Cost"
 fcp_capability: "Architecting & Workload Placement"
-fcp_capabilities_secondary: ["Allocation", "FinOps Practice Operations"]
+fcp_capabilities_secondary: ["Allocation", "FinOps Practice Operations", "Budgeting"]
 fcp_phases: ["Inform", "Operate"]
 fcp_personas_primary: ["FinOps Practitioner", "Engineering"]
 fcp_personas_collaborating: ["Finance", "Procurement", "Leadership"]

--- a/cloud-finops/references/finops-tagging.md
+++ b/cloud-finops/references/finops-tagging.md
@@ -2,7 +2,7 @@
 name: finops-tagging
 fcp_domain: "Understand Usage & Cost"
 fcp_capability: "Allocation"
-fcp_capabilities_secondary: ["Governance, Policy & Risk"]
+fcp_capabilities_secondary: ["Governance, Policy & Risk", "Automation, Tools & Services"]
 fcp_phases: ["Inform", "Operate"]
 fcp_personas_primary: ["FinOps Practitioner", "Engineering"]
 fcp_personas_collaborating: ["Security", "Finance"]

--- a/cloud-finops/references/finops-waste-detection-playbooks.md
+++ b/cloud-finops/references/finops-waste-detection-playbooks.md
@@ -2,7 +2,7 @@
 name: finops-waste-detection-playbooks
 fcp_domain: "Optimize Usage & Cost"
 fcp_capability: "Usage Optimization"
-fcp_capabilities_secondary: ["Anomaly Management", "Architecting & Workload Placement"]
+fcp_capabilities_secondary: ["Anomaly Management", "Architecting & Workload Placement", "Automation, Tools & Services"]
 fcp_phases: ["Optimize", "Operate"]
 fcp_personas_primary: ["FinOps Practitioner", "Engineering"]
 fcp_personas_collaborating: ["Finance", "SRE"]

--- a/fcp-coverage.md
+++ b/fcp-coverage.md
@@ -24,7 +24,7 @@ Marker legend:
 
 - [x] **Planning & Estimating** - finops-ai-value-management.md
 - [~] **Forecasting** _(secondary: finops-ai-value-management.md)_
-- [ ] **Budgeting** - **GAP** (see Roadmap in CLAUDE.md for deferred capabilities)
+- [~] **Budgeting** _(secondary: finops-allocation-showback.md; finops-anomaly-management.md; finops-chargeback.md; finops-onboarding-workloads.md)_
 - [ ] **KPIs & Benchmarking** - **GAP** (see Roadmap in CLAUDE.md for deferred capabilities)
 - [x] **Unit Economics** - finops-for-ai.md
 
@@ -44,15 +44,15 @@ Marker legend:
 - [ ] **FinOps Education & Enablement** - **GAP** (see Roadmap in CLAUDE.md for deferred capabilities)
 - [x] **Invoicing & Chargeback** - finops-chargeback.md
 - [~] **FinOps Assessment** _(secondary: finops-framework.md)_
-- [ ] **Automation, Tools & Services** - **GAP** (see Roadmap in CLAUDE.md for deferred capabilities)
+- [~] **Automation, Tools & Services** _(secondary: finops-tagging.md; finops-waste-detection-playbooks.md)_
 - [~] **Intersecting Disciplines** _(secondary: finops-itam.md)_
 
 ---
 
 **Primary coverage**: 12 / 22 (54%) - capabilities with at least one reference whose `fcp_capability` is the primary classification.
 
-**Any-coverage** (primary OR secondary): 17 / 22 (77%) - includes 5 capabilities marked `[~]` that are touched by another reference's `fcp_capabilities_secondary` but have no primary owner yet.
+**Any-coverage** (primary OR secondary): 19 / 22 (86%) - includes 7 capabilities marked `[~]` that are touched by another reference's `fcp_capabilities_secondary` but have no primary owner yet.
 
-**True gaps** (no primary AND no secondary): 5. These are tracked in the Roadmap section of CLAUDE.md with rationale and trigger-to-revisit.
+**True gaps** (no primary AND no secondary): 3. These are tracked in the Roadmap section of CLAUDE.md with rationale and trigger-to-revisit.
 
 _Legacy summary line (do not rely on this for scripting): **Coverage: 12 / 22 Framework Capabilities (54%)**_


### PR DESCRIPTION
## Summary

The matrix had two false negatives because frontmatters did not declare what the file content already covered. Plus a third gap (Executive Strategy Alignment) that should be marked as a deliberate non-write rather than as a deferred item awaiting trigger.

**Budgeting** - dispersed across 9 files with dedicated H3 sections (AWS Budgets, Azure Budgets, GCP budget anomaly alerts, OCI Budgets, Snowflake Budgets, Databricks budget policies, AI investment budgets, the 60-90 day forecast-then-commit rule at intake, soft-to-hard chargeback enforcement). Now declared as secondary in: finops-anomaly-management.md, finops-allocation-showback.md, finops-chargeback.md, finops-onboarding-workloads.md.

**Automation, Tools & Services** - dispersed (MCP automation in tagging, WasteLine in waste-detection, FinOps Toolkit + OpenCost throughout). Now declared as secondary in: finops-tagging.md, finops-waste-detection-playbooks.md.

**Executive Strategy Alignment** - added to the Deferred reference files table in CLAUDE.md with `Will not write` priority. The OptimNow doctrine ("connect cost to business value", the CFO test) already covers the practitioner-grade version of executive engagement. The FCP framing reads as a positioning concept rather than an operating discipline.

## Coverage matrix delta
- Primary coverage: 12/22 (54%) **unchanged** - we are not creating new files
- Any-coverage: 17/22 → **19/22 (86%)** - +2 from secondary additions
- True gaps: 5 → **3** (KPIs & Benchmarking, Executive Strategy Alignment, FinOps Education & Enablement). All three documented in Roadmap with explicit rationale.

## Test plan
- [x] `bash scripts/fcp-coverage.sh` runs cleanly, produces 19/22 any-coverage
- [x] `grep -h "^fcp_capabilities_secondary:" cloud-finops/references/*.md | grep -c "Budgeting"` = 4
- [x] `grep -h "^fcp_capabilities_secondary:" cloud-finops/references/*.md | grep -c "Automation, Tools"` = 2
- [x] CLAUDE.md Deferred files table has the ESA "Will not write" row + the Budgeting / Automation notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)