### PR TITLE
FCP coverage finition: declare Forecasting + Reporting & Analytics where covered dispersed

### DIFF
--- a/cloud-finops/references/finops-aws.md
+++ b/cloud-finops/references/finops-aws.md
@@ -2,7 +2,7 @@
 name: finops-aws
 fcp_domain: "Optimize Usage & Cost"
 fcp_capability: "Rate Optimization"
-fcp_capabilities_secondary: ["Usage Optimization", "Data Ingestion"]
+fcp_capabilities_secondary: ["Usage Optimization", "Data Ingestion", "Reporting & Analytics"]
 fcp_phases: ["Optimize", "Operate"]
 fcp_personas_primary: ["FinOps Practitioner", "Engineering"]
 fcp_personas_collaborating: ["Finance", "Procurement"]

--- a/cloud-finops/references/finops-azure.md
+++ b/cloud-finops/references/finops-azure.md
@@ -2,7 +2,7 @@
 name: finops-azure
 fcp_domain: "Optimize Usage & Cost"
 fcp_capability: "Rate Optimization"
-fcp_capabilities_secondary: ["Usage Optimization", "Data Ingestion"]
+fcp_capabilities_secondary: ["Usage Optimization", "Data Ingestion", "Reporting & Analytics"]
 fcp_phases: ["Optimize", "Operate"]
 fcp_personas_primary: ["FinOps Practitioner", "Engineering"]
 fcp_personas_collaborating: ["Finance", "Procurement"]

--- a/cloud-finops/references/finops-gcp.md
+++ b/cloud-finops/references/finops-gcp.md
@@ -2,7 +2,7 @@
 name: finops-gcp
 fcp_domain: "Optimize Usage & Cost"
 fcp_capability: "Rate Optimization"
-fcp_capabilities_secondary: ["Usage Optimization", "Data Ingestion"]
+fcp_capabilities_secondary: ["Usage Optimization", "Data Ingestion", "Reporting & Analytics"]
 fcp_phases: ["Optimize", "Operate"]
 fcp_personas_primary: ["FinOps Practitioner", "Engineering"]
 fcp_personas_collaborating: ["Finance", "Procurement"]

--- a/cloud-finops/references/finops-onboarding-workloads.md
+++ b/cloud-finops/references/finops-onboarding-workloads.md
@@ -2,7 +2,7 @@
 name: finops-onboarding-workloads
 fcp_domain: "Optimize Usage & Cost"
 fcp_capability: "Architecting & Workload Placement"
-fcp_capabilities_secondary: ["Allocation", "FinOps Practice Operations", "Budgeting"]
+fcp_capabilities_secondary: ["Allocation", "FinOps Practice Operations", "Budgeting", "Forecasting"]
 fcp_phases: ["Inform", "Operate"]
 fcp_personas_primary: ["FinOps Practitioner", "Engineering"]
 fcp_personas_collaborating: ["Finance", "Procurement", "Leadership"]

--- a/fcp-coverage.md
+++ b/fcp-coverage.md
@@ -17,13 +17,13 @@ Marker legend:
 
 - [x] **Data Ingestion** - finops-oci.md _(secondary: finops-aws.md; finops-azure.md; finops-gcp.md)_
 - [x] **Allocation** - finops-allocation-showback.md; finops-kubernetes.md; finops-tagging.md _(secondary: finops-ai-dev-tools.md; finops-databricks.md; finops-for-ai.md; finops-onboarding-workloads.md)_
-- [~] **Reporting & Analytics** _(secondary: finops-allocation-showback.md)_
+- [~] **Reporting & Analytics** _(secondary: finops-allocation-showback.md; finops-aws.md; finops-azure.md; finops-gcp.md)_
 - [x] **Anomaly Management** - finops-anomaly-management.md _(secondary: finops-oci.md; finops-waste-detection-playbooks.md)_
 
 ## Quantify Business Value
 
 - [x] **Planning & Estimating** - finops-ai-value-management.md
-- [~] **Forecasting** _(secondary: finops-ai-value-management.md)_
+- [~] **Forecasting** _(secondary: finops-ai-value-management.md; finops-onboarding-workloads.md)_
 - [~] **Budgeting** _(secondary: finops-allocation-showback.md; finops-anomaly-management.md; finops-chargeback.md; finops-onboarding-workloads.md)_
 - [ ] **KPIs & Benchmarking** - **GAP** (see Roadmap in CLAUDE.md for deferred capabilities)
 - [x] **Unit Economics** - finops-for-ai.md


### PR DESCRIPTION
## Summary

Mini follow-up to PR #73. Two more honest false-negative corrections, same shape (frontmatter declares what content already does, no new files):

- **Forecasting** added as secondary in `finops-onboarding-workloads.md`. The file has the 60-90 day forecast-then-commit rule AND the migration-cost-estimate-vs-actuals trap - both substantive forecasting content.
- **Reporting & Analytics** added as secondary in `finops-aws.md`, `finops-azure.md`, `finops-gcp.md`. Each has substantive reporting sections (AWS Cost Explorer, Azure Cost Management reports, GCP BigQuery reporting + Cloud Billing console).

## Coverage matrix delta
Aggregate counts **unchanged** - both capabilities were already `[~]` secondary-only so the gap totals don't shift. What changes is the displayed list of references next to each capability:
- Reporting & Analytics: was `(secondary: finops-allocation-showback.md)`, now `(secondary: finops-allocation-showback.md; finops-aws.md; finops-azure.md; finops-gcp.md)`
- Forecasting: was `(secondary: finops-ai-value-management.md)`, now `(secondary: finops-ai-value-management.md; finops-onboarding-workloads.md)`

The matrix is now an accurate map of coverage, not just an accurate count.

## Test plan
- [x] `bash scripts/fcp-coverage.sh` runs cleanly, totals unchanged (12/22 primary, 19/22 any-coverage, 3 true gaps)
- [x] Reporting & Analytics row lists 4 secondaries
- [x] Forecasting row lists 2 secondaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)