### PR TITLE
Codex follow-up #8: help truncation, llms.txt paths, Copilot AI Credits, AWS cross-account exports + plugin 1.20.0 bump

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloud-finops",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "Expert FinOps guidance for cloud, AI, SaaS, and data-platform spend (multi-provider, model-agnostic).",
   "author": {
     "name": "OptimNow",

--- a/cloud-finops/references/finops-ai-dev-tools.md
+++ b/cloud-finops/references/finops-ai-dev-tools.md
@@ -255,6 +255,20 @@ billing.
 
 Overage charges apply at $0.04 per premium request beyond the monthly allocation.
 
+**Imminent change - GitHub AI Credits (1 June 2026).** GitHub is moving Copilot
+overage from a fixed-rate `$0.04 per premium request` to **usage-based billing in
+GitHub AI Credits**. After 1 June 2026, requests are priced per their underlying
+model token cost (with the provider margin baked into the credit rate) rather
+than at the flat $0.04. This is a material shift for FinOps teams running
+Copilot at scale: cost forecasts based on the historical $0.04 rate will drift
+once developers route to higher-cost models (Claude Sonnet, GPT-5 family) where
+the credit price exceeds the legacy flat rate. Recommendations: (1) capture the
+last 90 days of premium-request volume per developer and project the AI Credits
+spend at the new rates before 1 June, (2) review Copilot model-routing defaults
+and Enterprise admin controls before the cutover, (3) validate that procurement
+budgets allow for variable usage-based billing in the relevant tax / cost-centre
+structure. Source: https://docs.github.com/en/copilot/how-tos/manage-and-track-spending/prepare-for-your-move-to-usage-based-billing
+
 Enterprise total cost of ownership is $60/seat/month when including the required GitHub
 Enterprise Cloud subscription - a detail that often surprises procurement.
 

--- a/cloud-finops/references/finops-aws.md
+++ b/cloud-finops/references/finops-aws.md
@@ -54,7 +54,23 @@ generally available - the canonical path for FOCUS-conformant cost data on AWS.
   FOCUS 1.2 preview export and GCP's FOCUS export, enabling true cross-cloud
   normalisation in a single warehouse.
 
-Source: https://aws.amazon.com/about-aws/whats-new/2025/11/aws-data-exports-focus-1-2-available/
+**Cross-account delivery (March 2026, GA).** AWS Data Exports now supports
+delivery directly to an S3 bucket in a different (authorised) account. This is
+the path AWS-native landing zones and centralised FinOps warehouses have been
+asking for: payer accounts can publish FOCUS 1.2 / CUR 2.0 exports straight into
+the FinOps team's analytics account without an intermediate copy step or a
+cross-account replication rule. Configure via the destination bucket policy on
+the receiving side and the export configuration on the source side.
+- Removes the previous "copy from payer S3 to analytics S3" pipeline that many
+  organisations had to operate themselves.
+- Simplifies the IAM model: one bucket policy on the analytics side rather than
+  per-payer-account IAM roles.
+- Especially useful for organisations that consolidate billing across multiple
+  AWS Organizations (M&A integrations, multi-payer setups, partner-resold
+  accounts).
+
+Sources: https://aws.amazon.com/about-aws/whats-new/2025/11/aws-data-exports-focus-1-2-available/
+and https://aws.amazon.com/about-aws/whats-new/2026/03/aws-data-exports-cross-account-delivery-cost/
 
 **Common CUR analysis queries (Athena):**
 ```sql

--- a/install.sh
+++ b/install.sh
@@ -60,7 +60,7 @@ trap cleanup EXIT
 # ---- helpers ----
 
 usage() {
-  sed -n '3,18p' "$0" | sed 's/^# \?//'
+  sed -n '3,25p' "$0" | sed 's/^# \?//'
   exit 0
 }
 

--- a/llms.txt
+++ b/llms.txt
@@ -15,37 +15,37 @@ infrastructure. Copy the files into your agent's context and it gains FinOps exp
 
 ## Key files
 
-- SKILL.md: Entry point and domain router for Claude Code and generic agents
-- POWER.md: Entry point for Kiro IDE
+- cloud-finops/SKILL.md: Entry point and domain router for Claude Code and generic agents
+- cloud-finops/POWER.md: Entry point for Kiro IDE
 - INSTALLATION.md: cross-tool installer covering 11 tool integrations + model-agnostic response contract
-- references/optimnow-methodology.md: Reasoning philosophy (read first on every query)
-- references/finops-for-ai.md: AI cost management, token economics, agentic patterns
-- references/finops-ai-value-management.md: AI investment governance, stage gates
-- references/finops-genai-capacity.md: Provisioned vs shared capacity, cross-provider
-- references/finops-ai-self-hosted-vs-managed.md: Self-hosted vs managed AI inference decisioning
-- references/finops-ai-dev-tools.md: AI coding tools (Cursor, Claude Code, Copilot, Codex, Windsurf)
-- references/finops-anthropic.md: Anthropic/Claude billing and governance
-- references/finops-aws.md: AWS FinOps (EC2, CUR, Savings Plans, cost allocation)
-- references/finops-bedrock.md: AWS Bedrock billing and optimisation
-- references/finops-azure.md: Azure FinOps (reservations, policies, hybrid benefit)
-- references/finops-azure-openai.md: Azure OpenAI Service (PTUs, spillover, costs)
-- references/finops-gcp.md: GCP FinOps (Compute, BigQuery, networking)
-- references/finops-vertexai.md: GCP Vertex AI billing and optimisation
-- references/finops-tagging.md: Tagging governance and naming conventions
-- references/finops-framework.md: FinOps Foundation framework and maturity model
-- references/finops-databricks.md: Databricks cost optimisation, allocation, DBCU commitments
-- references/finops-fabric.md: Microsoft Fabric capacity FinOps (F-SKU, CU smoothing)
-- references/finops-snowflake.md: Snowflake cost optimisation
-- references/finops-oci.md: Oracle Cloud Infrastructure optimisation
-- references/finops-sam.md: SaaS asset management
-- references/finops-itam.md: ITAM collaboration (BYOL, marketplace, vendor co-management)
-- references/greenops-cloud-carbon.md: Cloud carbon measurement and GreenOps
-- references/finops-anomaly-management.md: Cost anomaly management as standalone capability
-- references/finops-allocation-showback.md: Cost allocation methodology and showback
-- references/finops-chargeback.md: Chargeback maturity, Finance/accounting prerequisites
-- references/finops-onboarding-workloads.md: Migration-time cost hygiene, M&A integration
-- references/finops-kubernetes.md: Kubernetes FinOps (EKS / GKE / AKS) cross-cluster discipline
-- references/finops-waste-detection-playbooks.md: Seven-category waste taxonomy + WasteLine
+- cloud-finops/references/optimnow-methodology.md: Reasoning philosophy (read first on every query)
+- cloud-finops/references/finops-for-ai.md: AI cost management, token economics, agentic patterns
+- cloud-finops/references/finops-ai-value-management.md: AI investment governance, stage gates
+- cloud-finops/references/finops-genai-capacity.md: Provisioned vs shared capacity, cross-provider
+- cloud-finops/references/finops-ai-self-hosted-vs-managed.md: Self-hosted vs managed AI inference decisioning
+- cloud-finops/references/finops-ai-dev-tools.md: AI coding tools (Cursor, Claude Code, Copilot, Codex, Windsurf)
+- cloud-finops/references/finops-anthropic.md: Anthropic/Claude billing and governance
+- cloud-finops/references/finops-aws.md: AWS FinOps (EC2, CUR, Savings Plans, cost allocation)
+- cloud-finops/references/finops-bedrock.md: AWS Bedrock billing and optimisation
+- cloud-finops/references/finops-azure.md: Azure FinOps (reservations, policies, hybrid benefit)
+- cloud-finops/references/finops-azure-openai.md: Azure OpenAI Service (PTUs, spillover, costs)
+- cloud-finops/references/finops-gcp.md: GCP FinOps (Compute, BigQuery, networking)
+- cloud-finops/references/finops-vertexai.md: GCP Vertex AI billing and optimisation
+- cloud-finops/references/finops-tagging.md: Tagging governance and naming conventions
+- cloud-finops/references/finops-framework.md: FinOps Foundation framework and maturity model
+- cloud-finops/references/finops-databricks.md: Databricks cost optimisation, allocation, DBCU commitments
+- cloud-finops/references/finops-fabric.md: Microsoft Fabric capacity FinOps (F-SKU, CU smoothing)
+- cloud-finops/references/finops-snowflake.md: Snowflake cost optimisation
+- cloud-finops/references/finops-oci.md: Oracle Cloud Infrastructure optimisation
+- cloud-finops/references/finops-sam.md: SaaS asset management
+- cloud-finops/references/finops-itam.md: ITAM collaboration (BYOL, marketplace, vendor co-management)
+- cloud-finops/references/greenops-cloud-carbon.md: Cloud carbon measurement and GreenOps
+- cloud-finops/references/finops-anomaly-management.md: Cost anomaly management as standalone capability
+- cloud-finops/references/finops-allocation-showback.md: Cost allocation methodology and showback
+- cloud-finops/references/finops-chargeback.md: Chargeback maturity, Finance/accounting prerequisites
+- cloud-finops/references/finops-onboarding-workloads.md: Migration-time cost hygiene, M&A integration
+- cloud-finops/references/finops-kubernetes.md: Kubernetes FinOps (EKS / GKE / AKS) cross-cluster discipline
+- cloud-finops/references/finops-waste-detection-playbooks.md: Seven-category waste taxonomy + WasteLine
 
 ## Built by
 


### PR DESCRIPTION
## Summary

Five P2 fixes plus the P1 plugin version bump. After this merges I will tag v1.20.0 to trigger the release workflow and publish the up-to-date zip (the latest release is v1.12 from April; main has 6 references, 15 playbooks, and the FCP 2026 migration since then).

- **[P2] install.sh `--help` truncation** ([install.sh:62-64](install.sh:62)). `usage()` printed only lines 3-18 of the comment header, but the supported-tools list continues to line 19. The output stopped after "gemini," and dropped 5 tools. Extended sed range to lines 3-25.
- **[P2] llms.txt paths** ([llms.txt:18-21](llms.txt:18)). The file sat at repo root but listed `SKILL.md`, `POWER.md`, `references/...` as if also at root. Prefixed entry-point and reference lines with `cloud-finops/` so cross-agent discovery resolves.
- **[P2] Copilot AI Credits transition (1 June 2026)** ([finops-ai-dev-tools.md:256](cloud-finops/references/finops-ai-dev-tools.md:256)). Added an "Imminent change" block describing the shift from flat $0.04/premium-request overage to GitHub AI Credits usage-based billing, with three concrete pre-cutover recommendations and the official source.
- **[P2] AWS cross-account Data Exports (March 2026 GA)** ([finops-aws.md:41-55](cloud-finops/references/finops-aws.md:41)). New sub-section on cross-account delivery (FOCUS 1.2 / CUR 2.0 directly into a different authorised account's S3). Removes the previous "copy from payer S3 to analytics S3" workaround. Matters for landing zones and multi-payer organisations.
- **[P2] Pipeline test_classifier.py** - `_classify_single` signature changed when production switched to a cached references system block. Patched 5 call sites in the test to pass `""` for the new `reference_files_block` parameter. 7/7 tests now pass. Pipeline is gitignored so this fix is local-only and not in this PR's diff.
- **[P1] plugin.json bumped 1.19.0 → 1.20.0**. Reflects 6 new references + 15 playbooks + FCP 2026 migration + install path fixes + cosmetic cleanup since the last release tag v1.12.

## Test plan
- [x] `bash install.sh --help` now lists all 11 tools (gemini-cli, codex, aider, copilot, kiro included)
- [x] `grep -c "cloud-finops/SKILL.md\|cloud-finops/POWER.md\|cloud-finops/references" llms.txt` matches every entry-point/reference line
- [x] `python -m pytest pipeline/tests/test_classifier.py` passes 7/7
- [x] After merge, push tag `v1.20.0` to trigger `.github/workflows/release.yml` and produce `cloud-finops-v1.20.0.zip`

🤖 Generated with [Claude Code](https://claude.com/claude-code)