### PR TITLE
Self-review fixes: 4 issues caught by deep audit (snowflake space, README cadence regression, 2026 wording, detect_copilot false positive)

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ in any of the layers below.
 - Vendor marketing material restated as fact, without a primary source or
   practitioner-grade evidence behind the claim.
 - Wholesale AI-generated reference content with no human practitioner pass.
-  The pipeline that powers the bi-monthly refresh has hard guard rails (see
+  The pipeline that powers the twice-monthly refresh has hard guard rails (see
   the `Lessons learned` section of `CLAUDE.md` for why). Hand-written
   contributions go through human review for the same reasons.
 - "Best practices" lists with no business-value framing. Every recommendation

--- a/cloud-finops/POWER.md
+++ b/cloud-finops/POWER.md
@@ -232,7 +232,7 @@ matching the query.
 
 ## Core FinOps principles (always apply)
 
-These six principles from the FinOps Foundation (2025 wording) underpin every recommendation:
+These six principles from the FinOps Foundation (2026 framework) underpin every recommendation:
 
 1. Teams need to collaborate
 2. Business value drives technology decisions

--- a/cloud-finops/SKILL.md
+++ b/cloud-finops/SKILL.md
@@ -76,7 +76,7 @@ matching the query.
 ## Core FinOps principles (always apply)
 <!-- fp:37b46c22605776cb -->
 
-These six principles from the FinOps Foundation (2025 wording) underpin every recommendation:
+These six principles from the FinOps Foundation (2026 framework) underpin every recommendation:
 
 1. Teams need to collaborate
 2. Business value drives technology decisions

--- a/cloud-finops/references/finops-snowflake.md
+++ b/cloud-finops/references/finops-snowflake.md
@@ -227,7 +227,7 @@ Many organizations assign separate Snowflake warehouses to individual business u
 **Underutilized Snowflake Warehouse**
 Service: Snowflake Virtual Warehouse | Type: Underutilized Resource
 
-Underutilized Snowflake warehouses occur when a workload is assigned a larger warehouse size than necessary. For example, a workload that could efficiently execute on a Medium (M) warehouse may be running on a Large (L) or Extra Large (XL) warehouse.This leads to unnecessary credit consumption without a proportional benefit to performance.
+Underutilized Snowflake warehouses occur when a workload is assigned a larger warehouse size than necessary. For example, a workload that could efficiently execute on a Medium (M) warehouse may be running on a Large (L) or Extra Large (XL) warehouse. This leads to unnecessary credit consumption without a proportional benefit to performance.
 
 - Right-size the Snowflake warehouse by selecting a smaller size (e.g., from L to M, or M to S) that adequately supports workload performance and concurrency needs.
 - Implement a periodic review process to reassess warehouse sizing based on observed usage patterns and changes in workload requirements

--- a/install.sh
+++ b/install.sh
@@ -171,7 +171,13 @@ detect_gemini()          { return 1; }   # web-only
 detect_gemini_cli()      { command -v gemini >/dev/null 2>&1 || [[ -d "$HOME/.gemini" ]]; }
 detect_codex()           { command -v codex >/dev/null 2>&1 || [[ -d ".codex" || -d "$HOME/.codex" ]]; }
 detect_aider()           { command -v aider >/dev/null 2>&1 || [[ -f "CONVENTIONS.md" ]]; }
-detect_copilot()         { command -v code >/dev/null 2>&1 || [[ -d ".github" ]]; }
+detect_copilot()         {
+  # Heuristic: VS Code CLI present OR an existing copilot-instructions.md
+  # already in this repo. The previous version also detected on the
+  # presence of any .github/ directory, which over-detected on every
+  # repo with issue templates or workflows. Removed.
+  command -v code >/dev/null 2>&1 || [[ -f ".github/copilot-instructions.md" ]]
+}
 detect_kiro()            { command -v kiro >/dev/null 2>&1 || [[ -d ".kiro" ]]; }
 
 is_detected() {


### PR DESCRIPTION
## Summary

After PRs #59-#76 landed, ran a deep self-review with 4 parallel audit agents (content / distribution / docs coherence / structure). Most of the repo is clean. Four real findings, all P2/P3:

- **[P2] `finops-snowflake.md:230`** - "warehouse.This leads" missing space (same pattern as previous Codex follow-ups)
- **[P2] `README.md:419`** - "bi-monthly refresh" regression. We standardised on "twice-monthly" in PR #62; this occurrence was inside the Contributing paragraph rewritten in PR #68 and apparently re-introduced the older wording
- **[P2] `SKILL.md:79` + `POWER.md:235`** - "FinOps Foundation (2025 wording)" updated to "(2026 framework)" to align with the FCP 2026 migration in PR #71
- **[P3] `install.sh detect_copilot()`** - the previous heuristic `command -v code || [[ -d ".github" ]]` over-detected Copilot in essentially every GitHub-hosted repo. Replaced the `.github` bare-directory check with `[[ -f ".github/copilot-instructions.md" ]]` so the heuristic only fires on real signals (VS Code CLI installed OR repo already has a Copilot custom-instructions file). Audit comment added.

## What the audit explicitly found clean
- Frontmatter consistency (28/28 references valid for FCP 2026)
- 0 em dashes, 0 broken Markdown placeholder links, 0 double-HR artefacts, 0 inline-bullet collapse artefacts
- Tag/version sync (latest tag `v1.20.0` matches plugin.json)
- 0 leaked tracked files (gitignored content not committed)
- All 28 references routed in both SKILL.md and POWER.md
- 0 duplicate or near-empty .md files
- All 11 install paths pass `--dry-run --tool all` cleanly
- Cross-doc coherence on tool count (11), reference count (28), playbook count (15), build artefacts (42 / 10), license, repo URL, plugin command

## Test plan
- [x] `grep "warehouse\.[A-Z]" cloud-finops/references/finops-snowflake.md` returns nothing
- [x] `grep "bi-monthly" README.md` returns nothing
- [x] `grep "2025 wording" cloud-finops/SKILL.md cloud-finops/POWER.md` returns nothing
- [x] `bash -n install.sh` succeeds
- [x] `bash install.sh --dry-run --tool all --dest /tmp/audit` passes for all 11 tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)