### PR TITLE
Fix auto-tag workflow YAML (multi-line tag message broke literal block scalar)

### DIFF
--- a/.github/workflows/auto-tag-on-plugin-bump.yml
+++ b/.github/workflows/auto-tag-on-plugin-bump.yml
@@ -67,17 +67,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          # Build a tag message that points at plugin.json as the source of truth
-          # for what changed. The release.yml workflow uses generate_release_notes
-          # so the user-facing release body still gets auto-populated from the
-          # commits between this tag and the previous one.
-          git tag -a "$tag" -m "Auto-tagged from .claude-plugin/plugin.json bump to $version
-
-This tag was created automatically by .github/workflows/auto-tag-on-plugin-bump.yml
-when plugin.json on main moved to version $version.
-
-The release.yml workflow will fire from this tag and publish
-cloud-finops-${tag}.zip to a new GitHub release."
+          # Single-line tag message; the user-facing release notes are
+          # auto-populated by release.yml's generate_release_notes flag
+          # from the commit history between this tag and the previous one.
+          git tag -a "$tag" -m "Auto-tagged from .claude-plugin/plugin.json bump to $version"
 
           git push origin "$tag"
           echo "Pushed tag $tag - release.yml will produce cloud-finops-${tag}.zip"


### PR DESCRIPTION
## Summary

The auto-tag workflow added in PR #76 has been failing in 0s on every push to main since it landed. Root cause: the tag message inside `git tag -a -m "..."` spanned multiple lines, and the inner lines started at column 1 of the file. YAML's `run: |` literal block requires consistent indentation - lines at column 1 broke out of the block scalar and confused the YAML scanner. Result: GitHub couldn't parse the workflow file (the API even exposed the workflow `name` as the file path, a tell that name parsing failed) and every run failed immediately before any step could execute.

Fix: collapse the tag message to a single line. The user-facing release notes are auto-populated by `release.yml`'s `generate_release_notes: true` from the commit history, so the tag annotation itself does not need to be elaborate.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/auto-tag-on-plugin-bump.yml'))"` parses cleanly
- [ ] After this merges, the next plugin.json bump on main should trigger the workflow successfully and create the matching tag automatically. (Today's v1.20.0 was created manually because of the YAML bug; v1.20.1 onward should be automatic.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)