### PR TITLE
Bump plugin.json 1.20.0 -> 1.20.1 (validation test for auto-tag workflow)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloud-finops",
-  "version": "1.20.0",
+  "version": "1.20.1",
   "description": "Expert FinOps guidance for cloud, AI, SaaS, and data-platform spend (multi-provider, model-agnostic).",
   "author": {
     "name": "OptimNow",


### PR DESCRIPTION
## Summary

Patch bump with no content change. Validation test for the auto-tag workflow fixed in PR #78.

**Expected behaviour after this PR merges to main:**
1. `auto-tag-on-plugin-bump.yml` triggers on the merge commit (because it touches `.claude-plugin/plugin.json`)
2. It reads version `1.20.1`, sees no existing `v1.20.1` tag, creates and pushes the tag
3. The pushed tag triggers `release.yml`, which builds and publishes `cloud-finops-v1.20.1.zip`

If both steps succeed, future plugin.json bumps will create their tags and releases automatically without manual intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)