### PR TITLE
Audit + Harden plan correction: max_tokens was the root cause, not prompts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,43 @@ truncated state will conclude the other repo is more comprehensive than it reall
 Always check that key reference files end with the OptimNow footer (and not
 mid-sentence) before drawing any coverage comparison.
 
+### The May 2026 truncations had a config root cause, not a prompt-instruction one (2026-05-15)
+
+The "Pipeline applier truncated 8 reference files" lesson above states that
+the LLM "ignored instructions roughly 5% of the time" on long files. **That
+framing was wrong, and the audit doc (`docs/pipeline-audit-2026-05.md`)
+inherited it.** The actual root cause was `pipeline/config.yaml`
+`max_tokens: 4096`. Reference files like `finops-aws.md` (2657 lines, ~12K
+output tokens) cannot be returned in full when the model is capped at 4096
+output tokens; the model writes from the top, hits the cap, stops mid-file,
+and the result reads as "the model ignored the footer instruction". It was
+100% deterministic on any file >3K tokens, not "5% of the time".
+
+The fix is one line: `max_tokens: 16384`. The elaborate tool-use migration
+that the audit recommended as Phase-2 Item 1 was solving the wrong problem
+and was rolled back on 2026-05-15 after Opus regressed to legacy XML format
+under `tool_choice` (it emitted XML strings inside the JSON `hunks` field).
+
+**Compounding error: 79 passing tests with hand-crafted mocks of the
+Anthropic response gave false confidence.** None of the Harden A or B tests
+talked to the real API. The tool-use migration looked correct in tests and
+failed in the first production run. Lesson for future LLM-loop work in this
+repo: **at least one real-API smoke test must pass before declaring any
+batch ready.** `pipeline/smoke_test.py` is the answer; run it before any
+production scan.
+
+**A separate guard-rail gap surfaced on the same day.** The three guards in
+`validate_post_apply` only ran inside `apply_with_guard_rails`, which only
+runs during `--execute`. Preview mode showed proposals without validation,
+so a 89%-deletion diff displayed cleanly in the user's terminal. Preview-mode
+guard rails were added via `_validate_content` in `_process_change`; a
+broken proposal now prints "REJECTED by guard rail" rather than a
+1000-line unified diff.
+
+See `docs/pipeline-audit-2026-05.md` "Correction (2026-05-15)" and
+`docs/pipeline-harden-plan.md` "Status update (2026-05-15)" for the full
+forensic.
+
 ---
 
 ## Roadmap

--- a/docs/pipeline-audit-2026-05.md
+++ b/docs/pipeline-audit-2026-05.md
@@ -14,6 +14,85 @@ scope (see section 11).
 
 ---
 
+## Correction (2026-05-15): root cause was max_tokens, not prompt-instruction failure
+
+The first production run of the Harden PR A and B code on the 15 May 2026
+scheduled scan surfaced three concrete failures that materially correct the
+original audit. **The audit below should be read with these corrections in
+mind; some of its conclusions and recommendations were wrong.**
+
+**Correction 1: the actual root cause of the April-May 2026 truncations was
+`max_tokens: 4096` in `pipeline/config.yaml`, not prompt-instruction
+failure.** Reference files like `finops-aws.md` (2657 lines, ~12K output
+tokens) cannot be returned in full when the model is capped at 4096 output
+tokens. The model writes from the top, hits the cap, and stops mid-file -
+which presents as "the model truncated despite being told to preserve the
+footer". It is deterministic on any file >3K tokens, not the "~5% of the
+time" the audit hypothesised. The fix is a one-line config bump
+(`max_tokens: 16384`); the elaborate tool-use migration the audit
+recommended as Phase-2 Item 1 was solving a problem we did not have.
+
+**Correction 2: the tool-use migration (Harden Item 1) does not work
+reliably with the current Opus.** Under `tool_choice` forcing, the model
+regressed to the legacy XML tool-call format and emitted XML strings
+*inside* the JSON `hunks` field (e.g. `<parameter name="before">...`).
+Python then iterated the string character-by-character, producing 1200+
+malformed-hunk warnings per file. The migration was rolled back on
+2026-05-15; forensic preserved at
+`pipeline/applier/file_updater.py.harden-a-tool-use-attempt.bak`.
+Free-form rewrite is the production path again, now with an adequate
+`max_tokens` budget and a real-API smoke test.
+
+**Correction 3: 79 passing tests with hand-crafted mocks of the Anthropic
+response gave false confidence.** None of the Harden PR A or B tests
+talked to the real API. The tool-use migration looked correct in tests but
+failed instantly in production because the mocks I wrote never emitted the
+shape (XML-in-JSON) that the real model emits. The audit and Harden plan
+both implicitly assumed mock fidelity. A `pipeline/smoke_test.py` is now
+in place that runs the real API against the smallest reference file
+before any production batch.
+
+**Correction 4: the guard rails are reactive, not preventive - and the
+original audit didn't catch that distinction.** The three guards
+(`validate_post_apply`, lines 75-116) only fire inside
+`apply_with_guard_rails`, which only runs during `--execute`. Preview mode
+(`--preview`) showed proposals to the user without validation. On
+2026-05-15 the user saw a diff in their terminal with everything after
+line 288 of a 2657-line file deleted - a max-tokens artefact that the
+guard rails would have rolled back at execute time but that should never
+have been displayed at all. Preview-mode guard rails were added to
+`_process_change` (via `_validate_content`) on the same day so an unsafe
+proposal now prints "REJECTED by guard rail" instead of a 1000-line
+unified diff.
+
+**What remains valid from the original audit:**
+- The module-by-module contracts (section 2) - accurate
+- The destructive-actions inventory (section 4) - accurate
+- The state-directory shape (section 5) - accurate
+- The guard-rail logic and tests (section 6) - accurate; the guard rails
+  themselves work, the gap was where they were invoked
+- The implicit-assumptions list (section 7) - mostly accurate; should add
+  "config.yaml max_tokens is sized for the largest reference file" as
+  assumption #12, which was violated since at least the original 2024
+  implementation
+- The unfreeze criteria (section 10) - U1 and U3 still apply; U6 (tool-use
+  migration) should be removed since the migration was rolled back
+
+**What is wrong in the original audit:**
+- The framing in the Executive Summary and section 8 that tool-use
+  migration is the highest-value remediation - it isn't, max_tokens is
+- The "~5% of the time on long files" framing in section 6's
+  introduction - it was 100% on files >3K tokens
+- The unfreeze criterion U6 (tool-use migration done) - cannot be met
+  with current Opus behaviour
+- The implicit framing throughout that 79 passing mock tests means the
+  pipeline is safe to run - they meant nothing for production fitness
+
+The rest of the document below is the original audit, preserved unchanged
+for the historical record. Read it knowing what we now know.
+
+---
+
 ## 1. Executive summary
 
 The pipeline scans 30 cloud-provider and FinOps content sources every 15 days,

--- a/docs/pipeline-harden-plan.md
+++ b/docs/pipeline-harden-plan.md
@@ -7,8 +7,48 @@
 
 **Plan date:** 2026-05-11
 **Author:** Claude (Opus 4.7, agent-assisted), reviewed by Jean
-**Status:** Draft - changes to pipeline code begin only after this plan is
-approved.
+**Status:** Items 1 (applier tool-use) **rolled back**; items 2-5 partially
+landed; new items added on 2026-05-15. See the Status update box below.
+
+---
+
+## Status update (2026-05-15): tool-use rolled back, max_tokens was the real fix
+
+The first production run of the Harden code on 15 May 2026 surfaced
+material issues with this plan. See
+[`docs/pipeline-audit-2026-05.md`](pipeline-audit-2026-05.md) "Correction
+(2026-05-15)" section for the full forensic.
+
+Summary:
+- **Item 1 (applier tool-use migration): ROLLED BACK.** Opus regressed to
+  legacy XML format under `tool_choice` and emitted XML inside the JSON
+  `hunks` field. 1200+ malformed-hunk warnings per file. Free-form rewrite
+  is the production path again. Forensic at
+  `pipeline/applier/file_updater.py.harden-a-tool-use-attempt.bak`.
+- **The actual fix for the May 2026 truncation incidents:**
+  `pipeline/config.yaml` `max_tokens: 4096` -> `16384`. The audit
+  misidentified the root cause; this plan inherited that error.
+- **Item 2 (per-run structured report): LANDED.** Working.
+- **Item 3 (fetcher content-type/min-payload/bozo validation): LANDED.**
+  Caught 5 dead sources on the first run (databricks, snowflake, infracost,
+  azure-updates, azure-openai-pricing); sources.yaml was fixed.
+- **Item 4 (classifier tool-use migration): LANDED, but suspect.** Same
+  Opus-emits-XML risk exists; the classifier-side hasn't yet shown the
+  failure in production but should be considered fragile until proven.
+- **Item 5 (proposer well-formedness validation): LANDED.** Working.
+- **Plus dropped-URL tracking** (`classify_items` returns
+  `(classified, dropped_urls)`; URLs that hit API errors are NOT marked
+  as processed, so they retry next scan).
+- **Plus preview-mode guard rails** (`_validate_content` called from
+  `_process_change` before showing a diff). Closes the gap that allowed
+  a 90%-deletion proposal to display to the user without warning.
+- **Plus `pipeline/smoke_test.py`**, a real-API smoke test to run before
+  any production batch. The 79 passing mock-based tests were
+  self-confirming and gave false production-readiness signal in May 2026.
+
+The text below is the original plan, preserved for the record. Read it
+knowing that Item 1 did not work in production and that the actual
+production fix was a one-line config change.
 
 ---
 


### PR DESCRIPTION
## Summary

Corrects three material errors in `docs/pipeline-audit-2026-05.md` and `docs/pipeline-harden-plan.md` that surfaced on the 15 May 2026 production run. The original audit and plan are preserved unchanged below the correction sections - this is an addendum, not a rewrite.

## What the original audit got wrong

1. **Root cause attribution.** The May 2026 truncations were not "prompt instructions silently ignored on long files ~5% of the time". The actual cause was `pipeline/config.yaml` `max_tokens: 4096`, which deterministically truncates any file >3K output tokens. `finops-aws.md` is 2657 lines / ~12K tokens; the model writes from the top, hits the cap, stops mid-file. **100% reproducible on the big files, not 5%.** Fix is one line in config.yaml (`max_tokens: 16384`); the elaborate tool-use migration recommended as Phase-2 Item 1 was solving the wrong problem.

2. **Tool-use migration unworkable today.** Opus regressed to legacy XML format under `tool_choice` and emitted XML inside the JSON `hunks` field on the first production call (`<parameter name="before">...`). Python iterated the string character-by-character, producing 1200+ malformed-hunk warnings per file. Migration rolled back; forensic preserved at `pipeline/applier/file_updater.py.harden-a-tool-use-attempt.bak`.

3. **79 passing tests with hand-crafted mocks gave false confidence.** None of the Harden A or B tests touched the real Anthropic API. The mocks emitted the shape I expected; production Opus emitted a different shape; the gap was invisible until production. `pipeline/smoke_test.py` is now in place (gitignored) to do a real-API smoke check before any production batch.

4. **Guard rails ran only on `--execute`, not `--preview`.** A 89%-deletion proposal displayed cleanly in the user's terminal because `preview_change` bypassed the guards. Preview-mode guard rails were added via `_validate_content` in `_process_change`; an unsafe proposal now prints "REJECTED by guard rail" instead of a misleading 1000-line diff.

## What landed in pipeline code (gitignored, not in this PR)

- `config.yaml` `max_tokens: 4096` → `16384`
- `file_updater.py` free-form code restored from `.before-harden-a.bak`
- `file_updater.py` `_validate_content` extracted as content-based helper; `_process_change` calls it in preview mode to gate the diff display
- `smoke_test.py` written to run a real Anthropic call against the smallest reference file and validate the result

## What this PR changes (tracked in main)

- `docs/pipeline-audit-2026-05.md`: "Correction (2026-05-15)" section at top; original audit preserved unchanged below
- `docs/pipeline-harden-plan.md`: "Status update (2026-05-15)" section at top; original plan preserved unchanged below
- `CLAUDE.md`: new Lessons-learned entry "The May 2026 truncations had a config root cause, not a prompt-instruction one (2026-05-15)"

## Test plan

- [ ] Read the "Correction (2026-05-15)" section in `docs/pipeline-audit-2026-05.md` - it should clearly explain (a) what the audit got wrong, (b) what landed, (c) what remains valid
- [ ] Read the "Status update (2026-05-15)" section in `docs/pipeline-harden-plan.md` - per-item status (Item 1 rolled back, 2-5 landed with notes)
- [ ] `CLAUDE.md` "Lessons learned" has the new entry with clear forward references to the audit and plan corrections
- [ ] Original audit and plan text preserved unchanged below the correction sections (no historical revisionism)
- [ ] No em dashes (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)