### PR TITLE
Fix 8 Codex review findings: PyPI publish chain, playbook count drift, cadence + tool count alignment

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloud-finops",
-  "version": "1.22.0",
+  "version": "1.22.1",
   "description": "Expert FinOps guidance for cloud, AI, SaaS, and data-platform spend (multi-provider, model-agnostic).",
   "author": {
     "name": "OptimNow",

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Force LF line endings for shell scripts so they work on Windows checkouts
+# where core.autocrlf=true would otherwise rewrite them as CRLF and break bash.
+# Discovered by Codex review (2026-05-15): bash install.sh and bash
+# scripts/fcp-coverage.sh both failed with parser errors on a Windows
+# checkout because git had stored them as w/crlf.
+*.sh text eol=lf
+
+# Markdown stays platform-default; YAML/JSON inherit git's auto-detection.

--- a/.github/workflows/auto-tag-on-plugin-bump.yml
+++ b/.github/workflows/auto-tag-on-plugin-bump.yml
@@ -30,6 +30,11 @@ permissions:
 jobs:
   tag-and-release:
     runs-on: ubuntu-latest
+    outputs:
+      # Surfaced so the downstream publish-mcp job knows which tag to publish
+      # (and whether to skip when this push didn't actually need a new tag).
+      tag: ${{ steps.read_version.outputs.tag }}
+      skip: ${{ steps.check_tag.outputs.skip }}
     steps:
       - name: Checkout main
         uses: actions/checkout@v4
@@ -112,4 +117,20 @@ jobs:
 
             The attached `cloud-finops-${{ steps.read_version.outputs.tag }}.zip` is the skill bundle for upload into Claude Desktop / claude.ai (Settings -> Skills -> Upload).
 
-            For Claude Code users (and 10 other tools), see [INSTALLATION.md](https://github.com/OptimNow/cloud-finops-skills/blob/main/INSTALLATION.md) for the cross-tool installer and the model-agnostic response contract.
+            For Claude Code users (and 11 other tools), see [INSTALLATION.md](https://github.com/OptimNow/cloud-finops-skills/blob/main/INSTALLATION.md) for the cross-tool installer and the model-agnostic response contract.
+
+  # Tags pushed by GITHUB_TOKEN above do NOT re-trigger publish-mcp.yml's
+  # `push: tags` event (GitHub blocks recursive workflow runs from the
+  # default token). Calling it explicitly via workflow_call closes the
+  # gap: every plugin.json bump now publishes the matching cloud-finops-mcp
+  # version to PyPI alongside the GitHub Release zip.
+  publish-mcp:
+    name: Publish cloud-finops-mcp to PyPI
+    needs: tag-and-release
+    if: needs.tag-and-release.outputs.skip == 'false'
+    permissions:
+      contents: read
+      id-token: write   # publish-mcp.yml needs OIDC for trusted publishing
+    uses: ./.github/workflows/publish-mcp.yml
+    with:
+      tag: ${{ needs.tag-and-release.outputs.tag }}

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,14 +1,27 @@
 name: Publish cloud-finops-mcp to PyPI
 
 on:
+  # Manual tag pushes from a developer machine (git push v1.x.y) still work.
   push:
     tags:
       - 'v*'
+  # Auto-tag-on-plugin-bump.yml calls this workflow after pushing the tag,
+  # because tags pushed by GITHUB_TOKEN do not re-trigger the `push: tags`
+  # event. Without this entry, plugin.json bumps would build the release zip
+  # but never publish the matching cloud-finops-mcp version to PyPI.
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+        description: 'Tag to publish (e.g. v1.22.1)'
 
 # Trusted publishing via OIDC. No PyPI API token in repo secrets.
 # One-time setup: in PyPI project settings for "cloud-finops-mcp", add this
 # repo (OptimNow/cloud-finops-skills) as a trusted publisher with workflow
-# filename "publish-mcp.yml" and environment "pypi".
+# filename "publish-mcp.yml" and environment "pypi". The workflow filename
+# claim does not change when invoked via workflow_call, so the same trusted
+# publisher config works for both trigger paths.
 
 permissions:
   contents: read
@@ -23,6 +36,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # When triggered via push:tags, github.ref_name is the tag and the
+          # default checkout grabs the tagged commit. When invoked via
+          # workflow_call from auto-tag-on-plugin-bump.yml, the default checkout
+          # would grab the caller's main HEAD; that SHA is identical to the tag
+          # in practice (auto-tag pushes the tag at HEAD before calling this
+          # workflow), so we explicitly use the tag input when provided to make
+          # the contract obvious.
+          ref: ${{ inputs.tag || github.ref }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -31,11 +53,17 @@ jobs:
 
       - name: Resolve version from tag
         id: version
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
-          TAG="${GITHUB_REF_NAME}"
+          # When invoked via workflow_call, ${GITHUB_REF_NAME} is the calling
+          # workflow's ref (typically "main"), not a tag. Prefer the explicit
+          # tag input when provided; fall back to GITHUB_REF_NAME for the
+          # `push: tags` trigger.
+          TAG="${INPUT_TAG:-${GITHUB_REF_NAME}}"
           VERSION="${TAG#v}"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "Building cloud-finops-mcp ${VERSION}"
+          echo "Building cloud-finops-mcp ${VERSION} from tag ${TAG}"
 
       - name: Pin pyproject version to tag
         working-directory: mcp_server

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ MCP-compatible agent.
 - **AGENTS.md** - entry point for Codex CLI (this file)
 - **references/** - 28 domain-specific content files (billing mechanics, pricing,
   optimisation patterns)
-- **INSTALLATION.md** - cross-tool installer covering 11 tool integrations, plus
+- **INSTALLATION.md** - cross-tool installer covering 12 tool integrations, plus
   a model-agnostic response contract for non-Claude models
 
 All entry points route to the same reference files. No content is duplicated.
@@ -52,8 +52,8 @@ sub-modules, see CLAUDE.md.
 
 ## Content update pipeline
 
-The `pipeline/` folder contains a twice-monthly content scanner (around the 1st
-and the 15th) that detects FinOps-relevant changes across 29 sources and proposes
+The `pipeline/` folder contains a monthly content scanner (around the 1st of each
+month) that detects FinOps-relevant changes across 29 sources and proposes
 updates to the reference files. It is gitignored and not part of the public
 distribution.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Claude, GPT, Gemini, or any MCP-compatible agent.
 - **SKILL.md** - entry point for Claude Code and generic agents
 - **POWER.md** - entry point for Kiro IDE (same references, different format)
 - **references/** - domain-specific content files (billing mechanics, pricing, optimisation patterns)
-- **INSTALLATION.md** - one cross-tool installer covering 11 tool integrations, plus
+- **INSTALLATION.md** - one cross-tool installer covering 12 tool integrations, plus
   a model-agnostic response contract (system-prompt-injection section) for non-Claude
   models
 
@@ -30,7 +30,7 @@ differ.
 cloud-finops-skills/
 ├── CLAUDE.md              <- You are here
 ├── README.md              <- Public-facing documentation
-├── INSTALLATION.md        <- Setup instructions (11 tool integrations) + response contract
+├── INSTALLATION.md        <- Setup instructions (12 tool integrations) + response contract
 ├── LICENSE.md             <- CC BY-SA 4.0
 ├── install.sh             <- One-liner installer script
 ├── assets/                <- Screenshots for installation guide
@@ -66,6 +66,16 @@ cloud-finops-skills/
 │       ├── finops-onboarding-workloads.md  <- Migration-time cost hygiene + M&A
 │       ├── finops-kubernetes.md            <- K8s cross-cluster discipline (EKS/GKE/AKS)
 │       └── finops-waste-detection-playbooks.md  <- Seven-category waste taxonomy + WasteLine
+├── cloud-finops/playbooks/   <- 23 named-pattern runbooks (`<scope>-<pattern>.md`,
+│                                ~2-3KB each, FIND/DETECT/FIX/SOURCES format) +
+│                                README.md index. RAG-friendly chunks routed from
+│                                SKILL.md / POWER.md "named waste pattern" rows
+├── mcp_server/            <- `cloud-finops-mcp` PyPI package (six MCP tools,
+│                             faceted retrieval over references + playbooks)
+├── scripts/               <- `fcp-coverage.sh` (parses FCP frontmatter, emits
+│                             `fcp-coverage.md` matrix)
+├── fcp-coverage.md        <- Generated FCP capability coverage matrix (22 caps)
+├── .gitattributes         <- Force LF on *.sh for Windows checkouts
 └── pipeline/              <- Content update pipeline (gitignored, private)
     ├── run_scan.py        <- Weekly scan entry point
     ├── run_apply.py       <- Review and apply entry point
@@ -154,7 +164,7 @@ the only signal was the missing footer at the end, which no automated check veri
 had not kept pace with reference growth (AGENTS.md and llms.txt listed only 17
 references when 28 existed; install.sh ChatGPT/Gemini routing missed the 6-7 newest
 domains; "6 setup options" appeared in 4 files when INSTALLATION.md had moved to
-11 tools). The PR-checklist in this file now requires updating AGENTS.md, llms.txt,
+12 tools). The PR-checklist in this file now requires updating AGENTS.md, llms.txt,
 and the install.sh per-tool routing whenever a reference is added.
 
 ### When in doubt, validate the baseline before comparing
@@ -382,35 +392,6 @@ GitHub issues, which track in-flight work.
   framing from `optimnow-methodology.md` and replace it with a pointer to the doctrine
   layer.
 
-- **Playbooks directory** (`cloud-finops/playbooks/`). Extract the named-pattern
-  catalogues currently embedded in `finops-aws.md` (48 patterns), `finops-azure.md`
-  (48 patterns), `finops-gcp.md` (26 patterns), and the seven-category taxonomy in
-  `finops-waste-detection-playbooks.md` into individual playbook files (~2-3KB each).
-  Format per playbook: symptoms / detection (CUR / KQL / BigQuery SQL) / fix /
-  anti-pattern / sources. The reference files keep the patterns as in-context narrative
-  for linear reading; the `playbooks/` directory exposes them as RAG-friendly chunks
-  for ChatGPT / Gemini / generic LLM retrieval. Routing rule to add to SKILL.md and
-  POWER.md: "named waste pattern X -> `playbooks/X.md`". Drift risk to manage: changes
-  to a pattern must be applied in both places, or the reference file should be updated
-  to reference the playbook by an inline Markdown link (e.g.
-  `[aws-zombie-nat-gateway](../playbooks/aws-zombie-nat-gateway.md)`) instead of
-  duplicating the content.
-
-- **FCP coverage matrix tooling.** Adapt the approach from Cletrics' `fcp-coverage.sh`:
-  a small bash script that parses `fcp_domain` / `fcp_capability` /
-  `fcp_capabilities_secondary` from every reference frontmatter and emits a top-level
-  `fcp-coverage.md` table mapping the 22 FCP capabilities to the references that cover
-  them. Adds three benefits: (1) honesty signal vis-a-vis the framework - the matrix
-  computes coverage from the actual repo, not from claims; (2) PR check - new
-  references with a non-canonical capability or a missing frontmatter trip the script;
-  (3) Roadmap-driven view - the matrix shows which capabilities have no primary owner
-  yet. Current true gaps after the frontmatter-truth pass: KPIs & Benchmarking,
-  Executive Strategy Alignment, FinOps Education & Enablement (all in the deferred
-  table below). Budgeting and Automation Tools & Services were initially flagged
-  as gaps but are covered dispersed - the matrix now renders them as `[~]`
-  secondary-only after the frontmatter was updated to reflect that reality (PR
-  following the FCP-2026 migration).
-
 - **Public Custom GPT for ChatGPT users.** The current ChatGPT install path is
   self-host: `./install.sh --tool chatgpt --grouped` produces 10 grouped knowledge
   files the user uploads themselves. A public Cloud FinOps GPT in the OpenAI GPT
@@ -503,6 +484,13 @@ These files shipped during the white-space analysis follow-up (PRs #48, #50, #51
 - `finops-kubernetes.md` (PR #54) - Cross-cluster K8s discipline (EKS/GKE/AKS)
 - `finops-waste-detection-playbooks.md` (PR #56) - Seven-category waste taxonomy + WasteLine
 - YAML FCP frontmatter pass across all 22 pre-existing references (PR #53)
+- `cloud-finops/playbooks/` directory (PRs #64, #66, #67, #83) - 23 RAG-friendly
+  named-pattern playbooks (`<scope>-<pattern>.md`, ~2-3KB each, FIND/DETECT/FIX/SOURCES
+  format) covering AWS (incl. SageMaker + GPU), Azure, GCP, and cross-cloud waste patterns.
+  Routed from SKILL.md and POWER.md "named waste pattern" rows
+- `scripts/fcp-coverage.sh` + top-level `fcp-coverage.md` (PR #64) - bash matrix that
+  parses FCP frontmatter from every reference and renders a 22-capability coverage table.
+  Run on each PR; `[~]` secondary-only cells distinguish dispersed coverage from true gaps
 
 ---
 

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -12,7 +12,7 @@ the conversion for every supported tool. Per-tool blocks below are copy-pasteabl
 
 ---
 
-## Quick reference: one installer, eleven tools
+## Quick reference: one installer, twelve tools
 
 ```bash
 # Auto-detect tools in the current project / $HOME and install for each
@@ -111,10 +111,10 @@ Builds two artefacts in `dist/chatgpt/`:
 - `instructions.md` - target ≤ 8000 chars; the routing logic, reasoning sequence, and
   response contract that go into the GPT's Instructions field. The installer warns if
   the file exceeds the limit.
-- `knowledge/*.md` - **42 files** in the default per-reference build:
+- `knowledge/*.md` - **50 files** in the default per-reference build:
   - 27 reference files (one per domain; `optimnow-methodology.md` is **merged into
     `finops-for-ai.md`**)
-  - 15 playbook files prefixed `playbook-<slug>.md` so they sort together in the
+  - 23 playbook files prefixed `playbook-<slug>.md` so they sort together in the
     GPT Knowledge UI
   - The instructions routing contract points named waste patterns
     (zombie NAT, snapshot sprawl, etc.) at `playbook-<slug>.md` and other queries at

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 | <img src="https://img.shields.io/badge/-Gemini-4285F4?logo=googlegemini&logoColor=white" alt="Gemini" height="22"/> | Self-host: `./install.sh --tool gemini` _(a public Cloud FinOps Gem is on the Roadmap)_ |
 | <img src="https://img.shields.io/badge/-Cursor-000000?logo=cursor&logoColor=white" alt="Cursor" height="22"/> <img src="https://img.shields.io/badge/-Windsurf-3DDC91?logoColor=white" alt="Windsurf" height="22"/> <img src="https://img.shields.io/badge/-Codex-412991?logo=openai&logoColor=white" alt="Codex" height="22"/> <img src="https://img.shields.io/badge/-Aider-0F172A?logoColor=white" alt="Aider" height="22"/> <img src="https://img.shields.io/badge/-Copilot-181717?logo=githubcopilot&logoColor=white" alt="Copilot" height="22"/> <img src="https://img.shields.io/badge/-Kiro%20IDE-FF6F00?logoColor=white" alt="Kiro IDE" height="22"/> <img src="https://img.shields.io/badge/-Gemini%20CLI-4285F4?logo=googlegemini&logoColor=white" alt="Gemini CLI" height="22"/> | One-liner: `curl -sL https://raw.githubusercontent.com/OptimNow/cloud-finops-skills/main/install.sh \| bash -s -- --tool <name>` |
 | <img src="https://img.shields.io/badge/-Auto--detect-555555?logo=gnubash&logoColor=white" alt="Auto-detect" height="22"/> | `curl -sL https://raw.githubusercontent.com/OptimNow/cloud-finops-skills/main/install.sh \| bash` |
-| <img src="https://img.shields.io/badge/-MCP%20server-7C3AED?logoColor=white" alt="MCP server" height="22"/> | `pip install cloud-finops-mcp` then add to your MCP client config (Claude Code / Cursor / Codex / Windsurf / Cline). Snippets: `./install.sh --tool mcp`. Six tools - faceted retrieval over the 28 references and 15 named-pattern playbooks. |
+| <img src="https://img.shields.io/badge/-MCP%20server-7C3AED?logoColor=white" alt="MCP server" height="22"/> | `pip install cloud-finops-mcp` then add to your MCP client config (Claude Code / Cursor / Codex / Windsurf / Cline). Snippets: `./install.sh --tool mcp`. Six tools - faceted retrieval over the 28 references and 23 named-pattern playbooks. |
 
 Full options, troubleshooting, and the model-agnostic API loader: see [INSTALLATION.md](./INSTALLATION.md).
 
@@ -357,8 +357,8 @@ other MCP-aware client. See [mcp_server/](./mcp_server/README.md) and the
 
 ## This skill is actively maintained
 
-This is a living repository. Reference files are refreshed twice a month (around the
-1st and the 15th), driven by an automated scan of 29 data sources - cloud provider
+This is a living repository. Reference files are refreshed monthly (around the
+1st of each month), driven by an automated scan of 29 data sources - cloud provider
 pricing pages, release notes, billing changelogs, and FinOps community publications.
 Changes are reviewed before being applied, so the content reflects verified updates
 rather than raw feed output.
@@ -437,7 +437,7 @@ in any of the layers below.
 - Vendor marketing material restated as fact, without a primary source or
   practitioner-grade evidence behind the claim.
 - Wholesale AI-generated reference content with no human practitioner pass.
-  The pipeline that powers the twice-monthly refresh has hard guard rails (see
+  The pipeline that powers the monthly refresh has hard guard rails (see
   the `Lessons learned` section of `CLAUDE.md` for why). Hand-written
   contributions go through human review for the same reasons.
 - "Best practices" lists with no business-value framing. Every recommendation

--- a/install.sh
+++ b/install.sh
@@ -392,7 +392,7 @@ build_chatgpt_instructions() {
 
 You are an expert FinOps practitioner. Help users understand and optimise spend on cloud (AWS / Azure / GCP / OCI), AI platforms (Anthropic, Bedrock, Azure OpenAI / Foundry, Vertex AI), data platforms (Databricks, Microsoft Fabric, Snowflake), AI coding tools (Cursor, Claude Code, Copilot, Codex, Windsurf, Gemini Code Assist), SaaS, and cross-cutting concerns (tagging, FinOps Framework, GreenOps, ITAM).
 
-Your knowledge files contain accurate, current billing mechanics and optimisation patterns refreshed twice a month (around the 1st and the 15th). Always retrieve relevant knowledge files before answering - do not rely on general training data for billing specifics.
+Your knowledge files contain accurate, current billing mechanics and optimisation patterns refreshed monthly (around the 1st of each month). Always retrieve relevant knowledge files before answering - do not rely on general training data for billing specifics.
 
 ## Domain routing
 
@@ -427,7 +427,7 @@ Use these knowledge files for the following query types:
 | Onboarding workloads, migration-time cost hygiene, intake gate, 60-90 day forecast-then-commit rule, double-bubble cost, M&A integration | finops-onboarding-workloads.md |
 | Kubernetes FinOps (EKS / GKE / AKS), OpenCost / Kubecost, FOCUS-emitting K8s allocation, container rightsizing, Karpenter, Spot diversification | finops-kubernetes.md |
 | Waste detection playbooks, seven-category waste taxonomy, two-signal classification, WasteLine appliance | finops-waste-detection-playbooks.md |
-| Named waste pattern (zombie NAT, snapshot sprawl, idle ELB, cross-AZ egress, oversized RDS, orphan EBS, orphan Azure disks, App Service overprovisioning, Log Analytics ingestion sprawl, idle Azure SQL, idle GKE Autopilot, orphan Persistent Disks, Cloud Functions cold starts, schedule blindness, untagged spend drift) | playbook-<slug>.md (e.g. playbook-aws-zombie-nat-gateway.md) |
+| Named waste pattern (zombie NAT, snapshot sprawl, idle ELB, cross-AZ egress, oversized RDS, orphan EBS, orphan Azure disks, App Service overprovisioning, Log Analytics ingestion sprawl, idle Azure SQL, idle GKE Autopilot, orphan Persistent Disks, Cloud Functions cold starts, schedule blindness, untagged spend drift, idle SageMaker endpoint, always-on SageMaker notebook, SageMaker endpoint sprawl / MME consolidation, oversized GPU instance, multi-GPU underutilized, MIG candidate, GPU for CPU-bound workload, outdated GPU generation) | playbook-<slug>.md (e.g. playbook-aws-zombie-nat-gateway.md) |
 
 For multi-domain queries, retrieve all relevant files and synthesise. For named
 waste patterns, retrieve the matching `playbook-<slug>.md` knowledge file.
@@ -468,7 +468,7 @@ build_grouped_instructions() {
 
 You are an expert FinOps practitioner. Help users understand and optimise spend on cloud (AWS / Azure / GCP / OCI), AI platforms (Anthropic, Bedrock, Azure OpenAI / Foundry, Vertex AI), data platforms (Databricks, Microsoft Fabric, Snowflake), AI coding tools (Cursor, Claude Code, Copilot, Codex, Windsurf, Gemini Code Assist), SaaS, and cross-cutting concerns (tagging, FinOps Framework, GreenOps, ITAM, anomaly management, allocation/showback, chargeback, onboarding, Kubernetes, waste detection).
 
-Your knowledge files are grouped thematically and refreshed twice a month (around the 1st and the 15th). Always retrieve the relevant grouped file before answering - do not rely on general training data for billing specifics.
+Your knowledge files are grouped thematically and refreshed monthly (around the 1st of each month). Always retrieve the relevant grouped file before answering - do not rely on general training data for billing specifics.
 
 ## Domain routing (grouped layout)
 
@@ -484,7 +484,7 @@ Use these knowledge files for the following query types:
 | OCI (Cost Reports, FOCUS, cost-tracking tags, Universal Credits) | oci.md |
 | FinOps Framework (4 domains 2024 + Executive Strategy Alignment 2026), tagging, SaaS management, ITAM, GreenOps, Kubernetes FinOps, waste detection playbooks | cross-cutting.md |
 | Anomaly management, allocation and showback, chargeback (incl. Finance / accounting prerequisites), onboarding workloads (migration-time cost hygiene + M&A) | finops-discipline.md |
-| Named waste pattern (zombie NAT, snapshot sprawl, idle ELB, cross-AZ egress, oversized RDS, orphan EBS, orphan Azure disks, App Service overprovisioning, Log Analytics ingestion sprawl, idle Azure SQL, idle GKE Autopilot, orphan Persistent Disks, Cloud Functions cold starts, schedule blindness, untagged spend drift) | playbooks.md |
+| Named waste pattern (zombie NAT, snapshot sprawl, idle ELB, cross-AZ egress, oversized RDS, orphan EBS, orphan Azure disks, App Service overprovisioning, Log Analytics ingestion sprawl, idle Azure SQL, idle GKE Autopilot, orphan Persistent Disks, Cloud Functions cold starts, schedule blindness, untagged spend drift, idle SageMaker endpoint, always-on SageMaker notebook, SageMaker endpoint sprawl / MME consolidation, oversized GPU instance, multi-GPU underutilized, MIG candidate, GPU for CPU-bound workload, outdated GPU generation) | playbooks.md |
 | Reasoning methodology lens (diagnose before prescribing, connect cost to value, recommend progressively) | methodology.md |
 
 For multi-domain queries, retrieve all relevant grouped files and synthesise. For

--- a/llms.txt
+++ b/llms.txt
@@ -17,7 +17,7 @@ infrastructure. Copy the files into your agent's context and it gains FinOps exp
 
 - cloud-finops/SKILL.md: Entry point and domain router for Claude Code and generic agents
 - cloud-finops/POWER.md: Entry point for Kiro IDE
-- INSTALLATION.md: cross-tool installer covering 11 tool integrations + model-agnostic response contract
+- INSTALLATION.md: cross-tool installer covering 12 tool integrations + model-agnostic response contract
 - cloud-finops/references/optimnow-methodology.md: Reasoning philosophy (read first on every query)
 - cloud-finops/references/finops-for-ai.md: AI cost management, token economics, agentic patterns
 - cloud-finops/references/finops-ai-value-management.md: AI investment governance, stage gates

--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -1,7 +1,7 @@
 # cloud-finops-mcp
 
 MCP server exposing the [OptimNow Cloud FinOps skill](https://github.com/OptimNow/cloud-finops-skills)
-(28 reference files + 15 named-pattern playbooks) as queryable tools for any
+(28 reference files + 23 named-pattern playbooks) as queryable tools for any
 MCP-aware client (Claude Code, Cursor, Codex CLI, Windsurf, Aider, Cline, etc.).
 
 The skill itself ships in canonical Claude Agent-Skills format and is also installable

--- a/mcp_server/pyproject.toml
+++ b/mcp_server/pyproject.toml
@@ -76,6 +76,12 @@ artifacts = []
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
+# Force pytest to import from the local src/ tree, not whatever
+# `cloud_finops_mcp` happens to be installed in site-packages. Without
+# this, a stale `pip install` of the package would silently mask drift
+# between the test assertions and this checkout. See Codex review
+# (2026-05-15) for the failure mode this prevents.
+pythonpath = ["src"]
 
 [tool.ruff]
 line-length = 100

--- a/mcp_server/tests/test_e2e.py
+++ b/mcp_server/tests/test_e2e.py
@@ -93,7 +93,7 @@ async def test_e2e_list_playbooks(server_params: StdioServerParameters) -> None:
             await session.initialize()
             result = await session.call_tool("list_playbooks", {})
             payload = _payload(result)
-            assert payload["total"] == 15
+            assert payload["total"] == 23
 
 
 @pytest.mark.asyncio

--- a/mcp_server/tests/test_metadata.py
+++ b/mcp_server/tests/test_metadata.py
@@ -43,9 +43,9 @@ def test_lookup_unknown_returns_none() -> None:
 # --- playbook index ---------------------------------------------------------
 
 
-def test_playbook_index_returns_15() -> None:
+def test_playbook_index_returns_23() -> None:
     playbooks = metadata.get_playbook_index()
-    assert len(playbooks) == 15
+    assert len(playbooks) == 23
 
 
 def test_playbook_index_excludes_readme() -> None:

--- a/mcp_server/tests/test_tools.py
+++ b/mcp_server/tests/test_tools.py
@@ -106,10 +106,10 @@ def test_find_filters_echo_input() -> None:
 # --- list_playbooks ---------------------------------------------------------
 
 
-def test_list_playbooks_returns_15() -> None:
+def test_list_playbooks_returns_23() -> None:
     result = tools.list_playbooks()
-    assert result["total"] == 15
-    assert len(result["playbooks"]) == 15
+    assert result["total"] == 23
+    assert len(result["playbooks"]) == 23
     sample = result["playbooks"][0]
     assert {"name", "title", "scope", "waste_category", "confidence", "lines"}.issubset(sample)
 
@@ -141,7 +141,7 @@ def test_get_playbook_empty_name_rejects() -> None:
 
 def test_find_playbooks_no_filters_returns_everything() -> None:
     result = tools.find_playbooks()
-    assert result["total"] == 15
+    assert result["total"] == 23
     assert result["filters"] == {}
 
 


### PR DESCRIPTION
## Summary

Codex review on 2026-05-15 surfaced 8 findings (2 P1, 4 P2, 2 P3). All fixed in this PR.

The single most important fix is the **PyPI publish chain**: tags pushed by `GITHUB_TOKEN` from `auto-tag-on-plugin-bump.yml` don't re-trigger `publish-mcp.yml`'s `push: tags` event, so v1.22.0 shipped to GitHub Releases this morning while PyPI is still on 1.21.0. This PR converts `publish-mcp.yml` to also accept `workflow_call` and has the auto-tag workflow invoke it explicitly. Bumping to **1.22.1** validates the chain end-to-end on merge.

### P1 fixes
- **PyPI publish on auto-releases.** `publish-mcp.yml` now accepts a `workflow_call` invocation with a `tag` input; `auto-tag-on-plugin-bump.yml` calls it after creating the release. Trusted-publisher OIDC config still works (workflow filename claim is unchanged).
- **Playbook count drift (15 → 23).** 4 test functions and 3 public docs (README, INSTALLATION, mcp_server/README) now reflect the 23 playbooks added across PRs #58/#66/#67/#83.

### P2 fixes
- `install.sh` ChatGPT/Gemini routing tables now list all 23 named patterns (added SageMaker + GPU patterns from v1.21.0).
- Refresh cadence aligned to monthly across README, AGENTS, install.sh (3 spots).
- `mcp_server/pyproject.toml` gains `pythonpath = ["src"]` so pytest cannot silently use a stale site-packages install.
- `.gitattributes` added (`*.sh text eol=lf`); `install.sh` and `scripts/fcp-coverage.sh` renormalised so Windows checkouts get LF.

### P3 fixes
- Tool count `11 → 12` in AGENTS.md, CLAUDE.md (3 spots), llms.txt, INSTALLATION.md heading. Auto-tag release-notes `10 other tools` → `11`.
- CLAUDE.md Roadmap: removed Playbooks-directory + FCP-coverage-matrix bullets from in-flight (both shipped via PRs #64/#66/#67/#83); moved to "Closed gaps". Repo-structure tree now shows `cloud-finops/playbooks/`, `mcp_server/`, `scripts/`, `fcp-coverage.md`, `.gitattributes`.

## Test plan
- [x] `pytest` in `mcp_server/` against local src: **42/42 pass** (was 4 failed pre-fix).
- [x] `bash -n install.sh` and `bash -n scripts/fcp-coverage.sh`: clean.
- [x] `scripts/fcp-coverage.sh` produces stable 12/22 matrix.
- [ ] On merge: confirm `auto-tag-on-plugin-bump.yml` fires for v1.22.1, creates the release zip, AND chains into `publish-mcp.yml` so PyPI `cloud-finops-mcp` lands at 1.22.1.
- [ ] On merge: confirm trusted-publisher OIDC still works (no workflow-filename change to PyPI config needed).

## Notes for reviewer
- The `install.sh` diff is large because `git add --renormalize` recorded the LF conversion alongside my routing-table edits. The substantive content edits are: monthly cadence (2 spots), 23 named patterns in 2 routing tables.
- I left the `fcp-coverage.md` re-render (no content change, only line-ending normalization warning) uncommitted to keep the diff focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)