### PR TITLE
Fix PyPI publish chain: inline build+publish into auto-tag (workflow_call unsupported)

### DIFF
--- a/.github/workflows/auto-tag-on-plugin-bump.yml
+++ b/.github/workflows/auto-tag-on-plugin-bump.yml
@@ -31,9 +31,11 @@ jobs:
   tag-and-release:
     runs-on: ubuntu-latest
     outputs:
-      # Surfaced so the downstream publish-mcp job knows which tag to publish
-      # (and whether to skip when this push didn't actually need a new tag).
+      # Surfaced so the downstream build-mcp / publish-mcp jobs know which tag
+      # and version to publish, and whether to skip when this push didn't
+      # actually need a new tag.
       tag: ${{ steps.read_version.outputs.tag }}
+      version: ${{ steps.read_version.outputs.version }}
       skip: ${{ steps.check_tag.outputs.skip }}
     steps:
       - name: Checkout main
@@ -119,18 +121,89 @@ jobs:
 
             For Claude Code users (and 11 other tools), see [INSTALLATION.md](https://github.com/OptimNow/cloud-finops-skills/blob/main/INSTALLATION.md) for the cross-tool installer and the model-agnostic response contract.
 
-  # Tags pushed by GITHUB_TOKEN above do NOT re-trigger publish-mcp.yml's
-  # `push: tags` event (GitHub blocks recursive workflow runs from the
-  # default token). Calling it explicitly via workflow_call closes the
-  # gap: every plugin.json bump now publishes the matching cloud-finops-mcp
-  # version to PyPI alongside the GitHub Release zip.
-  publish-mcp:
-    name: Publish cloud-finops-mcp to PyPI
+  # Build the cloud-finops-mcp wheel + sdist for the just-tagged version.
+  #
+  # Why these steps are duplicated from publish-mcp.yml instead of invoked via
+  # workflow_call: PyPI Trusted Publishing does NOT support reusable workflows
+  # (https://docs.pypi.org/trusted-publishers/troubleshooting/#reusable-workflows-on-github).
+  # The 2026-05-15 attempt at workflow_call published the wheels but the
+  # attestation build_config_uri claim pointed to this workflow rather than the
+  # called one, and PyPI rejected the upload. Inlining the steps means PyPI sees
+  # `auto-tag-on-plugin-bump.yml` as the trusted publisher directly.
+  #
+  # One-time PyPI setup required: in cloud-finops-mcp's project settings on PyPI,
+  # add this repo as a SECOND trusted publisher with workflow filename
+  # `auto-tag-on-plugin-bump.yml` and environment `pypi`. The existing
+  # `publish-mcp.yml` entry is preserved so manual git-push-tag and
+  # workflow_dispatch recovery paths continue to publish.
+  build-mcp:
+    name: Build cloud-finops-mcp wheel + sdist
     needs: tag-and-release
     if: needs.tag-and-release.outputs.skip == 'false'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout tagged commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.tag-and-release.outputs.tag }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Pin pyproject version to tag
+        working-directory: mcp_server
+        env:
+          VERSION: ${{ needs.tag-and-release.outputs.version }}
+        run: |
+          # Same logic as publish-mcp.yml: the pyproject.toml version field
+          # must equal the git tag so wheel filenames and PyPI metadata agree.
+          python - <<'PY'
+          import os, pathlib, re
+          version = os.environ["VERSION"]
+          path = pathlib.Path("pyproject.toml")
+          text = path.read_text(encoding="utf-8")
+          new = re.sub(r'^version = ".*"', f'version = "{version}"', text, count=1, flags=re.M)
+          path.write_text(new, encoding="utf-8")
+          print(f"pyproject.toml version pinned to {version}")
+          PY
+
+      - name: Sync references into bundled data/
+        working-directory: mcp_server
+        run: python scripts/sync_references.py
+
+      - name: Install build tooling
+        run: python -m pip install --upgrade pip build
+
+      - name: Build sdist + wheel
+        working-directory: mcp_server
+        run: python -m build
+
+      - name: Upload artefacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: pypi-dist
+          path: mcp_server/dist/
+
+  publish-mcp:
+    name: Publish cloud-finops-mcp to PyPI
+    needs: build-mcp
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/cloud-finops-mcp
     permissions:
       contents: read
-      id-token: write   # publish-mcp.yml needs OIDC for trusted publishing
-    uses: ./.github/workflows/publish-mcp.yml
-    with:
-      tag: ${{ needs.tag-and-release.outputs.tag }}
+      id-token: write   # required for PyPI trusted publishing (OIDC)
+    steps:
+      - name: Download artefacts
+        uses: actions/download-artifact@v4
+        with:
+          name: pypi-dist
+          path: dist/
+
+      - name: Publish via trusted publishing
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,27 +1,33 @@
 name: Publish cloud-finops-mcp to PyPI
 
 on:
-  # Manual tag pushes from a developer machine (git push v1.x.y) still work.
+  # Manual tag pushes from a developer machine (git push v1.x.y) trigger
+  # this workflow normally - GitHub only blocks recursive triggers from
+  # GITHUB_TOKEN, not from PATs or developer machines.
   push:
     tags:
       - 'v*'
-  # Auto-tag-on-plugin-bump.yml calls this workflow after pushing the tag,
-  # because tags pushed by GITHUB_TOKEN do not re-trigger the `push: tags`
-  # event. Without this entry, plugin.json bumps would build the release zip
-  # but never publish the matching cloud-finops-mcp version to PyPI.
-  workflow_call:
+  # Manual recovery path: if auto-tag-on-plugin-bump.yml's inline publish
+  # job fails for any reason, you can re-publish a previously-tagged version
+  # by running `gh workflow run publish-mcp.yml -f tag=v1.x.y` (or via the
+  # Actions UI). The 2026-05-15 PyPI publish failure was the immediate
+  # motivator for this entry.
+  workflow_dispatch:
     inputs:
       tag:
         required: true
         type: string
-        description: 'Tag to publish (e.g. v1.22.1)'
+        description: 'Tag to publish, e.g. v1.22.1'
 
 # Trusted publishing via OIDC. No PyPI API token in repo secrets.
-# One-time setup: in PyPI project settings for "cloud-finops-mcp", add this
-# repo (OptimNow/cloud-finops-skills) as a trusted publisher with workflow
-# filename "publish-mcp.yml" and environment "pypi". The workflow filename
-# claim does not change when invoked via workflow_call, so the same trusted
-# publisher config works for both trigger paths.
+# One-time setup: in PyPI project settings for "cloud-finops-mcp", this repo
+# (OptimNow/cloud-finops-skills) is registered as a trusted publisher with
+# workflow filename "publish-mcp.yml" and environment "pypi". A SECOND
+# trusted-publisher entry exists for "auto-tag-on-plugin-bump.yml" so the
+# inline publish job in that workflow can also publish on plugin.json bumps.
+# Reusable-workflow (workflow_call) invocation is NOT used here because PyPI's
+# trusted publishing does not support reusable workflows
+# (https://docs.pypi.org/trusted-publishers/troubleshooting/#reusable-workflows-on-github).
 
 permissions:
   contents: read
@@ -37,13 +43,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          # When triggered via push:tags, github.ref_name is the tag and the
-          # default checkout grabs the tagged commit. When invoked via
-          # workflow_call from auto-tag-on-plugin-bump.yml, the default checkout
-          # would grab the caller's main HEAD; that SHA is identical to the tag
-          # in practice (auto-tag pushes the tag at HEAD before calling this
-          # workflow), so we explicitly use the tag input when provided to make
-          # the contract obvious.
+          # push:tags -> github.ref is refs/tags/<tag>; default checkout grabs
+          # the tagged commit. workflow_dispatch -> use the explicit tag input
+          # so manual recovery can target any historical tag.
           ref: ${{ inputs.tag || github.ref }}
 
       - name: Set up Python
@@ -56,10 +58,8 @@ jobs:
         env:
           INPUT_TAG: ${{ inputs.tag }}
         run: |
-          # When invoked via workflow_call, ${GITHUB_REF_NAME} is the calling
-          # workflow's ref (typically "main"), not a tag. Prefer the explicit
-          # tag input when provided; fall back to GITHUB_REF_NAME for the
-          # `push: tags` trigger.
+          # workflow_dispatch -> use the explicit tag input.
+          # push:tags -> GITHUB_REF_NAME is the tag.
           TAG="${INPUT_TAG:-${GITHUB_REF_NAME}}"
           VERSION="${TAG#v}"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Why

PR #88's `workflow_call` chain failed in production after merge because **PyPI Trusted Publishing does not support reusable workflows** ([docs.pypi.org](https://docs.pypi.org/trusted-publishers/troubleshooting/#reusable-workflows-on-github)).

The OIDC token's `workflow` claim correctly identified `publish-mcp.yml`, but the attestation's `build_config_uri` claim pointed to the calling workflow (`auto-tag-on-plugin-bump.yml`) and PyPI rejected the upload with HTTP 400. Net effect: v1.22.1 GitHub release exists, PyPI stayed on 1.21.0.

## What

1. **Inline the build + publish steps into `auto-tag-on-plugin-bump.yml`** as two new jobs (`build-mcp`, `publish-mcp`). PyPI now sees `auto-tag-on-plugin-bump.yml` as the trusted publisher directly. No reusable-workflow indirection.
2. **Revert `workflow_call` from `publish-mcp.yml`**; add `workflow_dispatch` with a `tag` input instead. Manual recovery path: `gh workflow run publish-mcp.yml -f tag=v1.x.y`. The `push: tags` trigger is unchanged so manual `git push v1.x.y` from a developer machine still works.
3. Surface a `version` output from the tag-and-release job so the inline build job can pin the pyproject version without reparsing.

## ⚠️ One-time PyPI config step required after merge

In [cloud-finops-mcp's PyPI project settings](https://pypi.org/manage/project/cloud-finops-mcp/settings/publishing/), add a **second** trusted publisher entry:
- **Owner**: `OptimNow`
- **Repository name**: `cloud-finops-skills`
- **Workflow filename**: `auto-tag-on-plugin-bump.yml`
- **Environment**: `pypi`

The existing `publish-mcp.yml` entry stays (manual paths still need it).

## Validation plan
- [ ] After merge, run `gh workflow run publish-mcp.yml -f tag=v1.22.1` to backfill PyPI to 1.22.1 (validates the manual path - works without the new PyPI config).
- [ ] After PyPI second trusted publisher is added, bump plugin.json to 1.22.2 in a follow-up PR to validate the inline auto path end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)