### PR TITLE
Bump plugin to 1.22.2 (validate PyPI publish chain)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloud-finops",
-  "version": "1.22.1",
+  "version": "1.22.2",
   "description": "Expert FinOps guidance for cloud, AI, SaaS, and data-platform spend (multi-provider, model-agnostic).",
   "author": {
     "name": "OptimNow",


### PR DESCRIPTION
## Why

Smoke test for the inline PyPI publish chain that landed in [PR #89](https://github.com/OptimNow/cloud-finops-skills/pull/89). No content change.

## What gets exercised on merge

1. `auto-tag-on-plugin-bump.yml` reads version `1.22.2` from plugin.json
2. Creates tag `v1.22.2` and the GitHub Release zip
3. Inline `build-mcp` + `publish-mcp` jobs build and upload `cloud-finops-mcp` 1.22.2 to PyPI via the new trusted-publisher entry for `auto-tag-on-plugin-bump.yml`

## Success criteria

- [ ] `v1.22.2` tag exists on GitHub
- [ ] `cloud-finops-v1.22.2.zip` attached to the GitHub Release
- [ ] PyPI shows `cloud-finops-mcp` at 1.22.2

## Fallback if it fails

`gh workflow run publish-mcp.yml -f tag=v1.22.2` (manual recovery path, validated for 1.22.1 earlier today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)