### PR TITLE
Set retention-days: 7 on pypi-dist workflow artefacts

### DIFF
--- a/.github/workflows/auto-tag-on-plugin-bump.yml
+++ b/.github/workflows/auto-tag-on-plugin-bump.yml
@@ -185,6 +185,10 @@ jobs:
         with:
           name: pypi-dist
           path: mcp_server/dist/
+          # Inter-job plumbing only; the durable copy is on PyPI. Default
+          # retention is 90 days, which is far longer than this artifact's
+          # value (zero once the publish job succeeds).
+          retention-days: 7
 
   publish-mcp:
     name: Publish cloud-finops-mcp to PyPI

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -101,6 +101,10 @@ jobs:
         with:
           name: pypi-dist
           path: mcp_server/dist/
+          # Inter-job plumbing only; the durable copy is on PyPI. Default
+          # retention is 90 days, which is far longer than this artifact's
+          # value (zero once the publish job succeeds).
+          retention-days: 7
 
   publish:
     name: Publish to PyPI


### PR DESCRIPTION
## Summary

Trim the GitHub Actions storage footprint of the `pypi-dist` workflow artefact from the default 90 days to 7 days. Touches both publish chains.

## Why

`pypi-dist` is **inter-job plumbing only** — it hands the built wheel + sdist from the `build` job to the `publish` job inside the same workflow run. Once the publish job succeeds, the durable copy lives on [PyPI](https://pypi.org/project/cloud-finops-mcp/) and the artefact's value drops to zero.

Default retention (90 days on public repos) is far longer than this artefact actually needs to exist. **7 days** is enough margin to debug a publish failure and re-run via `workflow_dispatch` on the same tag without churning storage on every release.

## Files

- `.github/workflows/auto-tag-on-plugin-bump.yml`
- `.github/workflows/publish-mcp.yml`

## Test plan

- [x] YAML parses (no syntax change beyond the new `retention-days: 7` key)
- [ ] Next plugin-version bump triggers `auto-tag-on-plugin-bump.yml`; observe that the workflow's artefact-storage page shows a 7-day expiry on the new `pypi-dist`

🤖 Generated with [Claude Code](https://claude.com/claude-code)