### PR TITLE
Bump plugin to 1.22.3: roll forward doc/license/spelling fixes

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloud-finops",
-  "version": "1.22.2",
+  "version": "1.22.3",
   "description": "Expert FinOps guidance for cloud, AI, SaaS, and data-platform spend (multi-provider, model-agnostic).",
   "author": {
     "name": "OptimNow",


### PR DESCRIPTION
## Summary

Patch release. Picks up the three doc-hygiene PRs that landed since v1.22.2 so the published release zip and PyPI package match `main`.

## Contents

- [#91](https://github.com/OptimNow/cloud-finops-skills/pull/91) - Doc-count drift (15 -> 23 playbooks), playbook CC BY-SA footers, MCP test fixture refactor, README directory tree, em dash cleanup, CLAUDE.md PR checklist
- [#92](https://github.com/OptimNow/cloud-finops-skills/pull/92) - British-spelling sweep on 11 reference files' body prose
- [#93](https://github.com/OptimNow/cloud-finops-skills/pull/93) - Workflow artefact retention 90d -> 7d

No functional change. No new features. Pure hygiene.

## What this triggers on merge

`auto-tag-on-plugin-bump.yml` reads the new `.version` and:
1. Creates the `v1.22.3` git tag
2. Builds `cloud-finops-v1.22.3.zip` and creates the GitHub Release with the zip attached
3. Builds the Python wheel + sdist and publishes `cloud-finops-mcp==1.22.3` to PyPI via trusted publishing

## Test plan

- [ ] PR merges → auto-tag workflow fires
- [ ] `v1.22.3` tag visible on https://github.com/OptimNow/cloud-finops-skills/tags
- [ ] Release zip attached at https://github.com/OptimNow/cloud-finops-skills/releases/latest
- [ ] `cloud-finops-mcp==1.22.3` visible on https://pypi.org/project/cloud-finops-mcp/
- [ ] The pypi-dist workflow artefact shows 7-day retention (from #93)

🤖 Generated with [Claude Code](https://claude.com/claude-code)