### PR TITLE
Fix marketplace.json schema to match Anthropic canonical pattern (v1.23.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,25 +1,20 @@
 {
-  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "optimnow",
-  "description": "Cloud Financial Management references and tooling by OptimNow.",
   "owner": {
     "name": "OptimNow",
     "url": "https://optimnow.io"
+  },
+  "metadata": {
+    "description": "Cloud Financial Management references and tooling by OptimNow.",
+    "version": "1.23.1"
   },
   "plugins": [
     {
       "name": "cloud-finops",
       "description": "Expert FinOps guidance for cloud, AI, SaaS, and data-platform spend. 28 reference files spanning AWS (incl. SageMaker operational FinOps and GPU instance rightsizing), Azure, GCP, Anthropic, Bedrock, Azure OpenAI, Vertex AI, Databricks, Microsoft Fabric, Snowflake, OCI, AI coding tools, FinOps Framework 2024+2026, GreenOps (AWS Sustainability Console, CSRD engagement framing), self-hosted vs managed AI inference decisioning, anomaly management, allocation and showback, chargeback (incl. Finance and accounting prerequisites), onboarding workloads (migration-time cost hygiene + M&A), Kubernetes (cross-cluster EKS/GKE/AKS discipline), waste-detection playbooks (seven-category taxonomy backed by OptimNow's WasteLine appliance) plus 23 RAG-friendly named-pattern playbooks across AWS, Azure, GCP and cross-cloud (incl. SageMaker idle endpoint, notebook auto-shutdown, MME consolidation, oversized GPU, multi-GPU underutilization, MIG candidate, GPU for CPU-bound workload, outdated GPU generation), SaaS asset management, and ITAM. Open source, model-agnostic, refreshed monthly.",
-      "author": {
-        "name": "OptimNow",
-        "url": "https://optimnow.io"
-      },
-      "category": "knowledge",
-      "source": {
-        "source": "github",
-        "repo": "OptimNow/cloud-finops-skills"
-      },
-      "homepage": "https://github.com/OptimNow/cloud-finops-skills"
+      "source": "./",
+      "strict": false,
+      "skills": ["./skills/cloud-finops"]
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloud-finops",
-  "version": "1.23.0",
+  "version": "1.23.1",
   "description": "Expert FinOps guidance for cloud, AI, SaaS, and data-platform spend (multi-provider, model-agnostic).",
   "author": {
     "name": "OptimNow",


### PR DESCRIPTION
## Summary

Cowork refuses to update from v1.22.3 to v1.23.0 despite the repo restructure landing correctly. **Root cause**: our `marketplace.json` schema diverges from the format Anthropic's own `anthropic-skills` marketplace uses, so Cowork's parser can't resolve the plugin source path and falls back to its last-known-good snapshot (1.22.3).

## Canonical pattern

Comparing against [anthropic-skills' marketplace.json](https://raw.githubusercontent.com/anthropics/skills/main/.claude-plugin/marketplace.json) the working format is:

```json
{
  "name": "...",
  "owner": { ... },
  "metadata": { "description": "...", "version": "..." },
  "plugins": [
    {
      "name": "...",
      "description": "...",
      "source": "./",
      "strict": false,
      "skills": ["./skills/<name>"]
    }
  ]
}
```

## Changes

| Field | Was | Now |
|---|---|---|
| `source` | `{"source": "github", "repo": "OptimNow/cloud-finops-skills"}` (object) | `"./"` (string — relative path to plugin root within the repo) |
| `skills` | (absent — relied on implicit discovery) | `["./skills/cloud-finops"]` (explicit) |
| `strict` | (absent) | `false` (canonical default) |
| `$schema` | `"https://anthropic.com/claude-code/marketplace.schema.json"` | (removed — not in canonical) |
| Top-level `description` | present | moved into `metadata.description` |
| `metadata.version` | (absent) | `"1.23.1"` |
| Per-plugin `author` / `category` / `homepage` | present | removed (Anthropic does not include these; `plugin.json` carries author + homepage for UI display) |

Plus `plugin.json` version bumped `1.23.0` → `1.23.1` to fire the auto-tag workflow and produce a fresh release Cowork will re-sync against.

## Expected outcome

After this PR merges:
1. Auto-tag workflow fires → `v1.23.1` tag, GitHub Release, PyPI publish
2. Cowork detects the new commit on `main`, re-pulls
3. The user's Cowork plugin updates to 1.23.1, "Compétences" tab shows `cloud-finops` (no longer empty)

## Test plan

- [x] `python -m json.tool` validates the new JSON
- [ ] After merge: `v1.23.1` tag + GitHub Release + PyPI publish (auto)
- [ ] User refreshes Cowork; plugin advances past 1.22.3 to 1.23.1; "Compétences" tab populates

🤖 Generated with [Claude Code](https://claude.com/claude-code)