### PR TITLE
Content update - 13 Jul 2026

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloud-finops",
-  "version": "1.24.0",
+  "version": "1.25.0",
   "description": "Expert FinOps guidance for cloud, AI, SaaS, and data-platform spend (multi-provider, model-agnostic).",
   "author": {
     "name": "OptimNow",

--- a/README.md
+++ b/README.md
@@ -125,7 +125,8 @@ The skill provides accurate, framework-aligned guidance across the following dom
   Savings Plans, Enterprise Discount Program (EDP) negotiation, RDS cost management,
   multi-organisation billing, cost allocation, SCPs, and AWS-native quick wins
 - **Azure FinOps** - Azure Cost Management, Reservations, Azure Policy, FinOps Toolkit,
-  Azure Hybrid Benefit, EA-to-MCA transition impact, and Azure-specific optimisation patterns
+  Azure Hybrid Benefit, EA-to-MCA transition impact, agentic FinOps (Copilot observability
+  agent, ARM MCP Server, FinOps hubs AI agents), and Azure-specific optimisation patterns
 - **GCP FinOps** - Compute Engine, Cloud SQL, GCS, BigQuery, networking optimisation
 - **Tagging governance** - tag taxonomy design, naming conventions, IaC enforcement,
   virtual tagging, MCP-based automation, and compliance monitoring

--- a/skills/cloud-finops/references/finops-anthropic.md
+++ b/skills/cloud-finops/references/finops-anthropic.md
@@ -211,22 +211,24 @@ Source: https://docs.anthropic.com/en/docs/about-claude/pricing
 
 As of July 2026, Anthropic released a set of native cost governance features - without
 an accompanying model release - that directly address cost visibility and governance
-gaps previously flagged in this file:
+gaps previously flagged in this file. **Scope note:** the release targets **Claude
+Enterprise** plan admins (covering Claude chat, Cowork, and Claude Code seat usage);
+it is not a billing surface for raw API platform spend:
 
 | Feature | What it does |
 |---|---|
-| Spend dashboard | Native view of organisation spend across models and workloads |
-| Model entitlements | Admin control over which models (and tiers) teams may access |
-| Threshold alerts | Configurable spend thresholds that trigger notifications |
-| Supporting APIs | Programmatic access to spend and entitlement data for FinOps tooling |
+| Spend dashboard | Admin analytics showing usage and cost by group and by user, with output (artifacts, files edited, skills/connectors used) shown next to cost |
+| Model entitlements | Admin control over which models are available per role or org-wide, and which model new conversations default to (chat, Cowork, Claude Code) |
+| Threshold alerts | Admins notified at 75% and 90% of an org-level spend limit; users notified in-app at 75% and 95%, with in-product limit-increase requests |
+| Admin API | Programmatic spend controls - automate limit-increase reviews, flag members near their spend limit, detect rapidly changing usage |
 
 **Assessment (as of July 2026):** this is a meaningful step toward native cost
 governance, but Finout's analysis suggests it is not yet a complete solution -
-notably around granular allocation and cross-workload attribution. Verify exact
-feature scope against Anthropic's official announcement before quoting specifics
-in a customer engagement.
+notably around granular allocation and cross-workload attribution, and it does
+not cover raw API platform spend.
 
-Source: [Anthropic keeps signaling where AI cost governance needs to go](https://www.finout.io/blog/anthropic-keeps-signaling-where-ai-cost-governance-needs-to-go.-its-not-all-the-way-there-yet) (Finout), plus Anthropic's own release.
+Sources: [Anthropic - New analytics and cost controls for Claude Enterprise](https://claude.com/blog/giving-admins-more-visibility-and-control-over-claude-usage-and-spend) (primary),
+[Anthropic keeps signaling where AI cost governance needs to go](https://www.finout.io/blog/anthropic-keeps-signaling-where-ai-cost-governance-needs-to-go.-its-not-all-the-way-there-yet) (Finout commentary).
 
 ### Managed Agents governance
 

--- a/skills/cloud-finops/references/finops-anthropic.md
+++ b/skills/cloud-finops/references/finops-anthropic.md
@@ -140,6 +140,13 @@ Unlike token-based API calls, Managed Agents introduce new cost drivers:
 > (Fast mode is a premium-priced channel, governance matters) is reliable; specific
 > multipliers and behaviours need verification against Anthropic docs before being
 > quoted as policy in customer engagements.
+>
+> **Update (as of July 2026):** Anthropic's native cost governance release (model
+> entitlements, spend dashboard, threshold alerts) provides primary-source
+> confirmation that Anthropic now treats admin-level spend controls as first-class.
+> This partially validates the governance posture described here, though the specific
+> Fast mode multipliers and retroactive-repricing behaviour still require verification
+> against Anthropic's primary pricing docs.
 
 ### What Fast mode is
 
@@ -200,6 +207,27 @@ Source: https://docs.anthropic.com/en/docs/about-claude/pricing
 | Batch jobs or background agents | Not allowed |
 | Production usage | Require approval or alerting |
 
+### Native cost governance tooling (July 2026)
+
+As of July 2026, Anthropic released a set of native cost governance features - without
+an accompanying model release - that directly address cost visibility and governance
+gaps previously flagged in this file:
+
+| Feature | What it does |
+|---|---|
+| Spend dashboard | Native view of organisation spend across models and workloads |
+| Model entitlements | Admin control over which models (and tiers) teams may access |
+| Threshold alerts | Configurable spend thresholds that trigger notifications |
+| Supporting APIs | Programmatic access to spend and entitlement data for FinOps tooling |
+
+**Assessment (as of July 2026):** this is a meaningful step toward native cost
+governance, but Finout's analysis suggests it is not yet a complete solution -
+notably around granular allocation and cross-workload attribution. Verify exact
+feature scope against Anthropic's official announcement before quoting specifics
+in a customer engagement.
+
+Source: [Anthropic keeps signaling where AI cost governance needs to go](https://www.finout.io/blog/anthropic-keeps-signaling-where-ai-cost-governance-needs-to-go.-its-not-all-the-way-there-yet) (Finout), plus Anthropic's own release.
+
 ### Managed Agents governance
 
 | Control | Recommendation |
@@ -227,6 +255,10 @@ Source: https://docs.anthropic.com/en/docs/about-claude/pricing
 - [ ] Detect Fast mode usage in CI/CD or batch jobs (anomaly detection)
 - [ ] Track Managed Agent runtime hours and resource utilisation
 - [ ] Monitor agent session persistence costs
+- [ ] Use Anthropic's native spend dashboard for organisation-level spend visibility (as of July 2026)
+- [ ] Configure native threshold alerts for spend limits per team or workload
+- [ ] Apply model entitlements to restrict access to premium models/tiers where appropriate
+- [ ] Integrate Anthropic's spend and entitlement APIs into existing FinOps tooling
 
 ---
 

--- a/skills/cloud-finops/references/finops-aws.md
+++ b/skills/cloud-finops/references/finops-aws.md
@@ -174,6 +174,18 @@ Source: https://docs.aws.amazon.com/savingsplans/latest/userguide/plan-types.htm
    guaranteed capacity in a specific AZ (e.g. GPU instances, high-demand regions),
    Standard RIs with capacity reservation are the only option.
 
+   **EC2 Auto Scaling reservations-first placement (as of July 2026).** EC2 Auto
+   Scaling now defaults to a reservations-then-balanced strategy: it prioritises
+   consuming existing Capacity Reservations (ODCRs, Capacity Blocks, and
+   Interruptible Capacity Reservations) before balancing new capacity across
+   Availability Zones. This improves reservation utilisation automatically and
+   reduces the risk of idle reserved capacity when Auto Scaling groups scale up
+   and down. For teams managing Capacity Reservations and ODCR sharing across
+   accounts, this is a relevant governance and optimisation detail: reserved
+   capacity is now more likely to be consumed by ASG-launched instances without
+   manual placement configuration, which affects how you track capacity
+   utilisation. Source: https://finopsweekly.com/news/aws-updates-2026-07-02/
+
 4. **Convertible RIs provide mid-term liquidity.** EC2 Instance Savings Plans offer
    similar flexibility at equal or better discount depth, but they are locked for
    the full term - no modifications allowed once purchased. Convertible RIs can be
@@ -295,6 +307,9 @@ START: What compute service runs the workload?
     │   - Spot nodes work well for stateless pods with proper
     │     disruption budgets and node affinity rules
     │   - For cost attribution: see Kubernetes cost management below
+    │   - EKS Auto Mode GPU fee reduction (see note below) makes
+    │     Auto Mode more cost-competitive vs self-managed node groups
+    │     for GPU workloads
     │
     └── EKS on Fargate → use Fargate decision tree above
 ```
@@ -755,6 +770,18 @@ playbook:
 - **Outdated GPU generation** - P3 (V100) or G4dn (T4) workloads that
   would run cheaper per inference on G5, G6, P4d, or P5.
   [aws-outdated-gpu-generation](../playbooks/aws-outdated-gpu-generation.md)
+
+**EKS Auto Mode / ECS Managed Instances GPU fee reduction.** As of 1 July
+2026, AWS reduced the EKS Auto Mode management fee for GPU and accelerated
+instance types - a 35% reduction for G-series instances and a 60% reduction
+for P-series and Trainium instances. The identical fee reduction applies to
+ECS Managed Instances. The reduction is applied automatically with no
+customer action required. This meaningfully narrows the cost gap between
+managed GPU infrastructure and self-managed node groups, making EKS Auto
+Mode a more cost-competitive option for GPU workloads (ML inference,
+fine-tuning, and batch). Re-evaluate the EKS Auto Mode vs Karpenter /
+self-managed cost comparison for GPU node pools in light of this change.
+Source: https://aws.amazon.com/about-aws/whats-new/2026/07/amazon-eks-auto-mode-gpu-price
 
 ---
 
@@ -2138,7 +2165,7 @@ Source: https://docs.aws.amazon.com/savingsplans/latest/userguide/plan-types.htm
 | MemoryDB | Yes - node-type specific | Yes - up to 20% discount | No | Same mechanics as ElastiCache RIs |
 | Neptune | Yes - instance-type specific | Yes - up to 35% discount (Serverless) | No | Low discount depth compared to RDS RIs |
 | OpenSearch | Yes - instance-type specific | Yes - up to 20% discount | No | Also covers legacy Elasticsearch domains |
-| Redshift | Yes - node-type specific | No | No | Consider Redshift Serverless for variable workloads (no RI available) |
+| Redshift | Yes - node-type specific (All Upfront / Partial Upfront / No Upfront for 1yr) | No | No | Consider Redshift Serverless for variable workloads (no RI available). As of July 2026, 1-year Redshift RIs support All Upfront and Partial Upfront payment options alongside No Upfront. |
 | DocumentDB | Yes - instance-type specific | No | No | Same RI mechanics as RDS commercial engines |
 
 **Verify Database Savings Plan eligibility per engine and instance class** at the
@@ -2197,6 +2224,12 @@ Is the database workload stable and predictable (90+ days of consistent usage)?
         │
         ├── Redshift
         │   → Reserved Nodes for stable provisioned clusters
+        │     - As of July 2026, 1-year Redshift RIs support All Upfront
+        │       and Partial Upfront payment options alongside the existing
+        │       No Upfront term, adding commitment flexibility. All Upfront
+        │       yields the deepest discount; Partial Upfront balances
+        │       discount depth against capital outlay.
+        │       Source: https://finopsweekly.com/news/aws-updates-2026-07-02/
         │   → For variable workloads: Redshift Serverless (no RI, pay
         │     per RPU-hour) may be cheaper than committed idle capacity
         │

--- a/skills/cloud-finops/references/finops-azure.md
+++ b/skills/cloud-finops/references/finops-azure.md
@@ -2403,6 +2403,94 @@ Pattern: `rg-{bu3chars}-{name}-{env}` (e.g., `rg-fin-webapp-dev`)
 
 ---
 
+## Agentic FinOps on Azure - Copilot agents and MCP servers
+
+Microsoft is extending cost and usage intelligence beyond the portal into agent
+workflows. As of July 2026, four surfaces matter for FinOps practitioners. They are
+frequently conflated in coverage, so exact names matter. This is the Azure-native
+counterpart to the MCP-based automation pattern documented in `finops-tagging.md`.
+
+### Azure Copilot observability agent (GA June 2026)
+
+Generally available since June 2026, with autonomous operations in public preview.
+The agent continuously analyses telemetry (application topology, dependencies,
+baseline behaviour), groups related alerts, begins investigations automatically, and
+recommends next steps. It is an operations surface, not a billing surface - its
+FinOps value is correlating "what changed" with deployment and configuration events.
+It does not restart resources or change configuration on its own, and prompts and
+responses are not used to train foundation models.
+
+### Azure Resource Manager MCP Server (public preview)
+
+A remote MCP server (hosted at `mcp.management.azure.com` - nothing to deploy) that
+gives AI agents access to Azure estate data and ARM deployments. Microsoft marketing
+also calls this the "Azure FinOps MCP Server" when framing cost scenarios - same
+product, two names in the same announcement. Six tools in the preview, cleanly split:
+
+| Half | Tools | FinOps relevance |
+|---|---|---|
+| Read (Azure Resource Graph) | `generate_query`, `validate_query`, `execute_query` | Tenant-wide estate queries in one call: cost-driver discovery by region/owner/workload, tag hygiene sweeps, orphaned-resource detection, rightsizing candidates |
+| Write (ARM deployments) | `create_template_deployment`, `get_arm_template_deployment_status`, `cancel_arm_template_deployment` | Governed remediation: tag patches, cleanup templates - every deploy is an auditable ARM operation with a correlation ID |
+
+**Permission model:** every operation runs in the context of the signed-in user -
+no service principal, no separate agent credential. The agent's effective permissions
+are exactly the human's, and Azure Policy assignments apply identically. Read-only
+agents need Reader plus Resource Graph Reader on the target scope; deploy-capable
+agents additionally need Contributor on the target resource groups.
+
+**Determinism caveat for recurring agents:** `generate_query` is non-deterministic -
+the same prompt can produce different KQL, different result sets, and therefore
+different remediation actions on different runs. Microsoft's own PoC catalogue for
+this server (24 agents, including a Cost Driver Finder, FinOps Rightsizer, Tag
+Hygiene Czar, and Weekly Cleanup PRs) pins literal KQL in reviewed rules files and
+uses the LLM only at dev time to draft queries. Adopt the same contract before
+putting a recurring FinOps agent on these tools. Microsoft's observed pattern is
+worth repeating verbatim: read-only agents are ~80% of the value at ~5% of the risk -
+start there, and gate any write behind an explicit user verb, a confirm step showing
+the resolved template and scope, and a freeze flag. This matches the
+policy-generation-over-direct-mutation doctrine in `finops-for-ai.md`.
+
+### Azure MCP Server pricing tools
+
+Distinct from the ARM MCP Server above: the **Azure MCP Server** (the `@azure/mcp`
+developer server) includes a read-only pricing tool that queries Azure retail rates
+by SKU, service, and region, with `Consumption`, `Reservation`, and
+`DevTestConsumption` price types and optional savings-plan pricing. Its FinOps use is
+**pre-deployment cost estimation inside the IDE**: extract resource types and SKUs
+from a Bicep/ARM template, query per resource, and sum monthly cost (hourly rate x
+730). This moves cost estimation from a post-deploy surprise to a design-time
+constraint.
+
+### FinOps hubs AI agents (FinOps Toolkit 14+)
+
+FinOps hubs (see "FinOps Toolkit and FinOps Hubs" above) connect AI agents to the
+hub's Data Explorer databases via the Azure MCP Server. Supported paths:
+
+- **GitHub Copilot Agent mode** with Microsoft's downloadable FinOps hub instruction
+  pack - engineers query FOCUS-normalised cost data in natural language (allocation,
+  anomaly detection, forecasting, Effective Savings Rate quantification), with the
+  KQL shown and approvable before execution
+- **Copilot Studio agent template** (added in Toolkit 14, April 2026) - publishes a
+  FinOps hub agent into Microsoft Teams or Microsoft 365 Copilot, aimed at finance,
+  product, and leadership audiences rather than engineers
+- **Any MCP client** (Claude, Continue, and others) - the hub connection is plain
+  MCP; Microsoft's instruction pack is written for Copilot but reusable
+
+Permission requirement: Database Viewer or greater on the hub's Data Explorer
+databases. The usual freshness caveat applies - answers are only as current as the
+last Cost Management export (typically every 24 hours), so ask the agent for the
+last refresh time before trusting its numbers.
+
+Sources (all Microsoft, as of July 2026):
+https://azure.microsoft.com/en-us/blog/from-insight-to-action-the-next-phase-of-agentic-cloud-operations/,
+https://techcommunity.microsoft.com/blog/azuregovernanceandmanagementblog/introducing-the-azure-resource-manager-mcp-server/4517521,
+https://techcommunity.microsoft.com/blog/azuregovernanceandmanagementblog/arm-mcp-server-a-catalog-of-24-pocs/4519069,
+https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/azure-pricing,
+https://techcommunity.microsoft.com/blog/finopsblog/whats-new-in-finops-toolkit-14-%E2%80%93-april-2026/4519497,
+https://learn.microsoft.com/en-us/cloud-computing/finops/toolkit/hubs/configure-ai
+
+---
+
 ## Azure governance tools - policy patterns and budgets
 
 The earlier "Governance - tagging and Azure Policy as a FinOps lever" section

--- a/skills/cloud-finops/references/finops-for-ai.md
+++ b/skills/cloud-finops/references/finops-for-ai.md
@@ -268,6 +268,13 @@ version); log full request and response content only for sampled traffic or erro
 | Token-level unit economics | App instrumentation + CloudWatch | App instrumentation + Azure Monitor | App instrumentation + Cloud Monitoring |
 | AI cost visibility | Bedrock inference profiles (limited) | Cost Management AI views | AI Cost Summary Agent (preview) |
 
+As of July 2026, Anthropic ships native cost governance tooling directly (announced 2 July
+2026, independent of any model release): a spend dashboard, model entitlements, threshold
+alerts, and supporting APIs. This narrows the visibility and governance gaps previously flagged
+in Anthropic's ecosystem, though it is not yet a complete solution - verify exact feature scope
+against Anthropic's official announcement before relying on specifics. See `finops-anthropic.md`
+for detail (Source: Anthropic release, 2 July 2026; Finout commentary).
+
 The common thread: native billing does not provide feature-level or user-level cost
 attribution for inference out of the box. Account and project separation handles
 team-level allocation. Application-layer instrumentation is required for feature-level

--- a/skills/cloud-finops/references/finops-for-ai.md
+++ b/skills/cloud-finops/references/finops-for-ai.md
@@ -269,11 +269,12 @@ version); log full request and response content only for sampled traffic or erro
 | AI cost visibility | Bedrock inference profiles (limited) | Cost Management AI views | AI Cost Summary Agent (preview) |
 
 As of July 2026, Anthropic ships native cost governance tooling directly (announced 2 July
-2026, independent of any model release): a spend dashboard, model entitlements, threshold
-alerts, and supporting APIs. This narrows the visibility and governance gaps previously flagged
-in Anthropic's ecosystem, though it is not yet a complete solution - verify exact feature scope
-against Anthropic's official announcement before relying on specifics. See `finops-anthropic.md`
-for detail (Source: Anthropic release, 2 July 2026; Finout commentary).
+2026, independent of any model release): admin spend analytics by group and user, model
+entitlements, spend-threshold alerts, and an Admin API. Scope: **Claude Enterprise** plans
+(chat, Cowork, Claude Code seats) - it narrows the visibility and governance gaps for that
+surface but does not cover raw API platform spend, where application-layer instrumentation
+is still required. See `finops-anthropic.md` for detail
+([Anthropic announcement, 2 July 2026](https://claude.com/blog/giving-admins-more-visibility-and-control-over-claude-usage-and-spend)).
 
 The common thread: native billing does not provide feature-level or user-level cost
 attribution for inference out of the box. Account and project separation handles

--- a/skills/cloud-finops/references/finops-gcp.md
+++ b/skills/cloud-finops/references/finops-gcp.md
@@ -296,7 +296,8 @@ usage" reflex - is the single most common BigQuery commitment failure.
 #### Principal-based reservation assignments - native slot attribution
 
 As of July 2026, BigQuery reservation assignments support an optional
-**`principal` property**, allowing queries to be routed to specific reservations
+**`principal` property** (in Preview per Google's documentation), allowing queries
+to be routed to specific reservations
 based on the calling user, service account, or third-party identity. This gives
 FinOps teams a native mechanism to attribute BigQuery slot consumption to specific
 principals/teams, directly addressing the shared-reservation attribution problem
@@ -319,7 +320,8 @@ baseline per team/service account. Combine with the waste-factor lens above to
 identify which principal is over-consuming committed slots, and to enforce
 per-principal budget guardrails inside a single shared reservation.
 
-Source: https://finopsweekly.com/news/gcp-updates-2026-07-02/
+Sources: https://docs.cloud.google.com/bigquery/docs/reservations-assignments (primary),
+https://finopsweekly.com/news/gcp-updates-2026-07-02/
 
 **Frame for clients**: BigQuery commitments trade flexibility for
 predictability, and often performance for predictability. The right

--- a/skills/cloud-finops/references/finops-gcp.md
+++ b/skills/cloud-finops/references/finops-gcp.md
@@ -293,6 +293,34 @@ maturity (Crawl or early Walk):
 Jumping straight to step 4 - the "I'll just commit to my observed average
 usage" reflex - is the single most common BigQuery commitment failure.
 
+#### Principal-based reservation assignments - native slot attribution
+
+As of July 2026, BigQuery reservation assignments support an optional
+**`principal` property**, allowing queries to be routed to specific reservations
+based on the calling user, service account, or third-party identity. This gives
+FinOps teams a native mechanism to attribute BigQuery slot consumption to specific
+principals/teams, directly addressing the shared-reservation attribution problem
+raised in the slot-commitment section above.
+
+Historically, slot consumption within a shared reservation could only be attributed
+through labels or project separation - both imperfect. Labels depend on consistent
+query-time tagging, and project separation forces organisational structure onto the
+billing model. Principal-based assignments add a third, cleaner attribution mechanism:
+
+- Route a given user, service account, or third-party identity to a specific
+  reservation, so their slot consumption is isolated and measurable
+- Enables **per-principal budget enforcement** within shared reservations, rather
+  than only at the reservation or project boundary
+- Improves allocation accuracy without relying solely on labels or project splits
+
+**Practical FinOps use:** where a shared reservation previously masked which team
+was driving the waste factor, principal-based assignments let you segment the
+baseline per team/service account. Combine with the waste-factor lens above to
+identify which principal is over-consuming committed slots, and to enforce
+per-principal budget guardrails inside a single shared reservation.
+
+Source: https://finopsweekly.com/news/gcp-updates-2026-07-02/
+
 **Frame for clients**: BigQuery commitments trade flexibility for
 predictability, and often performance for predictability. The right
 question is not "what discount can we get" but "what is the SLA the
@@ -514,6 +542,16 @@ Memorystore instances that are provisioned but unused  - whether due to deprecat
 - Decommission inactive or obsolete Memorystore instances
 - Consolidate fragmented caching layers across services or environments
 - Use automated tagging and monitoring to flag long-idle instances
+
+**Mandatory tag-binding for Bigtable instances (GA).** As of July 2026, Cloud Bigtable
+supports binding tags to instances at creation time and enforcing mandatory tag
+assignment through policies (GA). This closes a prior gap where GCP tagging governance
+relied on org policies applied post-hoc rather than enforced at creation for this
+service - enabling stronger cost-allocation governance for Bigtable workloads
+specifically. Bind allocation tags (team, cost-centre, environment) at instance
+creation and enforce them via policy so no Bigtable instance can be provisioned
+untagged. See `finops-tagging.md` for the broader tag enforcement strategy.
+Source: https://finopsweekly.com/news/gpc-updates-2026-07-10/
 
 **Excessive Shard Count In Gcp Bigtable**
 Service: GCP BigTable | Type: Inefficient Configuration

--- a/skills/cloud-finops/references/finops-kubernetes.md
+++ b/skills/cloud-finops/references/finops-kubernetes.md
@@ -303,6 +303,22 @@ the entire workload. Diversify:
 For workloads that cannot tolerate any interruption, Spot is not the right
 answer. Stay On-Demand or use commitment discounts on the on-demand portion.
 
+### GPU node pools and EKS Auto Mode fee reduction
+
+GPU node pools change the cost comparison between managed options (EKS Auto
+Mode, ECS Managed Instances) and self-managed node groups driven by
+Karpenter. As of July 2026, AWS reduced EKS Auto Mode management fees for
+GPU and accelerated instance types: a 35% reduction for G-series instances
+and a 60% reduction for P-series and Trainium instances, applied
+automatically with no customer action required. The identical fee reduction
+applies to ECS Managed Instances.
+
+This meaningfully narrows the cost gap between EKS Auto Mode and
+Karpenter / self-managed node groups for GPU workloads (ML inference,
+fine-tuning, batch). Re-run the Auto Mode vs Karpenter cost comparison for
+GPU node pools against the reduced fees before defaulting to self-managed;
+see the EKS / GPU decision tree in `finops-aws.md`.
+
 ### Idle node cost
 
 Even with rightsizing and autoscaling, the cluster will have some idle

--- a/skills/cloud-finops/references/finops-tagging.md
+++ b/skills/cloud-finops/references/finops-tagging.md
@@ -109,6 +109,7 @@ Tools:
 - AWS: Service Control Policies (SCPs) that deny resource creation without required tags
 - Azure: Azure Policy `deny` effect for missing required tags
 - GCP: Organization policies for label requirements
+- GCP Bigtable: As of July 2026, Bigtable instances support mandatory tag-binding at creation via GA policy enforcement, enabling allocation governance to be enforced at creation rather than applied post-hoc ([FinOps Weekly](https://finopsweekly.com/news/gpc-updates-2026-07-10/))
 
 **Layer 2: Detection (continuous compliance monitoring)**
 Scan deployed resources for missing or non-compliant tags on a scheduled basis.

--- a/skills/cloud-finops/references/finops-tagging.md
+++ b/skills/cloud-finops/references/finops-tagging.md
@@ -200,6 +200,16 @@ with human-in-the-loop confirmation is in active testing. Fully autonomous tag r
 (without per-operation confirmation) is intentionally not implemented - governance requires
 human approval for write operations.
 
+**Azure-native counterpart:**
+As of July 2026, Microsoft's **Azure Resource Manager MCP Server** (public preview)
+supports the same pattern natively on Azure: agents query tag compliance tenant-wide via
+Azure Resource Graph and remediate through auditable ARM template deployments, all in the
+signed-in user's identity (Reader + Resource Graph Reader for auditing; Contributor only
+where writes are needed). Microsoft's own PoC catalogue includes a "Tag Hygiene Czar"
+agent that finds resources missing required tags, generates a patch template, and deploys
+on approval - the same read-freely / write-behind-confirmation guardrail described above.
+See `finops-azure.md` ("Agentic FinOps on Azure") for the full treatment.
+
 ---
 
 ## Tagging maturity progression


### PR DESCRIPTION
## Content update - 13 Jul 2026

Closes https://github.com/OptimNow/cloud-finops-skills/issues/99

### Changes applied

- **Amazon EKS Auto Mode reduces GPU management fees by up to 60%** (PRICING_CHANGE)
  - Files: `finops-aws.md`, `finops-kubernetes.md`
  - AWS reduced EKS Auto Mode management fees for GPU and accelerated instance types starting July 1, 2026 - 35% reduction for G-series and 60% for P-series/Trainium instances, applied automatically with no customer action required. The same fee reduction applies to ECS Managed Instances, making managed GPU infrastructure meaningfully cheaper for ML inference, fine-tuning, and batch workloads on AWS.</summary>
</invoke>


- **GCP Updates 2026-07-10 | Cloud Provider News** (NEW_FEATURE)
  - Files: `finops-gcp.md`, `finops-tagging.md`
  - Google Cloud Bigtable now supports binding tags to instances at creation time and enforcing mandatory tag assignment through policies (GA), improving cost allocation governance for Bigtable workloads. This closes a gap where GCP resource tagging governance previously relied on org policies applied post-hoc rather than enforced at creation for this service.

- **AWS Updates 2026-07-02 | Cloud Provider News** (NEW_FEATURE)
  - Files: `finops-aws.md`
  - AWS EC2 Auto Scaling now uses a reservations-then-balanced strategy, prioritizing Capacity Reservations (ODCRs, Capacity Blocks, Interruptible Capacity Reservations) before balancing across AZs - improving reservation utilization automatically. Separately, Amazon Redshift now offers All Upfront and Partial Upfront payment options for 1-year Reserved Instances, adding commitment flexibility for Redshift customers.

- **GCP Updates 2026-07-02 | Cloud Provider News** (NEW_FEATURE)
  - Files: `finops-gcp.md`
  - GCP BigQuery reservation assignments now support an optional 'principal' property, allowing queries to be routed to specific reservations based on the calling user, service account, or third-party identity. This gives FinOps teams a native mechanism to attribute BigQuery slot consumption to specific principals/teams without relying solely on labels or project separation, improving allocation accuracy and enabling per-principal budget enforcement within shared reservations.

- **Anthropic Keeps Signaling Where AI Cost Governance Needs to Go. It's Not All the Way There Yet** (NEW_FEATURE)
  - Files: `finops-anthropic.md`, `finops-for-ai.md`
  - Anthropic released native cost governance tooling on July 2 - a spend dashboard, model entitlements, threshold alerts, and supporting APIs - without an accompanying model release. This directly addresses cost visibility and governance gaps previously noted in Anthropic's ecosystem (admin controls, spend monitoring, Fast mode/Managed Agents governance), though the article suggests it's not yet a complete solution.

---
_Generated by the FinOps content update pipeline._