### PR TITLE
Remove two residual hardcoded counts (AGENTS.md, mcp_server/README)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ MCP-compatible agent.
 - **SKILL.md** - entry point for Claude Code and generic agents
 - **POWER.md** - entry point for Kiro IDE (same references, different format)
 - **AGENTS.md** - entry point for Codex CLI (this file)
-- **references/** - 28 domain-specific content files (billing mechanics, pricing,
+- **references/** - domain-specific content files (billing mechanics, pricing,
   optimisation patterns)
 - **INSTALLATION.md** - cross-tool installer covering 12 tool integrations, plus
   a model-agnostic response contract for non-Claude models

--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -142,7 +142,7 @@ skill into the prompt.
 Agent prompt: *"Pull the AWS reference."*
 
 Calls `get_reference(name="finops-aws")` and gets back the full markdown body
-(~300 lines) instead of the entire 28-file knowledge base.
+(~300 lines) instead of the entire knowledge base.
 
 Agent prompt: *"Show me the obvious-confidence AWS waste playbooks."*
 


### PR DESCRIPTION
Docs-only follow-up to #101. Two "28"-count strings the drift sweep missed (they're prose, not file-path lists, so the new CI check doesn't cover them):

- `AGENTS.md:20` — "28 domain-specific content files" → "domain-specific content files"
- `mcp_server/README.md:145` — "28-file knowledge base" → "knowledge base"

No `plugin.json` bump — this does not trigger a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)