### PR TITLE
Split Agentic FinOps into finops-agentic.md (v1.28.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloud-finops",
-  "version": "1.26.0",
+  "version": "1.28.0",
   "description": "Expert FinOps guidance for cloud, AI, SaaS, and data-platform spend (multi-provider, model-agnostic).",
   "author": {
     "name": "OptimNow",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,7 @@ cloud-finops-skills/
 │       ├── optimnow-methodology.md         <- OptimNow reasoning lens, 4 pillars
 │       ├── finops-framework.md             <- FinOps Foundation framework reference
 │       ├── finops-for-ai.md                <- AI cost management discipline
+│       ├── finops-agentic.md                 <- Agentic FinOps (agent cost anatomy, x402/MPP)
 │       ├── finops-ai-value-management.md   <- AI Investment Council, stage gates
 │       ├── finops-genai-capacity.md        <- Provisioned vs shared capacity
 │       ├── finops-ai-self-hosted-vs-managed.md  <- Self-host vs managed inference

--- a/README.md
+++ b/README.md
@@ -107,8 +107,10 @@ theses with their own primary sources; see the `Roadmap` section of `CLAUDE.md`.
 
 The skill provides accurate, framework-aligned guidance across the following domains:
 
-- **FinOps for AI** - LLM inference economics, token cost management, agentic cost
-  patterns, unit economics for AI features, ROI frameworks, and AI cost governance
+- **FinOps for AI** - LLM inference economics, token cost management, harness cost
+  surface, unit economics for AI features, ROI frameworks, and AI cost governance
+- **Agentic FinOps** - workflow vs pipeline vs true agent cost behaviour, agentic
+  cost anatomy, cost-safe agent architecture, and agent-initiated payments (x402 / MPP)
 - **AI value management** - AI Investment Council, stage gate model, incremental
   funding, practice operations, cross-functional governance for AI investments
 - **GenAI capacity planning** - provisioned vs shared capacity, traffic shape analysis,
@@ -294,6 +296,7 @@ cloud-finops-skills/
     ├── references/
     │   ├── optimnow-methodology.md             ← OptimNow reasoning philosophy
     │   ├── finops-for-ai.md                    ← AI cost management
+    │   ├── finops-agentic.md                   ← Agentic FinOps (agent cost anatomy, x402/MPP)
     │   ├── finops-ai-value-management.md       ← AI investment governance
     │   ├── finops-genai-capacity.md            ← GenAI capacity models (cross-provider)
     │   ├── finops-ai-self-hosted-vs-managed.md ← Self-hosted vs managed AI inference decision

--- a/fcp-coverage.md
+++ b/fcp-coverage.md
@@ -18,7 +18,7 @@ Marker legend:
 - [x] **Data Ingestion** - finops-oci.md _(secondary: finops-aws.md; finops-azure.md; finops-gcp.md)_
 - [x] **Allocation** - finops-allocation-showback.md; finops-kubernetes.md; finops-tagging.md _(secondary: finops-ai-dev-tools.md; finops-databricks.md; finops-for-ai.md; finops-onboarding-workloads.md)_
 - [~] **Reporting & Analytics** _(secondary: finops-allocation-showback.md; finops-aws.md; finops-azure.md; finops-gcp.md)_
-- [x] **Anomaly Management** - finops-anomaly-management.md _(secondary: finops-oci.md; finops-waste-detection-playbooks.md)_
+- [x] **Anomaly Management** - finops-anomaly-management.md _(secondary: finops-agentic.md; finops-oci.md; finops-waste-detection-playbooks.md)_
 
 ## Quantify Business Value
 
@@ -30,8 +30,8 @@ Marker legend:
 
 ## Optimize Usage & Cost
 
-- [x] **Architecting & Workload Placement** - finops-ai-self-hosted-vs-managed.md; finops-onboarding-workloads.md _(secondary: finops-genai-capacity.md; finops-kubernetes.md; finops-waste-detection-playbooks.md; greenops-cloud-carbon.md)_
-- [x] **Usage Optimization** - finops-ai-dev-tools.md; finops-anthropic.md; finops-bedrock.md; finops-databricks.md; finops-snowflake.md; finops-waste-detection-playbooks.md _(secondary: finops-ai-self-hosted-vs-managed.md; finops-aws.md; finops-azure-openai.md; finops-azure.md; finops-fabric.md; finops-for-ai.md; finops-gcp.md; finops-genai-capacity.md; finops-kubernetes.md; finops-oci.md; finops-vertexai.md; greenops-cloud-carbon.md)_
+- [x] **Architecting & Workload Placement** - finops-agentic.md; finops-ai-self-hosted-vs-managed.md; finops-onboarding-workloads.md _(secondary: finops-genai-capacity.md; finops-kubernetes.md; finops-waste-detection-playbooks.md; greenops-cloud-carbon.md)_
+- [x] **Usage Optimization** - finops-ai-dev-tools.md; finops-anthropic.md; finops-bedrock.md; finops-databricks.md; finops-snowflake.md; finops-waste-detection-playbooks.md _(secondary: finops-agentic.md; finops-ai-self-hosted-vs-managed.md; finops-aws.md; finops-azure-openai.md; finops-azure.md; finops-fabric.md; finops-for-ai.md; finops-gcp.md; finops-genai-capacity.md; finops-kubernetes.md; finops-oci.md; finops-vertexai.md; greenops-cloud-carbon.md)_
 - [x] **Rate Optimization** - finops-aws.md; finops-azure-openai.md; finops-azure.md; finops-fabric.md; finops-gcp.md; finops-genai-capacity.md; finops-vertexai.md _(secondary: finops-ai-self-hosted-vs-managed.md; finops-bedrock.md; finops-databricks.md; finops-snowflake.md)_
 - [x] **Licensing & SaaS** - finops-itam.md; finops-sam.md _(secondary: finops-ai-dev-tools.md)_
 - [x] **Sustainability** - greenops-cloud-carbon.md
@@ -40,7 +40,7 @@ Marker legend:
 
 - [ ] **Executive Strategy Alignment** - **GAP** (see Roadmap in CLAUDE.md for deferred capabilities)
 - [x] **FinOps Practice Operations** - finops-framework.md; optimnow-methodology.md _(secondary: finops-ai-value-management.md; finops-onboarding-workloads.md)_
-- [~] **Governance, Policy & Risk** _(secondary: finops-tagging.md)_
+- [~] **Governance, Policy & Risk** _(secondary: finops-agentic.md; finops-tagging.md)_
 - [ ] **FinOps Education & Enablement** - **GAP** (see Roadmap in CLAUDE.md for deferred capabilities)
 - [x] **Invoicing & Chargeback** - finops-chargeback.md
 - [~] **FinOps Assessment** _(secondary: finops-framework.md)_

--- a/install.sh
+++ b/install.sh
@@ -265,7 +265,7 @@ install_cursor() {
 build_cursor_rule() {
   cat <<'EOF'
 ---
-description: Expert FinOps guidance for cloud, AI, SaaS, and data-platform spend (multi-provider, model-agnostic). Use for cost questions on AWS, Azure, GCP, Anthropic, Bedrock, Vertex AI, Azure OpenAI, Databricks, Microsoft Fabric, Snowflake, OCI, AI coding tools, self-hosted vs managed AI inference, GenAI capacity planning, AI value management, GreenOps, FinOps Framework, SaaS asset management, ITAM, anomaly management, allocation and showback, chargeback, onboarding workloads, Kubernetes FinOps, waste detection.
+description: Expert FinOps guidance for cloud, AI, SaaS, and data-platform spend (multi-provider, model-agnostic). Use for cost questions on AWS, Azure, GCP, Anthropic, Bedrock, Vertex AI, Azure OpenAI, Databricks, Microsoft Fabric, Snowflake, OCI, AI coding tools, self-hosted vs managed AI inference, agentic FinOps, GenAI capacity planning, AI value management, GreenOps, FinOps Framework, SaaS asset management, ITAM, anomaly management, allocation and showback, chargeback, onboarding workloads, Kubernetes FinOps, waste detection.
 globs:
   - "**/*"
 alwaysApply: false
@@ -408,6 +408,7 @@ Use these knowledge files for the following query types:
 | GCP cost management, BigQuery export, CUDs, SUDs, Spot, Carbon Footprint | finops-gcp.md |
 | Vertex AI pricing, Provisioned Throughput, Context Caching | finops-vertexai.md |
 | AI cost management, LLM economics, agentic patterns, ROI, methodology lens | finops-for-ai.md |
+| Agentic FinOps, agent cost anatomy, cost per completed task, cost-safe agent architecture, agent-initiated payments (x402/MPP) | finops-agentic.md |
 | AI investment governance, Investment Council, stage gates | finops-ai-value-management.md |
 | GenAI capacity planning, provisioned vs shared, spillover | finops-genai-capacity.md |
 | Self-hosted vs managed AI inference, build-vs-buy LLM, vLLM, GPU rental, hidden cost surface | finops-ai-self-hosted-vs-managed.md |
@@ -580,7 +581,8 @@ build_gemini_grouped_knowledge() {
   cat_required "$outdir/ai.md" \
     "$refs/finops-for-ai.md" "$refs/finops-anthropic.md" "$refs/finops-ai-dev-tools.md" \
     "$refs/finops-genai-capacity.md" "$refs/finops-ai-value-management.md" \
-    "$refs/finops-ai-self-hosted-vs-managed.md"
+    "$refs/finops-ai-self-hosted-vs-managed.md" \
+    "$refs/finops-agentic.md"
   cat_required "$outdir/data-platforms.md" \
     "$refs/finops-databricks.md" "$refs/finops-fabric.md" "$refs/finops-snowflake.md"
   cat_required "$outdir/oci.md" \

--- a/llms.txt
+++ b/llms.txt
@@ -20,6 +20,7 @@ infrastructure. Copy the files into your agent's context and it gains FinOps exp
 - INSTALLATION.md: cross-tool installer covering 12 tool integrations + model-agnostic response contract
 - skills/cloud-finops/references/optimnow-methodology.md: Reasoning philosophy (read first on every query)
 - skills/cloud-finops/references/finops-for-ai.md: AI cost management, token economics, agentic patterns
+- skills/cloud-finops/references/finops-agentic.md: Agentic FinOps - agent cost anatomy, cost-safe architecture, agent-initiated payments (x402/MPP)
 - skills/cloud-finops/references/finops-ai-value-management.md: AI investment governance, stage gates
 - skills/cloud-finops/references/finops-genai-capacity.md: Provisioned vs shared capacity, cross-provider
 - skills/cloud-finops/references/finops-ai-self-hosted-vs-managed.md: Self-hosted vs managed AI inference decisioning

--- a/skills/cloud-finops/POWER.md
+++ b/skills/cloud-finops/POWER.md
@@ -190,6 +190,13 @@ keywords:
   - tensor core
   - gpu memory bandwidth
   - gpu utilization misleading
+  - agentic finops
+  - agentic cost anatomy
+  - agent-initiated payments
+  - x402
+  - mpp
+  - agent wallets
+  - cost per completed task
 ---
 
 # Cloud FinOps - Expert Guidance
@@ -220,6 +227,7 @@ matching the query.
 | Query topic | Load reference |
 |---|---|
 | AI costs, LLM inference, token economics, agentic cost patterns, AI ROI, AI cost allocation, GPU cost attribution, GPU telemetry, DCGM metrics, "GPU utilization is misleading", tensor core activity, GPU memory bandwidth, RAG harness costs | `references/finops-for-ai.md` |
+| Agentic FinOps, true agents vs pipelines vs workflows, agentic cost anatomy, cost per completed task, cost-safe agent architecture, agent-initiated payments, x402, MPP, agent wallets | `references/finops-agentic.md` |
 | AI investment governance, AI Investment Council, stage gates, incremental funding, AI value management, AI practice operations | `references/finops-ai-value-management.md` |
 | GenAI capacity planning, provisioned vs shared capacity, traffic shape, spillover, throughput units | `references/finops-genai-capacity.md` |
 | Self-hosted vs managed AI inference, build vs buy LLM, vLLM, SGLang, llama.cpp, GPU rental, RunPod, CoreWeave, Lambda, hidden cost surface, ML-Ops maturity rubric, hybrid routing (LiteLLM, Portkey) | `references/finops-ai-self-hosted-vs-managed.md` |

--- a/skills/cloud-finops/SKILL.md
+++ b/skills/cloud-finops/SKILL.md
@@ -33,6 +33,7 @@ matching the query.
 | Query topic | Load reference |
 |---|---|
 | AI costs, LLM inference, token economics, agentic cost patterns, AI ROI, AI cost allocation, GPU cost attribution, GPU telemetry, DCGM metrics, "GPU utilization is misleading", tensor core activity, GPU memory bandwidth, RAG harness costs | `references/finops-for-ai.md` |
+| Agentic FinOps, true agents vs pipelines vs workflows, agentic cost anatomy, cost per completed task, cost-safe agent architecture, agent-initiated payments, x402, MPP, agent wallets | `references/finops-agentic.md` |
 | AI investment governance, AI Investment Council, stage gates, incremental funding, AI value management, AI practice operations | `references/finops-ai-value-management.md` |
 | GenAI capacity planning, provisioned vs shared capacity, traffic shape, spillover, throughput units | `references/finops-genai-capacity.md` |
 | Self-hosted vs managed AI inference, build vs buy LLM, vLLM, SGLang, llama.cpp, GPU rental, RunPod, CoreWeave, Lambda, hidden cost surface, ML-Ops maturity rubric, hybrid routing (LiteLLM, Portkey) | `references/finops-ai-self-hosted-vs-managed.md` |
@@ -131,7 +132,8 @@ premature - they risk committing to waste.
 | File | Contents | Lines |
 |---|---|---|
 | `optimnow-methodology.md` | OptimNow reasoning philosophy, 4 pillars, engagement principles, tools | ~165 |
-| `finops-for-ai.md` | AI cost management, LLM economics, agentic patterns, ROI framework, GPU telemetry (DCGM metric reference, "GPU utilization is misleading") | ~495 |
+| `finops-for-ai.md` | AI cost management, LLM economics, harness cost surface, unit economics, ROI framework, GPU telemetry (DCGM metric reference, "GPU utilization is misleading") | ~655 |
+| `finops-agentic.md` | Agentic FinOps: workflow vs pipeline vs true agent cost behaviour, agentic cost anatomy, cost-safe agent architecture, agent-initiated payments (x402 / MPP) | ~150 |
 | `finops-ai-value-management.md` | AI investment governance: AI Investment Council, stage gates, incremental funding, practice operations, value metrics | ~325 |
 | `finops-genai-capacity.md` | GenAI capacity models: provisioned vs shared, traffic shape, spillover (incl. Vertex AI default-PAYG), waste types, cross-provider comparison | ~235 |
 | `finops-ai-self-hosted-vs-managed.md` | Self-hosted vs managed AI inference: per-token vs per-hour billing, hidden cost surface (operational, reliability, compliance, talent), 5-criteria maturity rubric, hybrid routing patterns, eight client diagnostic questions, six anti-patterns | ~300 |

--- a/skills/cloud-finops/references/finops-agentic.md
+++ b/skills/cloud-finops/references/finops-agentic.md
@@ -1,0 +1,151 @@
+---
+name: finops-agentic
+fcp_domain: "Optimize Usage & Cost"
+fcp_capability: "Architecting & Workload Placement"
+fcp_capabilities_secondary: ["Usage Optimization", "Anomaly Management", "Governance, Policy & Risk"]
+fcp_phases: ["Optimize", "Operate"]
+fcp_personas_primary: ["FinOps Practitioner", "Engineering"]
+fcp_personas_collaborating: ["Product", "Finance", "Leadership", "Security"]
+fcp_maturity_entry: "Run"
+---
+
+# FinOps for Agentic Systems
+
+> True agents decide at run time what to call, in what order, and for how long, so
+> their cost is unbounded per task and settles across tokens, harness, and a new
+> direct-payment surface. This file covers agentic cost anatomy, cost-safe
+> architecture, and agent-initiated payments (x402 / MPP).
+
+Agentic systems introduce cost patterns that require a different governance model. Unlike
+static applications, agents make runtime decisions that directly affect spend - model
+selection, context retention, tool invocation frequency, and retry behaviour all create
+variable costs that no static budget can fully anticipate.
+
+## Workflow, pipeline, agent - three cost problems under one word
+
+Cost and evaluation behave differently across three system types that all get sold
+as "agents":
+
+| Type | Definition | Cost behaviour | Evaluation |
+|---|---|---|---|
+| **Workflow** | Traditional software with GenAI bolted into one or more steps | Bounded per invocation | Standard test set |
+| **Pipeline** | Predetermined steps, LLM called at one or more of them (most chatbots) | Bounded: per-call cost × known number of calls | LLM-as-judge works (fixed trajectory) |
+| **True agent** | Broad objective, tools available, decides at run time what to call, in what order, for how long | **Unbounded per task** - up to ~30x token variance on the same prompt (Pay-i-reported) | LLM-as-judge breaks: the agent constructs its own prompts, signal lives in the trajectory, not the final output |
+
+**FinOps implications:**
+
+- Budget and forecast per type. Workflows and pipelines can be unit-priced; true
+  agents must be budgeted as a **cost distribution** (P50/P90 per task), not a point
+  estimate.
+- **Procurement diligence:** most vendors selling an "agent" are selling a pipeline.
+  Often that is exactly what the client needs - but bounded-cost pipelines and
+  unbounded-cost agents deserve different contract and budget treatment. Ask which
+  one you are buying.
+- Agent failures rarely occur at the last step - they occur earlier and are masked
+  by later steps. Output-only quality gates therefore under-detect failure, which
+  understates the true cost per successful task.
+
+## Agentic cost anatomy - where the tokens actually go
+
+- **Refinement is the sink.** ~60% of an agentic task's cost sits in checking,
+  repairing, and re-verifying - not in generating the first answer (59.4%
+  review/refinement share, 53.9% average input-token share; arXiv:2601.14470,
+  analysis of 20 production agentic *coding* workflows - the mechanism generalises,
+  exact ratios vary by workload).
+- **Agentic tasks consume ~1,000x the tokens** of comparable single-turn or chat
+  interactions (arXiv:2604.22750; consistent with Anthropic's multi-agent research
+  system write-up). Long-lived context is an operating asset and a dominant cost.
+- **Multi-model by default:** ~3.5 different models per agent run on average, often
+  across providers (Pay-i-reported). Single-provider cost views structurally
+  under-count agent cost - attribution must be per task, across providers.
+- **Track cost per completed task, not per token.** Per-token price for fixed
+  capability has been falling (~6.67%/month compounding, Pay-i-reported), yet cost
+  per completed task rises in most production workloads because task ambition grows
+  faster than prices fall. Falling rate cards are not a savings forecast.
+
+**Three architectural pillars for cost-safe agents:**
+
+**1. Data connectivity with cost awareness**
+Agents require access to real-time cost data alongside operational data. An agent that
+can identify a spending anomaly but cannot correlate it to a specific resource, workflow,
+or decision point is only half useful. MCP-based connectivity (e.g., OptimNow's finops-tagging
+MCP server) provides standardized interfaces for cost data, tagging, and governance without
+custom integration code per data source.
+
+**2. Memory with cost controls**
+Stateful agents accumulate context over time - necessary for meaningful investigation but
+expensive if unbounded. Naive implementations store entire conversation histories, creating
+context windows that balloon to hundreds of thousands of tokens. Effective architectures
+use short-term memory for recent exchanges and long-term memory for persistent preferences
+and organisational context, with explicit token budgets for each layer.
+
+**3. Policy-generation over direct mutation**
+The safest agentic architecture for FinOps generates governance policies for human review
+rather than executing infrastructure changes directly. An agent that identifies idle
+resources and drafts a Cloud Custodian policy or OpenOps rule for review is production-safe.
+An agent that stops instances autonomously is not - regardless of how sophisticated its
+reasoning is. Governance, not technology capability, is the real constraint on autonomous
+FinOps agents.
+
+## Agents as cost actors: agent-initiated payments (x402 / MPP)
+
+Agent spend historically reached the organisation through two mediated channels:
+token consumption (cloud/model bill) and SaaS or API contracts signed by humans.
+A third, unmediated channel is now live: agents paying for resources directly -
+per request, from a funded wallet, with no account, API key, or procurement step.
+
+**The mechanics.** Both protocols are built on HTTP `402 Payment Required`: the
+agent requests a resource, receives a 402 challenge (amount, recipient, network),
+pays - typically in USDC stablecoin - and retries with a payment proof; the seller
+verifies, settles, and returns the resource with a receipt.
+
+| Layer | What exists (as of July 2026) |
+|---|---|
+| Protocol | **x402** - open standard, created by Coinbase, now a Linux Foundation project (x402 Foundation; Coinbase and Cloudflare founding members; AWS, Stripe, Vercel among members). **MPP** (Machine Payments Protocol) - Stripe + Tempo Labs, IETF standards track, adds card rails and streaming payment sessions, backwards-compatible with x402 |
+| Platform rails | **Amazon Bedrock AgentCore Payments** - managed wallets via Coinbase CDP or Stripe (Privy); every payment runs in a *payment session* with a spending cap (`maxSpendAmount`) and expiry; wallets start empty and the end user explicitly grants the agent transaction permission; AgentCore Gateway reaches paid MCP servers/APIs incl. the Coinbase x402 Bazaar catalogue. **Cloudflare Agents SDK** - agents that pay (optional human-in-the-loop confirmation per payment) and services that charge (`paidTool`, one-line middleware) |
+| Control plane | **Ampersend** (Edge & Node, on x402 + Google A2A) - team wallets, funding automation, approvals, spend observability. Early entrant; expect a category |
+
+Scale signal: x402.org self-reported counters showed ~75M transactions / ~$24M
+volume / ~22k sellers over 30 days in July 2026 - an average of ~$0.32 per
+transaction. Micro-transactions at high frequency, not few large charges.
+
+**FinOps implications:**
+
+- **Attribution gap.** This spend settles on wallet ledgers - outside the cloud
+  bill and outside SaaS invoices. It is also *prepaid* (fund wallet, draw down),
+  inverting the invoice-in-arrears assumption of most cost reporting. Ingest
+  wallet/session ledgers as a first-class cost source next to token spend, and
+  tag payment sessions to use cases.
+- **Pre-spend controls are native on day one** - unusual for a new cost category.
+  Session caps, expiry, explicit permission grants, merchant allowlists,
+  human-in-the-loop confirmation. Make them IaC defaults so an uncapped payment
+  session is an active choice, not an accident.
+- **New shadow-spend vector.** x402 removes exactly the friction (accounts, KYC,
+  procurement) that used to force spend through central visibility. A wallet
+  funded on an engineer's card is invisible to billing exports. Define who may
+  create and fund payment instruments, from which budget. Wallets hold stablecoin
+  balances - custody and accounting questions belong to treasury/compliance, not
+  FinOps alone.
+- **Unit economics.** Cost per completed task must include direct purchases
+  (paid MCP tools, specialist APIs, licensed content, agent-to-agent payments)
+  alongside tokens and harness. Extends the per-query SaaS dimension described
+  above: same mechanism, but contract-free and invoice-free.
+- **Anomaly profile changes.** Many sub-dollar transactions behave differently
+  from the few large charges existing thresholds expect; alert on session
+  patterns and velocity, not only on amounts.
+- **Seller side.** The same rails let an organisation charge agents for its own
+  APIs, data, or MCP tools per call, without onboarding friction - a
+  monetisation option to evaluate, not only a cost risk.
+
+Sources: https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/payments-how-it-works.html,
+https://developers.cloudflare.com/agents/tools/payments/, https://x402.org/,
+https://ampersend.ai/
+
+**Key insight:** Agents will be advisory long before they are autonomous. Organisations
+making progress treat agent development as iterative learning, not project delivery.
+
+---
+
+> Sources: OptimNow methodology; x402 / MPP provider documentation (linked inline).
+
+> *Cloud FinOps Skill by [OptimNow](https://optimnow.io) - licensed under [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/).*

--- a/skills/cloud-finops/references/finops-azure.md
+++ b/skills/cloud-finops/references/finops-azure.md
@@ -2448,7 +2448,7 @@ putting a recurring FinOps agent on these tools. Microsoft's observed pattern is
 worth repeating verbatim: read-only agents are ~80% of the value at ~5% of the risk -
 start there, and gate any write behind an explicit user verb, a confirm step showing
 the resolved template and scope, and a freeze flag. This matches the
-policy-generation-over-direct-mutation doctrine in `finops-for-ai.md`.
+policy-generation-over-direct-mutation doctrine in `finops-agentic.md`.
 
 ### Azure MCP Server pricing tools
 

--- a/skills/cloud-finops/references/finops-for-ai.md
+++ b/skills/cloud-finops/references/finops-for-ai.md
@@ -636,133 +636,19 @@ Use this to diagnose an organisation's current state before recommending solutio
 
 ## Agentic FinOps
 
-Agentic systems introduce cost patterns that require a different governance model. Unlike
-static applications, agents make runtime decisions that directly affect spend - model
-selection, context retention, tool invocation frequency, and retry behaviour all create
-variable costs that no static budget can fully anticipate.
+Agentic systems (true agents that decide at run time what to call, in what order,
+and for how long) introduce cost patterns a static budget cannot anticipate:
+unbounded per-task cost, refinement-heavy token anatomy, multi-model-per-run
+attribution, cost-safe architecture patterns, and a new agent-initiated payment
+surface (x402 / MPP wallets). That material now lives in its own reference:
 
-### Workflow, pipeline, agent - three cost problems under one word
+- `finops-agentic.md` - workflow vs pipeline vs true agent cost behaviour, agentic
+  cost anatomy, the three architectural pillars for cost-safe agents, and
+  agent-initiated payments (x402 / MPP).
 
-Cost and evaluation behave differently across three system types that all get sold
-as "agents":
-
-| Type | Definition | Cost behaviour | Evaluation |
-|---|---|---|---|
-| **Workflow** | Traditional software with GenAI bolted into one or more steps | Bounded per invocation | Standard test set |
-| **Pipeline** | Predetermined steps, LLM called at one or more of them (most chatbots) | Bounded: per-call cost × known number of calls | LLM-as-judge works (fixed trajectory) |
-| **True agent** | Broad objective, tools available, decides at run time what to call, in what order, for how long | **Unbounded per task** - up to ~30x token variance on the same prompt (Pay-i-reported) | LLM-as-judge breaks: the agent constructs its own prompts, signal lives in the trajectory, not the final output |
-
-**FinOps implications:**
-
-- Budget and forecast per type. Workflows and pipelines can be unit-priced; true
-  agents must be budgeted as a **cost distribution** (P50/P90 per task), not a point
-  estimate.
-- **Procurement diligence:** most vendors selling an "agent" are selling a pipeline.
-  Often that is exactly what the client needs - but bounded-cost pipelines and
-  unbounded-cost agents deserve different contract and budget treatment. Ask which
-  one you are buying.
-- Agent failures rarely occur at the last step - they occur earlier and are masked
-  by later steps. Output-only quality gates therefore under-detect failure, which
-  understates the true cost per successful task.
-
-### Agentic cost anatomy - where the tokens actually go
-
-- **Refinement is the sink.** ~60% of an agentic task's cost sits in checking,
-  repairing, and re-verifying - not in generating the first answer (59.4%
-  review/refinement share, 53.9% average input-token share; arXiv:2601.14470,
-  analysis of 20 production agentic *coding* workflows - the mechanism generalises,
-  exact ratios vary by workload).
-- **Agentic tasks consume ~1,000x the tokens** of comparable single-turn or chat
-  interactions (arXiv:2604.22750; consistent with Anthropic's multi-agent research
-  system write-up). Long-lived context is an operating asset and a dominant cost.
-- **Multi-model by default:** ~3.5 different models per agent run on average, often
-  across providers (Pay-i-reported). Single-provider cost views structurally
-  under-count agent cost - attribution must be per task, across providers.
-- **Track cost per completed task, not per token.** Per-token price for fixed
-  capability has been falling (~6.67%/month compounding, Pay-i-reported), yet cost
-  per completed task rises in most production workloads because task ambition grows
-  faster than prices fall. Falling rate cards are not a savings forecast.
-
-**Three architectural pillars for cost-safe agents:**
-
-**1. Data connectivity with cost awareness**
-Agents require access to real-time cost data alongside operational data. An agent that
-can identify a spending anomaly but cannot correlate it to a specific resource, workflow,
-or decision point is only half useful. MCP-based connectivity (e.g., OptimNow's finops-tagging
-MCP server) provides standardized interfaces for cost data, tagging, and governance without
-custom integration code per data source.
-
-**2. Memory with cost controls**
-Stateful agents accumulate context over time - necessary for meaningful investigation but
-expensive if unbounded. Naive implementations store entire conversation histories, creating
-context windows that balloon to hundreds of thousands of tokens. Effective architectures
-use short-term memory for recent exchanges and long-term memory for persistent preferences
-and organisational context, with explicit token budgets for each layer.
-
-**3. Policy-generation over direct mutation**
-The safest agentic architecture for FinOps generates governance policies for human review
-rather than executing infrastructure changes directly. An agent that identifies idle
-resources and drafts a Cloud Custodian policy or OpenOps rule for review is production-safe.
-An agent that stops instances autonomously is not - regardless of how sophisticated its
-reasoning is. Governance, not technology capability, is the real constraint on autonomous
-FinOps agents.
-
-### Agents as cost actors: agent-initiated payments (x402 / MPP)
-
-Agent spend historically reached the organisation through two mediated channels:
-token consumption (cloud/model bill) and SaaS or API contracts signed by humans.
-A third, unmediated channel is now live: agents paying for resources directly -
-per request, from a funded wallet, with no account, API key, or procurement step.
-
-**The mechanics.** Both protocols are built on HTTP `402 Payment Required`: the
-agent requests a resource, receives a 402 challenge (amount, recipient, network),
-pays - typically in USDC stablecoin - and retries with a payment proof; the seller
-verifies, settles, and returns the resource with a receipt.
-
-| Layer | What exists (as of July 2026) |
-|---|---|
-| Protocol | **x402** - open standard, created by Coinbase, now a Linux Foundation project (x402 Foundation; Coinbase and Cloudflare founding members; AWS, Stripe, Vercel among members). **MPP** (Machine Payments Protocol) - Stripe + Tempo Labs, IETF standards track, adds card rails and streaming payment sessions, backwards-compatible with x402 |
-| Platform rails | **Amazon Bedrock AgentCore Payments** - managed wallets via Coinbase CDP or Stripe (Privy); every payment runs in a *payment session* with a spending cap (`maxSpendAmount`) and expiry; wallets start empty and the end user explicitly grants the agent transaction permission; AgentCore Gateway reaches paid MCP servers/APIs incl. the Coinbase x402 Bazaar catalogue. **Cloudflare Agents SDK** - agents that pay (optional human-in-the-loop confirmation per payment) and services that charge (`paidTool`, one-line middleware) |
-| Control plane | **Ampersend** (Edge & Node, on x402 + Google A2A) - team wallets, funding automation, approvals, spend observability. Early entrant; expect a category |
-
-Scale signal: x402.org self-reported counters showed ~75M transactions / ~$24M
-volume / ~22k sellers over 30 days in July 2026 - an average of ~$0.32 per
-transaction. Micro-transactions at high frequency, not few large charges.
-
-**FinOps implications:**
-
-- **Attribution gap.** This spend settles on wallet ledgers - outside the cloud
-  bill and outside SaaS invoices. It is also *prepaid* (fund wallet, draw down),
-  inverting the invoice-in-arrears assumption of most cost reporting. Ingest
-  wallet/session ledgers as a first-class cost source next to token spend, and
-  tag payment sessions to use cases.
-- **Pre-spend controls are native on day one** - unusual for a new cost category.
-  Session caps, expiry, explicit permission grants, merchant allowlists,
-  human-in-the-loop confirmation. Make them IaC defaults so an uncapped payment
-  session is an active choice, not an accident.
-- **New shadow-spend vector.** x402 removes exactly the friction (accounts, KYC,
-  procurement) that used to force spend through central visibility. A wallet
-  funded on an engineer's card is invisible to billing exports. Define who may
-  create and fund payment instruments, from which budget. Wallets hold stablecoin
-  balances - custody and accounting questions belong to treasury/compliance, not
-  FinOps alone.
-- **Unit economics.** Cost per completed task must include direct purchases
-  (paid MCP tools, specialist APIs, licensed content, agent-to-agent payments)
-  alongside tokens and harness. Extends the per-query SaaS dimension described
-  above: same mechanism, but contract-free and invoice-free.
-- **Anomaly profile changes.** Many sub-dollar transactions behave differently
-  from the few large charges existing thresholds expect; alert on session
-  patterns and velocity, not only on amounts.
-- **Seller side.** The same rails let an organisation charge agents for its own
-  APIs, data, or MCP tools per call, without onboarding friction - a
-  monetisation option to evaluate, not only a cost risk.
-
-Sources: https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/payments-how-it-works.html,
-https://developers.cloudflare.com/agents/tools/payments/, https://x402.org/,
-https://ampersend.ai/
-
-**Key insight:** Agents will be advisory long before they are autonomous. Organisations
-making progress treat agent development as iterative learning, not project delivery.
+The five anti-patterns above (including agentic loops) and the Phase 2
+unit-economics model still apply; `finops-agentic.md` extends them for
+runtime-autonomous agents.
 
 ---
 


### PR DESCRIPTION
## Summary
Targeted split of `finops-for-ai.md`: extracts the **Agentic FinOps** section into a dedicated `finops-agentic.md` reference. It is the fastest-churning AI-cost content (agentic cost anatomy + agent-initiated payments / x402 / MPP), so isolating it keeps monthly updates off the stable hub and gives it its own FCP facets. Scoped per discussion: only this one section moves. The GPU/DCGM, unit-economics, and anti-pattern content that most backlinks target stays in the hub.

## Changes
- **New** `skills/cloud-finops/references/finops-agentic.md` (FCP: Optimize/Operate, Architecting & Workload Placement, maturity Run; CC BY-SA footer)
- `finops-for-ai.md` keeps the section heading as a pointer stub (127 lines moved, footer preserved)
- Routing: `SKILL.md` (domain + reference table), `POWER.md` (domain + keywords), `install.sh` (ChatGPT inline routing, grouped `ai.md` bundle, Cursor rule description)
- Docs: `README.md` (covers + directory), `CLAUDE.md` (structure), `llms.txt` (CI-gated Key files)
- Backlink: `finops-azure.md` policy-generation doctrine now points at `finops-agentic.md`
- `fcp-coverage.md` regenerated; `plugin.json` -> v1.28.0

## Validation (local)
- `scripts/check-llms-txt.sh` -> OK (29 references, no stale paths)
- `scripts/fcp-coverage.sh --check` -> rc=0

## Merge note
The version bump assumes #105 (v1.27.0) merges first; if merged in the other order, adjust the `plugin.json` bump line. Otherwise independent of #105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)