### PR TITLE
Fix cloud-finops-mcp: pin to mcp SDK v1 (v1.26.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloud-finops",
-  "version": "1.26.0",
+  "version": "1.26.1",
   "description": "Expert FinOps guidance for cloud, AI, SaaS, and data-platform spend (multi-provider, model-agnostic).",
   "author": {
     "name": "OptimNow",

--- a/mcp_server/pyproject.toml
+++ b/mcp_server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cloud-finops-mcp"
-version = "1.22.2"
+version = "1.26.1"
 description = "MCP server exposing the OptimNow Cloud FinOps skill (reference library + named-pattern playbooks) as queryable tools."
 readme = "README.md"
 license = { text = "CC-BY-SA-4.0" }
@@ -29,8 +29,8 @@ classifiers = [
   "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-  "mcp>=1.0.0",
-  "pyyaml>=6.0",
+  "mcp>=1.28,<2",
+  "pyyaml>=6.0,<7",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Problem

`cloud-finops-mcp` is broken for every new install. The `mcp` Python SDK released 2.0.0 with breaking changes: `mcp.server.fastmcp` was removed. `server.py` imports `from mcp.server.fastmcp import FastMCP`, and the unbounded `mcp>=1.0.0` resolves to 2.0.0, so the server crashes at startup:

    ModuleNotFoundError: No module named 'mcp.server.fastmcp'

## Fix (dependency constraints only, no v2 migration)

- `mcp>=1.0.0` -> `mcp>=1.28,<2` (the SDK's recommended pin for packages not yet migrated to v2)
- `pyyaml>=6.0` -> `pyyaml>=6.0,<7` (defensive upper bound, same failure class)
- package version `1.22.2` -> `1.26.1`; `plugin.json` `1.26.0` -> `1.26.1` to trigger the PyPI publish chain on merge (auto-tag `v1.26.1` -> publish-mcp)

## Validation

Built the wheel and installed it in a clean, isolated venv:

- resolves **mcp 1.29.0** (a 1.x, not 2.0.0) and **pyyaml 6.0.3**
- `from mcp.server.fastmcp import FastMCP` and the server module import cleanly
- `cloud-finops-mcp` starts over stdio without exception
- suite: **41 passed / 1 failed** - the single failure is a pre-existing stale count assertion (see below), unrelated to this change

## CI note (expected red, pre-existing)

`main` CI has been red since #104 (2026-07-31): a 24th playbook was added without updating the `== 23` assertion in `test_e2e.py::test_e2e_list_playbooks`. This PR inherits that one failure; it is unrelated to the dependency fix and is tracked in a separate assertions PR. Safe to merge despite the red check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
