### PR TITLE
CI: clean-install smoke test for cloud-finops-mcp + marketplace version guard

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Cloud Financial Management references and tooling by OptimNow.",
-    "version": "1.23.1"
+    "version": "1.26.1"
   },
   "plugins": [
     {

--- a/.github/workflows/marketplace-version-check.yml
+++ b/.github/workflows/marketplace-version-check.yml
@@ -1,0 +1,40 @@
+name: marketplace version in sync
+
+# Fails if .claude-plugin/marketplace.json metadata.version drifts from
+# .claude-plugin/plugin.json version. Runs only when a version-bearing file
+# changes, so it is cheap and targeted.
+#
+# This is how metadata.version is "automated": a bot cannot commit the sync to
+# main (the "Protect main" ruleset requires a reviewed PR), so instead the guard
+# makes drift impossible - the marketplace bump must ride the same PR that bumps
+# plugin.json, or this check goes red. Same pattern as the llms.txt drift guard
+# in ci.yml.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.claude-plugin/plugin.json'
+      - '.claude-plugin/marketplace.json'
+      - 'scripts/check-marketplace-version.sh'
+      - '.github/workflows/marketplace-version-check.yml'
+  pull_request:
+    paths:
+      - '.claude-plugin/plugin.json'
+      - '.claude-plugin/marketplace.json'
+      - 'scripts/check-marketplace-version.sh'
+      - '.github/workflows/marketplace-version-check.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: plugin.json and marketplace.json versions agree
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check marketplace.json metadata.version matches plugin.json
+        run: bash scripts/check-marketplace-version.sh

--- a/.github/workflows/mcp-install-smoke.yml
+++ b/.github/workflows/mcp-install-smoke.yml
@@ -1,0 +1,89 @@
+name: cloud-finops-mcp clean-install smoke
+
+# Reproduces a first-time user install of the cloud-finops-mcp package: build the
+# wheel + sdist, install into a pristine venv with fresh dependency resolution
+# (no lockfile, no dev extras), then launch the console script and do a minimal
+# MCP round-trip.
+#
+# Why this exists: the unit tests in ci.yml run in an environment where
+# dependencies are already resolved, so they did NOT catch the mcp SDK 2.0.0
+# breaking change that broke every fresh install (unbounded "mcp>=1.0.0" pulled
+# 2.0.0, which removed mcp.server.fastmcp, crashing the server at startup). The
+# weekly cron below is the important part: it re-runs with fresh dependency
+# resolution even when our code has not changed, so an upstream release that
+# breaks us is caught within a week instead of by a user.
+
+on:
+  push:
+    paths:
+      - 'mcp_server/**'
+      - '.github/workflows/mcp-install-smoke.yml'
+  pull_request:
+    paths:
+      - 'mcp_server/**'
+      - '.github/workflows/mcp-install-smoke.yml'
+  schedule:
+    # Mondays 06:00 UTC (~07-08:00 CET) - results are ready at the start of the
+    # week. Catches breakage from a newly published upstream dependency version.
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  clean-install:
+    name: clean install + start (py ${{ matrix.python }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        # The Python versions cloud-finops-mcp declares in its pyproject.toml
+        # classifiers (requires-python is ">=3.10"). Keep this list in step with
+        # those classifiers.
+        python: ['3.10', '3.11', '3.12']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Build wheel + sdist
+        working-directory: mcp_server
+        run: |
+          python -m pip install --upgrade pip build
+          # Builds the sdist, then builds the wheel from that sdist - so both
+          # artefacts are exercised. The hatch build hook runs sync_references.py
+          # to bundle the reference + playbook data.
+          python -m build
+          echo "Built artefacts:"
+          ls -lh dist/
+
+      - name: Install into a pristine venv (fresh resolution, no lockfile)
+        working-directory: mcp_server
+        run: |
+          set -euo pipefail
+          python -m venv /tmp/cleanenv
+          /tmp/cleanenv/bin/python -m pip install --upgrade pip
+          # Install ONLY the locally built wheel - never from PyPI, so this
+          # validates the repo's code, not the last published release. Runtime
+          # dependencies (mcp, pyyaml) resolve fresh from PyPI with no lockfile,
+          # which is exactly what a first-time user gets and what surfaces an
+          # upstream breaking release.
+          /tmp/cleanenv/bin/pip install dist/*.whl
+
+      - name: Log resolved dependency versions
+        run: |
+          echo "Resolved versions in the clean environment (watch 'mcp' here):"
+          /tmp/cleanenv/bin/pip show cloud-finops-mcp mcp pyyaml | grep -E '^(Name|Version):'
+
+      - name: Smoke test the installed console script
+        # Runs with the clean venv's interpreter so the script finds the
+        # cloud-finops-mcp console script next to it. Fails loudly (with a
+        # ::error:: annotation) if the binary crashes at startup or the MCP
+        # handshake does not complete.
+        run: /tmp/cleanenv/bin/python mcp_server/scripts/smoke_install.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -636,6 +636,9 @@ Good test patterns:
       hardcoded "N references / N playbooks" counts; use "the reference library"
       phrasing. `llms.txt` is the one list to keep current.)
 - [ ] Plugin version bumped in `.claude-plugin/plugin.json` (minor for user-visible feature)
+- [ ] `.claude-plugin/marketplace.json` `metadata.version` bumped to match
+      `plugin.json` `version` (CI-gated by `scripts/check-marketplace-version.sh`
+      via the `marketplace version in sync` workflow - the two must always match)
 - [ ] Marketplace description in `.claude-plugin/marketplace.json` reflects the new
       reference file count and topic list
 - [ ] SKILL.md description stays under 1024 characters

--- a/mcp_server/scripts/smoke_install.py
+++ b/mcp_server/scripts/smoke_install.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python
+"""Clean-install smoke test for the ``cloud-finops-mcp`` console script.
+
+Reproduces what a first-time user experiences: the package is freshly installed
+(fresh dependency resolution, no lockfile) and the ``cloud-finops-mcp`` binary
+is launched. This catches the failure mode the unit tests miss - an upstream
+dependency shipping a breaking change (e.g. the ``mcp`` SDK 2.0.0 removing
+``mcp.server.fastmcp``) while our own code is unchanged.
+
+Run it with the interpreter of the environment where the package is installed,
+so the console script sits next to ``sys.executable``::
+
+    python smoke_install.py
+
+Two phases:
+
+1. **Liveness** - launch the binary, hold stdin open, and assert it is still
+   running after ``LIVENESS_SECONDS`` with no traceback on stderr. A stdio MCP
+   server is silent and long-lived; an early exit or a stderr traceback is a
+   failure.
+2. **MCP round-trip** - use the official ``mcp`` SDK stdio client to
+   ``initialize`` the server and ``list_tools``, asserting the expected tools
+   are present.
+
+Exit code 0 = pass. Any failure prints a loud, actionable message (plus a
+GitHub Actions ``::error::`` annotation) and exits 1.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess
+import sys
+import time
+from pathlib import Path
+from shutil import which
+
+LIVENESS_SECONDS = 5
+ROUNDTRIP_TIMEOUT = 30
+EXPECTED_TOOLS = {
+    "list_references",
+    "get_reference",
+    "find_references",
+    "list_playbooks",
+    "get_playbook",
+    "find_playbooks",
+}
+
+
+def _fail(msg: str) -> None:
+    """Print a loud, readable failure and exit non-zero."""
+    print("\n" + "=" * 72, file=sys.stderr)
+    print("SMOKE TEST FAILED", file=sys.stderr)
+    print("=" * 72, file=sys.stderr)
+    print(msg, file=sys.stderr)
+    print("=" * 72, file=sys.stderr)
+    # GitHub Actions annotation - surfaces at the top of the run summary.
+    print(f"::error::cloud-finops-mcp smoke test failed: {msg.splitlines()[0]}")
+    sys.exit(1)
+
+
+def _console_script() -> str:
+    """Locate the installed ``cloud-finops-mcp`` console script for this Python."""
+    bindir = Path(sys.executable).parent
+    for name in ("cloud-finops-mcp", "cloud-finops-mcp.exe"):
+        candidate = bindir / name
+        if candidate.exists():
+            return str(candidate)
+    found = which("cloud-finops-mcp")
+    if found:
+        return found
+    _fail(
+        "Could not find the 'cloud-finops-mcp' console script.\n"
+        f"Looked in {bindir} and on PATH. Is the package installed in this "
+        "environment? Check the 'pip install' step above."
+    )
+    raise SystemExit(1)  # unreachable; _fail already exits
+
+
+def phase1_liveness(cmd: str) -> None:
+    """Launch the binary and assert it stays alive and silent on stderr."""
+    print(f"[phase 1] launching '{cmd}' - expecting a silent, long-lived stdio server")
+    # Keep stdin as a pipe we never close, so the server does not receive EOF
+    # and exit. Capture stderr; discard stdout.
+    proc = subprocess.Popen(
+        [cmd],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+    )
+    time.sleep(LIVENESS_SECONDS)
+
+    rc = proc.poll()
+    if rc is not None:
+        # Exited early = crashed at startup. This is exactly the mcp 2.0.0 case.
+        err = b""
+        if proc.stderr is not None:
+            err = proc.stderr.read() or b""
+        _fail(
+            f"The server exited {LIVENESS_SECONDS}s after launch with exit code "
+            f"{rc}, but a stdio MCP server must stay running.\n"
+            "This usually means the binary crashed at startup - most often "
+            "because a dependency published a breaking change.\n"
+            "Check the resolved 'mcp' / 'pyyaml' versions logged above against "
+            "the constraints in mcp_server/pyproject.toml.\n"
+            "----- server stderr -----\n" + err.decode("utf-8", "replace")
+        )
+
+    # Still alive: stop it and inspect what it wrote to stderr during startup.
+    proc.terminate()
+    try:
+        _, err = proc.communicate(timeout=10)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        _, err = proc.communicate()
+    text = (err or b"").decode("utf-8", "replace")
+    if text.strip():
+        # A clean bare launch is silent. Print anything it wrote for diagnosis,
+        # but only fail on an actual traceback/error (a benign warning must not
+        # break the build).
+        print("[phase 1] note: server wrote to stderr during startup:")
+        print(text)
+        if "Traceback" in text or "Error" in text:
+            _fail(
+                "The server stayed alive but wrote an error/traceback to stderr "
+                "during startup (see above)."
+            )
+    print(f"[phase 1] OK - alive after {LIVENESS_SECONDS}s, no traceback on stderr")
+
+
+async def _roundtrip(cmd: str) -> set[str]:
+    from mcp import ClientSession, StdioServerParameters
+    from mcp.client.stdio import stdio_client
+
+    params = StdioServerParameters(command=cmd, args=[])
+    async with stdio_client(params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            result = await session.list_tools()
+            return {t.name for t in result.tools}
+
+
+def phase2_roundtrip(cmd: str) -> None:
+    """Do a minimal MCP handshake via the official SDK stdio client."""
+    print("[phase 2] MCP initialize + list_tools round-trip via the mcp SDK client")
+    try:
+        names = asyncio.run(asyncio.wait_for(_roundtrip(cmd), timeout=ROUNDTRIP_TIMEOUT))
+    except asyncio.TimeoutError:
+        _fail(
+            f"The MCP handshake did not complete within {ROUNDTRIP_TIMEOUT}s. "
+            "The server started but is not responding to 'initialize' - it may "
+            "be hanging on import or on transport setup."
+        )
+    except SystemExit:
+        raise
+    except BaseException as exc:  # noqa: BLE001 - any failure is a test failure
+        import traceback
+
+        _fail(
+            "The MCP handshake raised an exception - the server likely crashed "
+            "when the client connected:\n"
+            f"{type(exc).__name__}: {exc}\n"
+            "----- traceback -----\n" + traceback.format_exc()
+        )
+
+    missing = EXPECTED_TOOLS - names
+    if missing:
+        _fail(
+            "MCP initialize succeeded but the server did not expose the expected "
+            f"tools. Missing: {sorted(missing)}. Got: {sorted(names)}."
+        )
+    print(f"[phase 2] OK - MCP initialize + list_tools returned {len(names)} tools")
+
+
+def main() -> None:
+    cmd = _console_script()
+    print(f"cloud-finops-mcp smoke test - interpreter:    {sys.executable}")
+    print(f"cloud-finops-mcp smoke test - console script: {cmd}")
+    phase1_liveness(cmd)
+    phase2_roundtrip(cmd)
+    print("\nSMOKE TEST PASSED - clean install starts and speaks MCP.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check-marketplace-version.sh
+++ b/scripts/check-marketplace-version.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# check-marketplace-version.sh - Keep .claude-plugin/marketplace.json's
+# metadata.version in sync with .claude-plugin/plugin.json's version. The
+# marketplace catalogue must advertise the same version the plugin ships.
+#
+# Why this is a guard and not an auto-fixer: the marketplace version silently
+# drifted three releases behind plugin.json (1.23.1 vs 1.26.x) because nothing
+# bumps it - the release automation (auto-tag-on-plugin-bump.yml) only reads
+# plugin.json. A workflow cannot auto-commit the fix to main either, because the
+# "Protect main" ruleset requires a reviewed PR (a bot push to main is blocked).
+# So enforcement at PR time is the robust equivalent: the marketplace bump rides
+# the same PR that bumps plugin.json, and CI stays red until it does.
+#
+# Usage:
+#   ./scripts/check-marketplace-version.sh    Report drift; exit 1 if found.
+#
+# Wired into CI (.github/workflows/marketplace-version-check.yml) so a PR that
+# bumps plugin.json without bumping marketplace.json fails with a clear message.
+# Same spirit as scripts/check-llms-txt.sh.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+PLUGIN=".claude-plugin/plugin.json"
+MARKET=".claude-plugin/marketplace.json"
+
+plugin_ver="$(python3 -c "import json; print(json.load(open('$PLUGIN'))['version'])")"
+market_ver="$(python3 -c "import json; print(json.load(open('$MARKET'))['metadata']['version'])")"
+
+if [[ "$plugin_ver" != "$market_ver" ]]; then
+  echo "FAIL: version drift between plugin and marketplace." >&2
+  echo "  $PLUGIN  version          = $plugin_ver" >&2
+  echo "  $MARKET  metadata.version = $market_ver" >&2
+  echo "" >&2
+  echo "Fix: set .metadata.version in $MARKET to \"$plugin_ver\" (in the same PR" >&2
+  echo "that bumps plugin.json), then re-run. The two must always match." >&2
+  exit 1
+fi
+
+echo "OK: marketplace.json metadata.version and plugin.json version agree ($plugin_ver)."


### PR DESCRIPTION
## What

Two additions, both motivated by the mcp SDK 2.0.0 breakage that shipped a broken `cloud-finops-mcp` to PyPI without any test catching it.

### 1. Clean-install smoke test (the main ask)

New workflow `.github/workflows/mcp-install-smoke.yml` + script `mcp_server/scripts/smoke_install.py`.

Reproduces a first-time user install (the unit tests miss this - they run with dependencies already resolved):

- builds the wheel + sdist
- installs into a **pristine venv with fresh dependency resolution** (no lockfile, no dev extras, the **locally built wheel** - never from PyPI)
- launches the `cloud-finops-mcp` console script and asserts:
  - **Phase 1 (liveness):** still alive after 5s with no traceback on stderr (a stdio MCP server is silent and long-lived; an early exit or a stderr traceback fails)
  - **Phase 2 (round-trip):** an MCP `initialize` + `list_tools` handshake via the official SDK client returns the 6 expected tools
- **Matrix:** Python 3.10 / 3.11 / 3.12 (the classifiers declared in pyproject.toml), Ubuntu
- **Triggers:** push/PR touching `mcp_server/`, **a weekly cron** (Mon 06:00 UTC - the part that catches an upstream dependency breaking us when our own code has not changed), and manual dispatch
- Fails loudly with `::error::` annotations that say what to look at

### 2. marketplace.json / plugin.json version guard

`metadata.version` had silently drifted three releases (1.23.1 vs 1.26.x). New guard `scripts/check-marketplace-version.sh` + workflow `marketplace-version-check.yml` fail CI when `marketplace.json` `metadata.version` does not equal `plugin.json` `version`.

A bot cannot auto-commit the sync to `main` (the "Protect main" ruleset requires a reviewed PR), so this guard - the same idiom as `check-llms-txt.sh` - is the robust equivalent: the marketplace bump rides the same PR that bumps plugin.json. Also syncs the current value to 1.26.1 and documents the gate in the CLAUDE.md PR checklist.

## Note on CI

`main`'s `CI` check is red on a **pre-existing** stale count assertion (`test_e2e_list_playbooks`, 24 vs 23) unrelated to this PR - tracked separately. The two new checks added here (clean-install smoke, marketplace version) should be green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
