### PR TITLE
Test: derive MCP content counts dynamically instead of hardcoding

### DIFF
--- a/mcp_server/tests/conftest.py
+++ b/mcp_server/tests/conftest.py
@@ -45,12 +45,17 @@ def _populate_data() -> None:
 # Authoritative reference/playbook counts read from disk at collection
 # time. Tests assert the function output matches these counts, so adding a
 # new reference or playbook does not require hand-editing count assertions
-# across multiple test files.
+# across multiple test files. The >= 20 floor keeps an empty or misplaced
+# source directory from turning every count assertion into 0 == 0.
 @pytest.fixture(scope="session")
 def expected_references() -> int:
-    return len(list(REFERENCES_SOURCE.glob("*.md")))
+    count = len(list(REFERENCES_SOURCE.glob("*.md")))
+    assert count >= 20, f"suspiciously few references in {REFERENCES_SOURCE}"
+    return count
 
 
 @pytest.fixture(scope="session")
 def expected_playbooks() -> int:
-    return len([p for p in PLAYBOOKS_SOURCE.glob("*.md") if p.name != "README.md"])
+    count = len([p for p in PLAYBOOKS_SOURCE.glob("*.md") if p.name != "README.md"])
+    assert count >= 20, f"suspiciously few playbooks in {PLAYBOOKS_SOURCE}"
+    return count

--- a/mcp_server/tests/test_e2e.py
+++ b/mcp_server/tests/test_e2e.py
@@ -52,13 +52,15 @@ async def test_e2e_lists_tools(server_params: StdioServerParameters) -> None:
 
 
 @pytest.mark.asyncio
-async def test_e2e_list_references(server_params: StdioServerParameters) -> None:
+async def test_e2e_list_references(
+    server_params: StdioServerParameters, expected_references: int
+) -> None:
     async with stdio_client(server_params) as (read, write):
         async with ClientSession(read, write) as session:
             await session.initialize()
             result = await session.call_tool("list_references", {})
             payload = _payload(result)
-            assert payload["total"] == 29
+            assert payload["total"] == expected_references
 
 
 @pytest.mark.asyncio
@@ -87,13 +89,15 @@ async def test_e2e_find_references(server_params: StdioServerParameters) -> None
 
 
 @pytest.mark.asyncio
-async def test_e2e_list_playbooks(server_params: StdioServerParameters) -> None:
+async def test_e2e_list_playbooks(
+    server_params: StdioServerParameters, expected_playbooks: int
+) -> None:
     async with stdio_client(server_params) as (read, write):
         async with ClientSession(read, write) as session:
             await session.initialize()
             result = await session.call_tool("list_playbooks", {})
             payload = _payload(result)
-            assert payload["total"] == 25
+            assert payload["total"] == expected_playbooks
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

`mcp_server/tests/test_e2e.py` hardcoded two content counts:
- `assert payload["total"] == 29` (references)
- `assert payload["total"] == 25` (playbooks)

Both are now derived from the existing `expected_references` / `expected_playbooks` session fixtures in `conftest.py`.

## Why

These hardcoded integers have drifted twice already:
- **23-vs-24** broke `main` CI for two days after #104
- **28-vs-29** would have broken on the finops-agentic split (#110)

This is the same class of hand-maintained count the repo deliberately removed from prose in 2026-07. `test_tools.py` and `test_metadata.py` already consumed these fixtures; `test_e2e.py` was the only file left asserting literal counts.

## How

- `test_e2e_list_references` / `test_e2e_list_playbooks` now take the `expected_references` / `expected_playbooks` fixtures and assert against them.
- The fixtures count the source directories (`skills/cloud-finops/references/*.md`, `skills/cloud-finops/playbooks/*.md` excluding `README.md`) at collection time. CI runs `scripts/sync_references.py` before pytest, so the bundled `data/` the server reads and the source dirs the fixtures count always agree.
- Added a `>= 20` **sanity floor** to each fixture so an empty or misplaced source directory fails loudly with a message instead of silently passing `0 == 0`.

## Scope

Test-only change. No version bump, no `plugin.json` / `marketplace.json` changes.

## Verification

```
cd mcp_server && pytest -q
42 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)