### PR TITLE
Restore dispute resolution-time metric to finops-chargeback (from PR #49 draft)

### DIFF
--- a/skills/cloud-finops/references/finops-chargeback.md
+++ b/skills/cloud-finops/references/finops-chargeback.md
@@ -297,7 +297,14 @@ A working methodology dispute process:
 4. **Decision log**: every methodology dispute that closes either with a
    change or a "no change" decision is logged with the rationale. Future
    disputes citing the same issue get pointed at the log and closed
-5. **Annual methodology refresh**: the cumulative effect of methodology
+5. **Dispute-throughput metrics**: track dispute count, resolution time
+   against the triage SLA, and the top disputed cost classes at each
+   quarterly review. At chargeback maturity these are audit-relevant -
+   Internal Audit and the Controller expect evidence that disputes clear
+   within SLA, not merely that they are counted. Rising resolution time is
+   an early signal that the review forum is under-resourced, visible before
+   a backlog shows up in the count.
+6. **Annual methodology refresh**: the cumulative effect of methodology
    decisions over the year feeds into the annual methodology review (see
    cadence table above)
 


### PR DESCRIPTION
## What

During the 2026-08-02 branch audit, the archived draft `archive/pr49-finops-chargeback` (closed PR #49, superseded by #50/#51) was compared against the two shipped references it was split into. This restores the **one substantive element** that was genuinely dropped in the split: **resolution time as a tracked quarterly dispute-retrospective metric**.

It lands as a new **Dispute-throughput metrics** step in the *Methodology dispute process* section of `finops-chargeback.md`, scoped to the file's Finance/audit angle (SLA adherence as audit evidence for Internal Audit and the Controller).

## Comparison verdict

The PR #49 → #50/#51 split was a deliberate, high-quality editorial refactor, not a lossy one. Of the three items the audit flagged as "unique to the archived draft":

| Flagged item | Verdict |
|---|---|
| Segment-reporting materiality note | **Already shipped** in `finops-chargeback.md` (lines 145 and 230). Not lost. |
| Metrics-vs-labels allocation commentary | **Already shipped** in `finops-allocation-showback.md:134`, deliberately reworded "labels" → "tags" to match repo vocabulary. Not lost. |
| Dispute-resolution process | **Already shipped and more developed** — split into a data-quality dispute process (allocation-showback) and a methodology dispute process (chargeback). Only casualty: `resolution time` as a retrospective metric. |

So nothing else was re-added — doing so would duplicate content already in the two shipped files.

## Release-train compliance

Content-only change. No `plugin.json` or `marketplace.json` version bump, per the release-train rule.