### PR TITLE
Fix conflicting-manifests load error on install (strict: true)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "cloud-finops",
       "description": "Expert FinOps guidance for cloud, AI, SaaS, and data-platform spend. Reference files spanning AWS (incl. SageMaker operational FinOps and GPU instance rightsizing), Azure, GCP, Anthropic, Bedrock, Azure OpenAI, Vertex AI, Databricks, Microsoft Fabric, Snowflake, OCI, AI coding tools, agentic FinOps (agent cost anatomy, x402/MPP), FinOps Framework 2024+2026, GreenOps (AWS Sustainability Console, CSRD engagement framing), self-hosted vs managed AI inference decisioning, anomaly management, allocation and showback, chargeback (incl. Finance and accounting prerequisites), onboarding workloads (migration-time cost hygiene + M&A), Kubernetes (cross-cluster EKS/GKE/AKS discipline), waste-detection playbooks (seven-category taxonomy backed by OptimNow's WasteLine appliance) plus RAG-friendly named-pattern playbooks across AWS, Azure, GCP and cross-cloud (incl. SageMaker idle endpoint, notebook auto-shutdown, MME consolidation, oversized GPU, multi-GPU underutilization, MIG candidate, GPU for CPU-bound workload, outdated GPU generation, coding-agent token waste), SaaS asset management, and ITAM. Open source, model-agnostic, refreshed monthly.",
       "source": "./",
-      "strict": false,
+      "strict": true,
       "skills": ["./skills/cloud-finops"]
     }
   ]


### PR DESCRIPTION
Closes #103. Reported by @ramos2501 on 15 July 2026.

## Problem

Every new install of `cloud-finops@optimnow` reported a load error in `/doctor`, and `/reload-plugins` showed `1 error during load`:

> Plugin cloud-finops has conflicting manifests: both plugin.json and marketplace entry specify components. Set `strict: true` in marketplace entry or remove component specs from one location.

The plugin still loaded, so the impact was cosmetic in effect but not in cost - a first-run error message undermines trust in the plugin.

## Root cause

Slightly different from the issue's analysis, which assumed `plugin.json` declares components. It does not: `.claude-plugin/plugin.json` has never carried a `skills`, `commands`, or `agents` key (`git log -S'"skills"' -- .claude-plugin/plugin.json` is empty).

The second component view is **auto-discovery**. Since #95 moved the skill to `skills/cloud-finops/`, the loader finds that directory from the plugin source on its own, which collides with the marketplace entry's explicit `"skills": ["./skills/cloud-finops"]`. With `"strict": false` the loader tries to merge both views and reports the conflict.

`"strict": false` was introduced in #96 (v1.23.1) and has never been changed since.

## Fix

One line in `.claude-plugin/marketplace.json`:

```diff
-      "strict": false,
+      "strict": true,
```

`strict: true` tells the loader to use only the marketplace entry's component definitions and ignore auto-discovery. The explicit `skills` array stays as the single source of truth.

The alternative was dropping the `skills` array and letting auto-discovery stand alone. Kept the explicit declaration instead: it is the self-documenting form, and it is what the marketplace consumer reads.

## Validation

- `marketplace.json` parses as valid JSON; `skills` array and `metadata.version` unchanged
- `scripts/check-marketplace-version.sh` green (1.27.0 on both sides)

## Versioning

Content/fix PR - **no version bump**, per the release-train rule. `plugin.json`, `marketplace.json` `metadata.version`, and `mcp_server/pyproject.toml` are untouched. The fix ships with the next release PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
