### PR TITLE
Harden the MCP server: content gate, loud parse failures, facet conformance

### DIFF
--- a/.github/workflows/mcp-install-smoke.yml
+++ b/.github/workflows/mcp-install-smoke.yml
@@ -42,7 +42,7 @@ jobs:
         # The Python versions cloud-finops-mcp declares in its pyproject.toml
         # classifiers (requires-python is ">=3.10"). Keep this list in step with
         # those classifiers.
-        python: ['3.10', '3.11', '3.12']
+        python: ['3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -177,9 +177,18 @@ pytest
 
 ## Versioning
 
-The PyPI package version tracks the skill release tag. Tagging `v1.13` on the
-parent repo triggers both the skill release zip and a new `cloud-finops-mcp` PyPI
-publish so the bundled references match what the rest of the repo ships.
+The PyPI package version tracks the skill release. The trigger is a
+`.claude-plugin/plugin.json` version bump reaching `main`, not a hand-cut tag:
+the `auto-tag-on-plugin-bump` workflow reads the new version, creates the
+matching `vX.Y.Z` tag, and publishes both the skill release zip and a new
+`cloud-finops-mcp` wheel, so the bundled references match what the rest of the
+repo ships. Versions must be full three-part semver (`v1.27.0`); the workflow
+rejects anything else.
+
+Because a `plugin.json` bump publishes, content PRs never touch it. Version
+bumps live in dedicated release PRs that move `plugin.json`,
+`.claude-plugin/marketplace.json` `metadata.version`, and this package's
+`pyproject.toml` together. See the release-train rule in the repo's CLAUDE.md.
 
 ## License
 

--- a/mcp_server/pyproject.toml
+++ b/mcp_server/pyproject.toml
@@ -1,5 +1,9 @@
 [build-system]
-requires = ["hatchling>=1.18", "hatch-build-scripts>=0.0.4"]
+# Upper-bounded for the same reason the runtime deps are: an unbounded
+# dependency is how the mcp 2.0 breakage reached a published wheel.
+# hatch-build-scripts is a third-party 0.0.x plugin, so any release could
+# be breaking - pin to the 0.0.x line.
+requires = ["hatchling>=1.18,<2", "hatch-build-scripts>=0.0.4,<0.1"]
 build-backend = "hatchling.build"
 
 [project]
@@ -26,6 +30,8 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [

--- a/mcp_server/scripts/smoke_install.py
+++ b/mcp_server/scripts/smoke_install.py
@@ -29,6 +29,7 @@ GitHub Actions ``::error::`` annotation) and exits 1.
 from __future__ import annotations
 
 import asyncio
+import json
 import subprocess
 import sys
 import time
@@ -37,6 +38,13 @@ from shutil import which
 
 LIVENESS_SECONDS = 5
 ROUNDTRIP_TIMEOUT = 30
+# Floor for the bundled content. The real numbers are ~29 references and ~25
+# playbooks; the floor exists to catch a wheel built with an empty or partial
+# data bundle, not to pin exact counts (which would need bumping on every
+# content PR). A wheel that ships zero content starts cleanly and answers every
+# tool call with an empty list - phases 1 and 2 cannot tell the difference.
+MIN_REFERENCES = 20
+MIN_PLAYBOOKS = 20
 EXPECTED_TOOLS = {
     "list_references",
     "get_reference",
@@ -140,6 +148,38 @@ async def _roundtrip(cmd: str) -> set[str]:
             return {t.name for t in result.tools}
 
 
+def _parse_total(payload: str, tool: str) -> int:
+    """Pull ``total`` out of a tool result, whatever shape the SDK returns."""
+    try:
+        data = json.loads(payload)
+    except json.JSONDecodeError:
+        _fail(
+            f"{tool} did not return JSON. Got:\n{payload[:500]}"
+        )
+        raise SystemExit(1)  # unreachable
+    if not isinstance(data, dict) or "total" not in data:
+        _fail(f"{tool} returned no 'total' field. Got keys: {list(data)[:10]}")
+    return int(data["total"])
+
+
+async def _content_counts(cmd: str) -> dict[str, int]:
+    from mcp import ClientSession, StdioServerParameters
+    from mcp.client.stdio import stdio_client
+
+    params = StdioServerParameters(command=cmd, args=[])
+    counts: dict[str, int] = {}
+    async with stdio_client(params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            for tool in ("list_references", "list_playbooks"):
+                result = await session.call_tool(tool, {})
+                text = "".join(
+                    block.text for block in result.content if getattr(block, "text", None)
+                )
+                counts[tool] = _parse_total(text, tool)
+    return counts
+
+
 def phase2_roundtrip(cmd: str) -> None:
     """Do a minimal MCP handshake via the official SDK stdio client."""
     print("[phase 2] MCP initialize + list_tools round-trip via the mcp SDK client")
@@ -172,13 +212,61 @@ def phase2_roundtrip(cmd: str) -> None:
     print(f"[phase 2] OK - MCP initialize + list_tools returned {len(names)} tools")
 
 
+def phase3_content(cmd: str) -> None:
+    """Assert the wheel actually carries its content bundle.
+
+    Phases 1 and 2 pass identically on a wheel whose data/ directory is empty:
+    the server starts, speaks MCP, and lists all six tools. Only calling a tool
+    and counting the results distinguishes a working package from a hollow one.
+    """
+    print("[phase 3] calling list_references / list_playbooks to verify the data bundle")
+    try:
+        counts = asyncio.run(
+            asyncio.wait_for(_content_counts(cmd), timeout=ROUNDTRIP_TIMEOUT)
+        )
+    except asyncio.TimeoutError:
+        _fail(f"Content tool calls did not complete within {ROUNDTRIP_TIMEOUT}s.")
+    except SystemExit:
+        raise
+    except BaseException as exc:  # noqa: BLE001 - any failure is a test failure
+        import traceback
+
+        _fail(
+            "Calling a content tool raised an exception:\n"
+            f"{type(exc).__name__}: {exc}\n"
+            "----- traceback -----\n" + traceback.format_exc()
+        )
+
+    problems = []
+    for tool, floor in (
+        ("list_references", MIN_REFERENCES),
+        ("list_playbooks", MIN_PLAYBOOKS),
+    ):
+        got = counts.get(tool, 0)
+        print(f"[phase 3] {tool} -> total={got} (floor {floor})")
+        if got < floor:
+            problems.append(f"{tool} returned {got}, expected at least {floor}")
+    if problems:
+        _fail(
+            "The server starts and speaks MCP but is serving an empty or partial "
+            "content bundle:\n  - "
+            + "\n  - ".join(problems)
+            + "\nThis means the wheel was built without running "
+            "scripts/sync_references.py, or the hatch-build-scripts hook did not "
+            "fire. The package is installable and starts cleanly, so nothing else "
+            "in the pipeline catches this."
+        )
+    print("[phase 3] OK - content bundle present")
+
+
 def main() -> None:
     cmd = _console_script()
     print(f"cloud-finops-mcp smoke test - interpreter:    {sys.executable}")
     print(f"cloud-finops-mcp smoke test - console script: {cmd}")
     phase1_liveness(cmd)
     phase2_roundtrip(cmd)
-    print("\nSMOKE TEST PASSED - clean install starts and speaks MCP.")
+    phase3_content(cmd)
+    print("\nSMOKE TEST PASSED - clean install starts, speaks MCP, and serves content.")
 
 
 if __name__ == "__main__":

--- a/mcp_server/src/cloud_finops_mcp/metadata.py
+++ b/mcp_server/src/cloud_finops_mcp/metadata.py
@@ -10,11 +10,14 @@ Walks the bundled ``data/`` directory at startup, parses frontmatter from each
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
 
 import yaml
+
+logger = logging.getLogger(__name__)
 
 DATA_DIR = Path(__file__).resolve().parent / "data"
 PLAYBOOKS_DIR = DATA_DIR / "playbooks"
@@ -65,8 +68,14 @@ class Reference:
         }
 
 
-def _split_frontmatter(text: str) -> tuple[dict, str]:
-    """Return (frontmatter_dict, body). Empty frontmatter dict if none present."""
+def _split_frontmatter(text: str, source: str = "<unknown>") -> tuple[dict, str]:
+    """Return (frontmatter_dict, body). Empty frontmatter dict if none present.
+
+    A malformed frontmatter block is not fatal - the file stays in the index and
+    is still retrievable by name - but it silently loses every facet, so it
+    vanishes from ``find_references`` / ``find_playbooks`` results. Log it at
+    WARNING so the failure is visible rather than mysterious.
+    """
     if not text.startswith("---"):
         return {}, text
     parts = text.split("---", 2)
@@ -74,7 +83,20 @@ def _split_frontmatter(text: str) -> tuple[dict, str]:
         return {}, text
     try:
         fm = yaml.safe_load(parts[1]) or {}
-    except yaml.YAMLError:
+    except yaml.YAMLError as exc:
+        logger.warning(
+            "Malformed YAML frontmatter in %s - facets unavailable, the file will "
+            "not appear in any faceted query: %s",
+            source,
+            exc,
+        )
+        fm = {}
+    if not isinstance(fm, dict):
+        logger.warning(
+            "Frontmatter in %s parsed as %s, expected a mapping - facets unavailable.",
+            source,
+            type(fm).__name__,
+        )
         fm = {}
     body = parts[2].lstrip("\n")
     return fm, body
@@ -115,7 +137,7 @@ def _normalize_list(value) -> list[str]:
 
 def _parse_reference(path: Path) -> Reference:
     text = path.read_text(encoding="utf-8")
-    fm, body = _split_frontmatter(text)
+    fm, body = _split_frontmatter(text, source=path.name)
 
     name = str(fm.get("name") or path.stem)
     description = _extract_description(fm, body)
@@ -140,10 +162,28 @@ def _parse_reference(path: Path) -> Reference:
 
 @lru_cache(maxsize=1)
 def get_index() -> list[Reference]:
-    """Return the full index of bundled references, sorted by name."""
+    """Return the full index of bundled references, sorted by name.
+
+    An empty result means the wheel was built without its data bundle. The
+    server still starts and every tool still answers, just with nothing in it -
+    which is indistinguishable from a working server to any caller. Log loudly
+    so a mis-built package is diagnosable from the server's own output.
+    """
     if not DATA_DIR.exists():
+        logger.error(
+            "Reference data directory is missing (%s). This package was built "
+            "without its content bundle; every reference tool will return empty "
+            "results.",
+            DATA_DIR,
+        )
         return []
     refs = [_parse_reference(p) for p in DATA_DIR.glob("*.md")]
+    if not refs:
+        logger.error(
+            "No reference files found in %s. This package was built without its "
+            "content bundle; every reference tool will return empty results.",
+            DATA_DIR,
+        )
     refs.sort(key=lambda r: r.name)
     return refs
 
@@ -200,7 +240,7 @@ def _extract_title(body: str, fallback: str) -> str:
 
 def _parse_playbook(path: Path) -> Playbook:
     text = path.read_text(encoding="utf-8")
-    fm, body = _split_frontmatter(text)
+    fm, body = _split_frontmatter(text, source=f"playbooks/{path.name}")
 
     name = str(fm.get("name") or path.stem)
     title = _extract_title(body, fallback=name)
@@ -224,10 +264,26 @@ def _parse_playbook(path: Path) -> Playbook:
 
 @lru_cache(maxsize=1)
 def get_playbook_index() -> list[Playbook]:
-    """Return the full index of bundled playbooks, sorted by name."""
+    """Return the full index of bundled playbooks, sorted by name.
+
+    Same failure mode as :func:`get_index` - an empty bundle looks like a
+    healthy server serving nothing. Log it.
+    """
     if not PLAYBOOKS_DIR.exists():
+        logger.error(
+            "Playbook data directory is missing (%s). This package was built "
+            "without its content bundle; every playbook tool will return empty "
+            "results.",
+            PLAYBOOKS_DIR,
+        )
         return []
     playbooks = [_parse_playbook(p) for p in PLAYBOOKS_DIR.glob("*.md")]
+    if not playbooks:
+        logger.error(
+            "No playbook files found in %s. This package was built without its "
+            "content bundle; every playbook tool will return empty results.",
+            PLAYBOOKS_DIR,
+        )
     playbooks.sort(key=lambda p: p.name)
     return playbooks
 

--- a/mcp_server/src/cloud_finops_mcp/server.py
+++ b/mcp_server/src/cloud_finops_mcp/server.py
@@ -1,6 +1,7 @@
 """MCP server wiring.
 
-Registers the three v1 tools with FastMCP and runs the stdio transport.
+Registers the six tools with FastMCP and runs the stdio transport - three over
+references (list / get / find) and three over playbooks (list / get / find).
 The actual tool logic lives in :mod:`cloud_finops_mcp.tools` so it can be
 unit-tested without an MCP client.
 """
@@ -12,6 +13,7 @@ from typing import Any
 from mcp.server.fastmcp import FastMCP
 
 from . import __version__
+from . import metadata as _metadata
 from . import tools as _tools
 
 mcp = FastMCP(
@@ -89,7 +91,9 @@ def find_references(
             ``fcp_personas_collaborating``).
         maturity: Entry maturity level (``"Crawl"``, ``"Walk"``, ``"Run"``).
 
-    Returns ``{"filters": {...}, "references": [...], "total": N}``.
+    Returns ``{"filters": {...}, "references": [...], "total": N}``. A query
+    that matches nothing also returns `hint` and `valid_values`, so a typo is
+    distinguishable from a genuine gap in coverage.
     """
     return _tools.find_references(
         domain=domain,
@@ -155,9 +159,11 @@ def find_playbooks(
         confidence: ``"obvious"`` (single signal is enough),
             ``"likely"`` (two signals required), or ``"possible"``
             (needs human review). From the OptimNow three-tier confidence
-            model in ``finops-waste-detection-playbooks``.
+            model in `finops-waste-detection-playbooks`.
 
-    Returns ``{"filters": {...}, "playbooks": [...], "total": N}``.
+    Returns ``{"filters": {...}, "playbooks": [...], "total": N}``. A query
+    that matches nothing also returns `hint` and `valid_values`, so a typo is
+    distinguishable from a genuine gap in coverage.
     """
     return _tools.find_playbooks(
         scope=scope,
@@ -169,6 +175,13 @@ def find_playbooks(
 
 async def run() -> None:
     """Run the MCP server over the stdio transport."""
+    # Touch both indexes before serving. They are lru_cached and built lazily,
+    # so without this an empty content bundle stays silent until the first tool
+    # call - and then answers it with an empty list rather than an error. The
+    # index builders log at ERROR when they find nothing, which surfaces in the
+    # client's MCP server log at startup instead of never.
+    _metadata.get_index()
+    _metadata.get_playbook_index()
     # FastMCP exposes both synchronous and asynchronous run helpers; we use
     # the async one so the entry point can be called from ``asyncio.run``.
     await mcp.run_stdio_async()

--- a/mcp_server/src/cloud_finops_mcp/tools.py
+++ b/mcp_server/src/cloud_finops_mcp/tools.py
@@ -91,6 +91,98 @@ def _capability_match(ref: Reference, capability: str) -> bool:
     )
 
 
+def reference_vocabulary() -> dict[str, list[str]]:
+    """Distinct values present in the reference index, per facet.
+
+    Derived from the bundled data rather than hardcoded, so it cannot drift
+    from what the files actually declare.
+    """
+    vocab: dict[str, set[str]] = {
+        "domain": set(),
+        "capability": set(),
+        "phase": set(),
+        "persona": set(),
+        "maturity": set(),
+    }
+    for ref in get_index():
+        if ref.fcp_domain:
+            vocab["domain"].add(ref.fcp_domain)
+        if ref.fcp_capability:
+            vocab["capability"].add(ref.fcp_capability)
+        vocab["capability"].update(ref.fcp_capabilities_secondary)
+        vocab["phase"].update(ref.fcp_phases)
+        vocab["persona"].update(ref.fcp_personas_primary)
+        vocab["persona"].update(ref.fcp_personas_collaborating)
+        if ref.fcp_maturity_entry:
+            vocab["maturity"].add(ref.fcp_maturity_entry)
+    return {k: sorted(v) for k, v in vocab.items()}
+
+
+def playbook_vocabulary() -> dict[str, list[str]]:
+    """Distinct values present in the playbook index, per facet."""
+    vocab: dict[str, set[str]] = {
+        "scope": set(),
+        "service": set(),
+        "waste_category": set(),
+        "confidence": set(),
+    }
+    for pb in get_playbook_index():
+        for facet, value in (
+            ("scope", pb.scope),
+            ("service", pb.service),
+            ("waste_category", pb.waste_category),
+            ("confidence", pb.confidence),
+        ):
+            if value:
+                vocab[facet].add(value)
+    return {k: sorted(v) for k, v in vocab.items()}
+
+
+def _unmatched_filters(
+    active: dict[str, str], vocabulary: dict[str, list[str]]
+) -> list[str]:
+    """Active filter names whose value appears nowhere in the index.
+
+    A filter listed here is the reason the result set is empty - as opposed to
+    a legitimate no-overlap combination of individually-valid values.
+    """
+    unmatched = []
+    for key, value in active.items():
+        known = {v.casefold() for v in vocabulary.get(key, [])}
+        if value.casefold() not in known:
+            unmatched.append(key)
+    return unmatched
+
+
+def _empty_result_help(
+    active: dict[str, str], vocabulary: dict[str, list[str]]
+) -> dict[str, Any]:
+    """Explain a zero-match faceted query instead of returning a bare total: 0.
+
+    The name-based tools already offer difflib suggestions on a miss; the
+    faceted tools returned nothing at all, leaving the caller unable to tell a
+    typo from a genuine gap in coverage.
+    """
+    unmatched = _unmatched_filters(active, vocabulary)
+    if unmatched:
+        detail = (
+            "No match for "
+            + ", ".join(f"{k}={active[k]!r}" for k in unmatched)
+            + " - "
+            + ("that value is" if len(unmatched) == 1 else "those values are")
+            + " not present in the bundled set."
+        )
+    else:
+        detail = (
+            "Every filter value is valid on its own, but no single item carries "
+            "all of them together. Try relaxing one filter."
+        )
+    return {
+        "hint": detail,
+        "valid_values": {k: vocabulary.get(k, []) for k in active},
+    }
+
+
 def find_references(
     domain: str | None = None,
     capability: str | None = None,
@@ -102,7 +194,20 @@ def find_references(
 
     All parameters are optional and combine with AND semantics. String matches
     are case-insensitive and exact (no substring matching). Empty filters return
-    the full index.
+    the full index. A query that matches nothing returns ``hint`` and
+    ``valid_values`` alongside ``total: 0``, so a typo is distinguishable from a
+    genuine coverage gap.
+
+    Args:
+        domain: one of the four FinOps Framework domains, e.g.
+            ``"Optimize Usage & Cost"``.
+        capability: a FinOps Capability, matched against both the primary and
+            the secondary declarations, e.g. ``"Rate Optimization"``.
+        phase: ``Inform``, ``Optimize``, or ``Operate``.
+        persona: matched against both primary and collaborating personas, e.g.
+            ``"Engineering"``.
+        maturity: ``Crawl``, ``Walk``, or ``Run`` - the entry gate below which
+            the reference is premature.
     """
     filters = {
         "domain": domain,
@@ -129,11 +234,14 @@ def find_references(
             continue
         matches.append(ref)
 
-    return {
+    result: dict[str, Any] = {
         "filters": active,
         "references": [r.to_dict() for r in matches],
         "total": len(matches),
     }
+    if not matches and active:
+        result.update(_empty_result_help(active, reference_vocabulary()))
+    return result
 
 
 # --- playbook tools ---------------------------------------------------------
@@ -193,19 +301,25 @@ def find_playbooks(
     """Filter playbooks by their pattern frontmatter.
 
     All parameters are optional and combine with AND semantics. String matches
-    are case-insensitive and exact (no substring matching).
+    are case-insensitive and exact (no substring matching). A query that
+    matches nothing returns `hint` and `valid_values` alongside `total: 0`.
+
+    The double-backtick values listed below are the accepted vocabulary for
+    each facet, and are pinned against the bundled data by
+    `tests/test_conformance.py` - keep them in step when content changes.
 
     Args:
         scope: ``aws``, ``azure``, ``gcp``, or ``cross-cloud``.
         service: provider service name (e.g. ``"AWS NAT Gateway"``,
-            ``"Azure Disk Storage"``). Exact-match - use ``list_playbooks`` to
-            see the values present in the bundled set.
+            ``"Azure Managed Disks"``). Exact-match against a free-text field -
+            call ``list_playbooks`` first to see the values actually present,
+            or filter on ``scope`` instead. A miss returns the valid values.
         waste_category: ``orphaned``, ``idle``, ``overprovisioned``,
             ``commitment-mismatch``, ``schedule-blindness``, ``modernization``,
             ``ai-ml-inefficiency``, or ``egress``.
         confidence: ``obvious``, ``likely``, or ``possible`` - the OptimNow
-            three-tier confidence model from
-            ``finops-waste-detection-playbooks``.
+            three-tier confidence model defined in the
+            `finops-waste-detection-playbooks` reference.
     """
     filters = {
         "scope": scope,
@@ -231,8 +345,11 @@ def find_playbooks(
             continue
         matches.append(pb)
 
-    return {
+    result: dict[str, Any] = {
         "filters": active,
         "playbooks": [pb.to_dict() for pb in matches],
         "total": len(matches),
     }
+    if not matches and active:
+        result.update(_empty_result_help(active, playbook_vocabulary()))
+    return result

--- a/mcp_server/tests/test_conformance.py
+++ b/mcp_server/tests/test_conformance.py
@@ -1,0 +1,214 @@
+"""Conformance checks over the bundled content.
+
+These tests guard the failure class where a content PR silently degrades
+retrieval without breaking anything visibly:
+
+- a broken YAML frontmatter block leaves the file in ``list_*`` but strips
+  every facet, so it disappears from ``find_*`` (F8)
+- a facet value that exists in the data but is not advertised in the tool
+  docstring, or vice versa, makes the tool surface lie to the agent (F9)
+
+Both are invisible to a reviewer reading the markdown diff, which is why they
+are pinned here rather than left to the PR checklist.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+import pytest
+from cloud_finops_mcp import metadata, server, tools
+
+# Advertised in the find_playbooks docstring but carried by no playbook today.
+# The taxonomy defines the category and the tool offers it as a filter, so a
+# caller can ask for it and get an empty result. Tracked as a coverage gap in
+# the CLAUDE.md Roadmap. If you add a playbook for one of these, delete it from
+# this set - the test will tell you to.
+KNOWN_EMPTY_FACET_VALUES = {"commitment-mismatch"}
+
+
+FACET_ORDER = ("scope", "service", "waste_category", "confidence")
+
+# The vocabulary is written out twice: in tools.py (the implementation) and in
+# server.py (the docstring FastMCP actually publishes to the agent). server.py
+# is the one a model reads, so both are pinned and required to agree.
+DOCSTRING_SOURCES = {
+    "tools": tools.find_playbooks,
+    "server": server.find_playbooks,
+}
+
+
+def _advertised_in(fn, facet: str) -> set[str]:
+    """Pull the double-backtick-quoted values a docstring advertises for a facet.
+
+    The docstring is the contract the agent reads, so these tests parse it
+    rather than a duplicate list held in code. Single backticks are used for
+    file and field references and are deliberately not picked up here.
+    """
+    doc = fn.__doc__ or ""
+    # Google-style Args: entries sit at 8 spaces, their continuations at 12,
+    # and the following section ("Returns:", prose) dedents to 4 or less. Stop
+    # at the next entry or at that dedent, so trailing prose in the last entry
+    # is not read as part of its vocabulary.
+    m = re.search(
+        rf"^ {{8}}{facet}: (.+?)(?=^ {{8}}\w+:|^ {{0,4}}\S|\Z)", doc, re.S | re.M
+    )
+    assert m, f"{fn.__module__}.{fn.__name__} documents no {facet!r} facet"
+    # server.py quotes its values (``"aws"``), tools.py does not (``aws``).
+    return {v.strip('"').strip("'") for v in re.findall(r"``([^`]+)``", m.group(1))}
+
+
+def _advertised(facet: str) -> set[str]:
+    """The vocabulary the agent-facing docstring advertises."""
+    return _advertised_in(server.find_playbooks, facet)
+
+
+@pytest.mark.parametrize("facet", ["scope", "waste_category", "confidence"])
+def test_tools_and_server_docstrings_agree(facet: str) -> None:
+    """The two copies of the facet vocabulary must not drift apart.
+
+    server.py's docstring is what FastMCP publishes; tools.py's is what a
+    developer reads. A fix applied to one and not the other is silent.
+    """
+    in_tools = _advertised_in(tools.find_playbooks, facet)
+    in_server = _advertised_in(server.find_playbooks, facet)
+    assert in_tools == in_server, (
+        f"{facet} vocabulary differs between tools.py and server.py: "
+        f"only in tools={sorted(in_tools - in_server)}, "
+        f"only in server={sorted(in_server - in_tools)}"
+    )
+
+
+# --- frontmatter integrity (F8) --------------------------------------------
+
+
+def test_every_reference_declares_an_fcp_domain() -> None:
+    """A reference with no domain has either broken or missing frontmatter.
+
+    Either way it is unreachable via find_references(domain=...).
+    """
+    missing = [r.name for r in metadata.get_index() if not r.fcp_domain]
+    assert not missing, (
+        "references with no fcp_domain (broken or missing frontmatter): "
+        f"{sorted(missing)}"
+    )
+
+
+def test_every_reference_declares_a_capability_and_maturity() -> None:
+    incomplete = [
+        r.name
+        for r in metadata.get_index()
+        if not r.fcp_capability or not r.fcp_maturity_entry
+    ]
+    assert not incomplete, f"references missing capability or maturity: {sorted(incomplete)}"
+
+
+def test_every_reference_declares_at_least_one_phase_and_persona() -> None:
+    incomplete = [
+        r.name
+        for r in metadata.get_index()
+        if not r.fcp_phases or not r.fcp_personas_primary
+    ]
+    assert not incomplete, f"references missing phases or personas: {sorted(incomplete)}"
+
+
+def test_every_playbook_declares_all_four_facets() -> None:
+    incomplete = [
+        pb.name
+        for pb in metadata.get_playbook_index()
+        if not (pb.scope and pb.service and pb.waste_category and pb.confidence)
+    ]
+    assert not incomplete, f"playbooks with an incomplete facet set: {sorted(incomplete)}"
+
+
+def test_malformed_frontmatter_is_logged_not_swallowed(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    broken = "---\nname: x\n  bad: [unclosed\n---\n\n# Body\n"
+    with caplog.at_level(logging.WARNING, logger="cloud_finops_mcp.metadata"):
+        fm, body = metadata._split_frontmatter(broken, source="broken.md")
+    assert fm == {}
+    assert "# Body" in body
+    assert any("broken.md" in r.getMessage() for r in caplog.records), (
+        "a malformed frontmatter block must warn - silently returning {} strips "
+        "every facet and removes the file from faceted search"
+    )
+
+
+def test_non_mapping_frontmatter_is_logged(caplog: pytest.LogCaptureFixture) -> None:
+    scalar_fm = "---\njust a string\n---\n\n# Body\n"
+    with caplog.at_level(logging.WARNING, logger="cloud_finops_mcp.metadata"):
+        fm, _ = metadata._split_frontmatter(scalar_fm, source="scalar.md")
+    assert fm == {}
+    assert caplog.records
+
+
+# --- facet vocabulary conformance (F9) --------------------------------------
+
+
+@pytest.mark.parametrize("facet", ["scope", "waste_category", "confidence"])
+def test_no_facet_value_is_undocumented(facet: str) -> None:
+    """Every value in the data must be advertised by the tool docstring.
+
+    This is the check that would have caught `waste_category: egress` sitting
+    outside the taxonomy: the playbook carried a value the docs never named.
+    """
+    in_data = set(tools.playbook_vocabulary()[facet])
+    advertised = _advertised(facet)
+    undocumented = in_data - advertised
+    assert not undocumented, (
+        f"{facet} values present in playbooks but not advertised in the "
+        f"find_playbooks docstring: {sorted(undocumented)}"
+    )
+
+
+@pytest.mark.parametrize("facet", ["scope", "waste_category", "confidence"])
+def test_no_advertised_facet_value_is_empty(facet: str) -> None:
+    """Every advertised value should return something, or be a known gap.
+
+    An advertised value with no content is a silent empty result for the agent.
+    """
+    in_data = set(tools.playbook_vocabulary()[facet])
+    advertised = _advertised(facet)
+    empty = advertised - in_data - KNOWN_EMPTY_FACET_VALUES
+    assert not empty, (
+        f"{facet} values advertised by find_playbooks but carried by no "
+        f"playbook: {sorted(empty)}. Either write the playbooks or add them to "
+        "KNOWN_EMPTY_FACET_VALUES and record the gap in the CLAUDE.md Roadmap."
+    )
+
+
+def test_known_empty_values_are_still_empty() -> None:
+    """Ratchet: when a known gap is filled, this reminds you to close it out."""
+    in_data = set(tools.playbook_vocabulary()["waste_category"])
+    now_covered = KNOWN_EMPTY_FACET_VALUES & in_data
+    assert not now_covered, (
+        f"{sorted(now_covered)} now has playbook coverage. Remove it from "
+        "KNOWN_EMPTY_FACET_VALUES and drop the matching CLAUDE.md Roadmap entry."
+    )
+
+
+def test_waste_categories_match_the_taxonomy_file() -> None:
+    """The eight categories are defined in the reference, not in the code."""
+    ref = metadata.get_by_name("finops-waste-detection-playbooks")
+    assert ref is not None
+    text = ref.path.read_text(encoding="utf-8")
+    assert "## The eight waste categories" in text, (
+        "the waste taxonomy heading changed - the facet vocabulary in "
+        "find_playbooks must be re-checked against it"
+    )
+    for advertised in _advertised("waste_category"):
+        # Frontmatter uses kebab-case; the reference prose uses words.
+        assert advertised.replace("-", " ").split()[0].lower() in text.lower(), (
+            f"advertised waste_category {advertised!r} has no counterpart in "
+            "finops-waste-detection-playbooks.md"
+        )
+
+
+def test_facet_values_are_lowercase_and_consistent() -> None:
+    """Facets are matched case-insensitively but stored values should be uniform."""
+    vocab = tools.playbook_vocabulary()
+    for facet in ("scope", "waste_category", "confidence"):
+        odd = [v for v in vocab[facet] if v != v.lower()]
+        assert not odd, f"{facet} values are not lowercase: {odd}"

--- a/mcp_server/tests/test_tools.py
+++ b/mcp_server/tests/test_tools.py
@@ -189,3 +189,51 @@ def test_find_playbooks_no_match_returns_empty() -> None:
 def test_find_playbooks_filters_echo_input() -> None:
     result = tools.find_playbooks(scope="aws", waste_category="idle")
     assert result["filters"] == {"scope": "aws", "waste_category": "idle"}
+
+
+# --- empty faceted results explain themselves (F21) -------------------------
+
+
+def test_find_references_typo_returns_valid_values() -> None:
+    """A bare {"total": 0} cannot be told apart from a genuine coverage gap."""
+    result = tools.find_references(domain="Optimise Usage & Cost")  # British misspelling
+    assert result["total"] == 0
+    assert "hint" in result
+    assert "domain" in result["valid_values"]
+    assert "Optimize Usage & Cost" in result["valid_values"]["domain"]
+    assert "not present" in result["hint"]
+
+
+def test_find_playbooks_typo_returns_valid_values() -> None:
+    result = tools.find_playbooks(waste_category="orphan")  # actual value is "orphaned"
+    assert result["total"] == 0
+    assert "orphaned" in result["valid_values"]["waste_category"]
+
+
+def test_valid_but_non_overlapping_filters_say_so() -> None:
+    """Each value exists; the combination does not. That is a different message."""
+    result = tools.find_playbooks(scope="azure", service="AWS NAT Gateway")
+    assert result["total"] == 0
+    assert "no single item carries all of them" in result["hint"]
+
+
+def test_empty_result_help_is_absent_when_there_are_matches() -> None:
+    result = tools.find_playbooks(scope="aws")
+    assert result["total"] > 0
+    assert "hint" not in result
+    assert "valid_values" not in result
+
+
+def test_no_filters_returns_everything_without_help(expected_references: int) -> None:
+    result = tools.find_references()
+    assert result["total"] == expected_references
+    assert "hint" not in result
+
+
+def test_vocabulary_helpers_are_derived_from_data() -> None:
+    vocab = tools.playbook_vocabulary()
+    assert "egress" in vocab["waste_category"]
+    assert set(vocab["scope"]) <= {"aws", "azure", "gcp", "cross-cloud"}
+    ref_vocab = tools.reference_vocabulary()
+    assert set(ref_vocab["maturity"]) <= {"Crawl", "Walk", "Run"}
+    assert set(ref_vocab["phase"]) <= {"Inform", "Optimize", "Operate"}


### PR DESCRIPTION
Stacked on the taxonomy PR, which the facet conformance test depends on.

Unlike the original review, everything here is verified by execution — I got a working test environment up (`uv`, since `python3-venv` isn't installed). **66 tests pass, up from 42.**

## F6 — a hollow wheel passed every gate
`get_index()` returned `[]` and the smoke test asserted tool *names* only, so a wheel published without its data bundle would start cleanly, speak MCP, list all six tools, and serve nothing. Added a third smoke phase that calls the tools and asserts a floor of 20 each.

**Verified by hiding the data directory:** phases 1 and 2 still pass on a hollow wheel; phase 3 fails with a diagnosis.

## F8 — malformed frontmatter was swallowed
`except yaml.YAMLError: fm = {}` left the file in `list_*` but stripped every facet, so it vanished from `find_*` with no signal anywhere. Now logs at WARNING with the filename, and handles the non-mapping case. Backed by tests asserting every bundled file declares a complete facet set.

## F9 — and one the review missed
The `service` example was wrong as reported (`"Azure Disk Storage"` → `"Azure Managed Disks"`). More significantly: **the facet vocabulary is written out twice**, in `tools.py` and in `server.py` — and `server.py`'s copy is the one FastMCP publishes to the agent. The review cited only `tools.py`. Both are fixed and a test now requires them to agree.

Verified in both directions by injecting a bad facet value and a broken frontmatter block.

## F21 — bare empty results
Zero-match faceted queries returned `{"total": 0}`. They now carry `hint` and `valid_values`, and distinguish "that value doesn't exist" from "each value is valid but nothing carries all of them". Vocabulary is derived from the index, so it can't drift.

## Also
- **F11** — build deps bounded (`hatchling<2`, `hatch-build-scripts<0.1`). Wheel rebuilt and verified to carry 29 references and 25 playbooks.
- **F22** — smoke matrix and classifiers extended to Python 3.13/3.14.
- **F25** — `server.py` said "three v1 tools" (six registered); `mcp_server/README.md` described a two-part tag `v1.13` that the auto-tag workflow's own regex rejects, and named the wrong trigger.
- `run()` touches both indexes at startup so an empty bundle logs immediately rather than staying silent until the first tool call.

No version bumps (release-train rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)