### PR TITLE
Fix playbook detection queries that cannot run as written

### DIFF
--- a/skills/cloud-finops/playbooks/README.md
+++ b/skills/cloud-finops/playbooks/README.md
@@ -51,6 +51,23 @@ confidence: obvious | likely | possible
 ## Detection
 <a query block (CUR / KQL / BigQuery SQL / CLI) that finds the pattern>
 
+Detection blocks are the part of a playbook a reader copy-pastes, so a query
+that cannot run is worse than no query at all - it returns empty and reads as
+"no waste found". Before merging a new or edited Detection block:
+
+- **Run it against a live account**, or state the prerequisite that stops you.
+  A query needing the CloudWatch agent, a diagnostic setting, or a specific
+  export is fine; leaving that unsaid is not.
+- **Check the metric/table/column actually exists.** Namespaces
+  (`AWS/NATGateway`, not `NATGateway/`), required dimensions (SageMaker
+  `Invocations` needs `VariantName`), and table names (Azure Resource Graph
+  has no billing table) are the recurring failure modes.
+- **Distinguish "no results" from "no data".** Where an empty result could
+  mean the telemetry is missing rather than the waste is absent, include the
+  command that tells the two apart.
+- **Do not present pseudo-code as runnable.** If a step is illustrative, label
+  it.
+
 ## Fix
 <bullet list of remediation steps, ordered safest-first>
 
@@ -102,6 +119,10 @@ drift, the recommended workflow is:
    should ideally link to the matching playbook (e.g.
    `[aws-zombie-nat-gateway](../playbooks/aws-zombie-nat-gateway.md)`)
    rather than repeat all the detail
+4. When a provider renames a metric, moves a namespace, or changes a required
+   dimension, the Detection block is the thing that breaks silently. Treat
+   provider console/API changes as a reason to re-run the affected queries,
+   not just to reword the prose
 
 The `cloud-finops/references/finops-waste-detection-playbooks.md` file is
 the canonical taxonomy and confidence rubric; playbooks instantiate it.

--- a/skills/cloud-finops/playbooks/aws-gpu-instance-oversized.md
+++ b/skills/cloud-finops/playbooks/aws-gpu-instance-oversized.md
@@ -16,16 +16,18 @@ is ~$5.67/hour ~= $4,140/month; a `p4d.24xlarge` (8 x A100 40 GB) is
 ~$32.77/hour ~= $23,920/month. Picking an instance with more GPU compute
 and memory than the workload uses is one of the highest-dollar waste
 patterns in AWS - and one of the hardest to spot, because the basic
-`GPUUtilization` CloudWatch metric (equivalent to `nvidia-smi`'s
-`GPU-Util`) reports whether the GPU did anything in the interval, not how
-much of its compute capacity was actually used (see
+GPU-utilisation metric most teams reach for (`nvidia-smi`'s `GPU-Util`,
+surfaced by the CloudWatch agent as `nvidia_smi_utilization_gpu`) reports
+whether the GPU did anything in the interval, not how much of its compute
+capacity was actually used (see
 [finops-for-ai.md](../references/finops-for-ai.md), section on GPU
 telemetry).
 
 ## Symptoms
 
-- CloudWatch `GPUUtilization` < 30% over a 14-day window
-- CloudWatch `GPUMemoryUtilization` < 40% over the same window
+- `nvidia_smi_utilization_gpu` < 30% over a 14-day window (CloudWatch agent,
+  `CWAgent` namespace - EC2 publishes no GPU metrics natively)
+- `nvidia_smi_utilization_memory` < 40% over the same window
 - The model's loaded weights fit in well under half of the GPU memory
 - Model latency p95 is far below the SLA (room to move to a smaller GPU
   without violating user-facing budgets)
@@ -37,21 +39,38 @@ telemetry).
 Two-tier signal: cheap (CloudWatch) for triage, expensive (DCGM) for the
 real decision.
 
-CloudWatch quick scan:
+CloudWatch quick scan. **Prerequisite:** EC2 publishes no GPU metrics of its
+own - `AWS/EC2` has no `GPUUtilization`. GPU telemetry on EC2 requires the
+CloudWatch agent configured with its NVIDIA GPU section, which publishes
+`nvidia_smi_*` metrics into the `CWAgent` namespace. If the command below
+returns no datapoints, the agent is not collecting GPU metrics on that
+instance; that is the first thing to fix, not evidence the GPU is idle.
 
 ```
 aws cloudwatch get-metric-statistics \
-  --namespace AWS/EC2 \
-  --metric-name GPUUtilization \
+  --namespace CWAgent \
+  --metric-name nvidia_smi_utilization_gpu \
   --dimensions Name=InstanceId,Value=<id> \
   --start-time $(date -u -d '14 days ago' +%Y-%m-%dT%H:%M:%SZ) \
   --end-time   $(date -u +%Y-%m-%dT%H:%M:%SZ) \
   --period 3600 --statistics Average,Maximum
 ```
 
-Note: `GPUUtilization` in CloudWatch is the legacy `nvidia-smi` metric and
-overestimates real compute usage. Treat any value < 30% as "investigate
-further", not "definitely oversized".
+Confirm the metric exists before trusting an empty result:
+
+```
+aws cloudwatch list-metrics --namespace CWAgent \
+  --metric-name nvidia_smi_utilization_gpu \
+  --dimensions Name=InstanceId,Value=<id>
+```
+
+Note: `nvidia_smi_utilization_gpu` is the `nvidia-smi` `GPU-Util` figure and
+overestimates real compute usage for the reason described above. Treat any
+value < 30% as "investigate further", not "definitely oversized".
+
+(On SageMaker the equivalent metric *is* native: `GPUUtilization` in the
+`/aws/sagemaker/Endpoints` namespace. That is a different playbook - see
+`aws-sagemaker-idle-endpoint.md`.)
 
 DCGM (deploy DCGM Exporter on the instance via SSM or Helm) gives the
 honest answer:
@@ -82,15 +101,20 @@ rightsize candidate.
 4. **Validate memory.** Confirm the model + activations + KV cache (for
    LLMs) fits within the target's frame buffer with 20% headroom for
    request-size variability.
-5. **Cut over** behind a weight-shifted endpoint variant (`InitialVariantWeight`
-   ramp 10% → 50% → 100%) so a regression is reversible.
+5. **Cut over incrementally** so a regression is reversible: shift a fraction
+   of the fleet (or of the load-balancer target weights) to the new instance
+   type, 10% → 50% → 100%, holding at each step long enough to see a full
+   traffic cycle. Keep the old capacity until the last step completes.
+   (If the workload is behind a SageMaker endpoint rather than raw EC2, the
+   equivalent is an `InitialVariantWeight` ramp across production variants -
+   see `aws-sagemaker-idle-endpoint.md`.)
 
 ## Anti-pattern
 
 - Rightsizing on **average** utilisation only. Models with batch jobs,
   monthly retraining, or end-of-quarter spikes will look oversized for 28
   days then break on day 29.
-- Trusting `GPUUtilization` (CloudWatch / `nvidia-smi`) without DCGM
+- Trusting `GPU-Util` (`nvidia_smi_utilization_gpu` / `nvidia-smi`) without DCGM
   cross-check. The metric is a "did the GPU do anything" boolean dressed
   up as a percentage - a workload touching 1 SM out of 132 on an H100 SXM
   (114 on the PCIe part) reports `GPU-Util: 100%`.

--- a/skills/cloud-finops/playbooks/aws-sagemaker-idle-endpoint.md
+++ b/skills/cloud-finops/playbooks/aws-sagemaker-idle-endpoint.md
@@ -45,7 +45,7 @@ FROM cur2
 WHERE line_item_usage_start_date >= date_trunc('month', current_date - interval '1' month)
   AND line_item_usage_start_date <  date_trunc('month', current_date)
   AND product_servicecode = 'AmazonSageMaker'
-  AND line_item_usage_type LIKE '%SageMaker:host-%'
+  AND line_item_usage_type LIKE '%Host:ml.%'   -- e.g. USE1-Host:ml.m5.xlarge
 GROUP BY 1, 2
 HAVING SUM(line_item_usage_amount) > 600   -- > 600 hours/month = always-on
 ORDER BY cost_month DESC;
@@ -53,11 +53,24 @@ ORDER BY cost_month DESC;
 
 Then cross-check each `endpoint_arn` against CloudWatch:
 
+`Invocations` is published per production variant, so the `VariantName`
+dimension is required - querying on `EndpointName` alone returns no
+datapoints, which reads as "idle" whether or not it is. List the variants
+first:
+
+```
+aws sagemaker describe-endpoint --endpoint-name <endpoint-name> \
+  --query 'ProductionVariants[].VariantName' --output text
+```
+
+Then query each one (most endpoints have a single variant, `AllTraffic`):
+
 ```
 aws cloudwatch get-metric-statistics \
   --namespace AWS/SageMaker \
   --metric-name Invocations \
   --dimensions Name=EndpointName,Value=<endpoint-name> \
+               Name=VariantName,Value=<variant-name> \
   --start-time $(date -u -d '30 days ago' +%Y-%m-%dT%H:%M:%SZ) \
   --end-time   $(date -u +%Y-%m-%dT%H:%M:%SZ) \
   --period 86400 --statistics Sum
@@ -65,6 +78,14 @@ aws cloudwatch get-metric-statistics \
 
 A 30-day Sum of zero (or below ~50 across the whole month) is the strong
 signal: the endpoint pays the full hourly rate while serving no traffic.
+An *empty* result set is not the same thing - confirm the dimension pair
+exists before concluding anything:
+
+```
+aws cloudwatch list-metrics --namespace AWS/SageMaker \
+  --metric-name Invocations \
+  --dimensions Name=EndpointName,Value=<endpoint-name>
+```
 
 ## Fix
 
@@ -83,8 +104,11 @@ endpoint is genuinely idle or just lightly used.
    the real-time variant.
 3. **Move to serverless inference** if traffic is genuinely intermittent
    (a few requests per hour or per day) and the workload can tolerate cold
-   starts of 1-15 s. Serverless inference bills per-request rather than
-   per-hour, with no idle charge.
+   starts of 1-15 s. Serverless inference bills on compute duration per
+   request (GB-seconds of memory x duration) plus a per-request charge,
+   rather than per provisioned instance-hour - so there is no idle charge,
+   but a high-volume endpoint can still cost more than a right-sized
+   always-on one. Model the crossover before switching.
 4. **Rightsize** if the endpoint legitimately needs to stay available but
    the instance is too large. See
    [aws-gpu-instance-oversized](aws-gpu-instance-oversized.md) for the GPU

--- a/skills/cloud-finops/playbooks/aws-zombie-nat-gateway.md
+++ b/skills/cloud-finops/playbooks/aws-zombie-nat-gateway.md
@@ -47,8 +47,8 @@ ORDER BY cost_month DESC;
 ```
 
 For real-time validation, the canonical CloudWatch metrics are
-`NATGateway/BytesOutToSource` and `NATGateway/BytesOutToDestination` at
-1-minute granularity.
+`BytesOutToSource` and `BytesOutToDestination` in the `AWS/NATGateway`
+namespace, dimensioned by `NatGatewayId`, at 1-minute granularity.
 
 ## Fix
 
@@ -80,8 +80,9 @@ For real-time validation, the canonical CloudWatch metrics are
   webhooks fail silently and only surface in operational alerts hours
   later.
 - Replacing a per-AZ NAT Gateway with a single cross-AZ NAT to "save
-  money" - cross-AZ data transfer ($0.01-0.02/GB each direction) often
-  outweighs the saved NAT hours, AND introduces a single-AZ failure mode.
+  money" - cross-AZ data transfer ($0.01/GB each direction, so $0.02/GB
+  round-trip) often outweighs the saved NAT hours, AND introduces a
+  single-AZ failure mode.
 
 ## See also
 

--- a/skills/cloud-finops/playbooks/azure-idle-sql-database.md
+++ b/skills/cloud-finops/playbooks/azure-idle-sql-database.md
@@ -19,7 +19,8 @@ DB lingered, "we'll use it eventually" databases provisioned years ago.
 
 ## Symptoms
 
-- `connection_successful` count < 10 / day over 14 days
+- `connection_successful` total < 100 over 14 days (the threshold the
+  detection query below uses - roughly 7/day)
 - CPU < 5% p95 over 30 days
 - DTU / vCore consumption < 5% sustained
 - The database name encodes a project / app that no longer exists in
@@ -36,8 +37,20 @@ resources
   and name != "master"
 | extend tier = tostring(sku.tier)
 | extend size = tostring(sku.name)
-| project subscriptionId, resourceGroup, server = strcat(split(id, "/")[8]), name, tier, size
+| project subscriptionId, resourceGroup, server = tostring(split(id, "/")[8]), name, tier, size
 | order by tier desc
+```
+
+**Prerequisite:** the `AzureMetrics` table only has rows for databases whose
+diagnostic settings route metrics to the Log Analytics workspace you are
+querying. A database with no diagnostic setting produces no rows, which looks
+identical to a database with no connections. Confirm coverage first:
+
+```kusto
+// Which SQL databases are actually reporting into this workspace?
+AzureMetrics
+| where ResourceProvider == "MICROSOFT.SQL" and TimeGenerated > ago(14d)
+| distinct Resource
 ```
 
 ```kusto
@@ -57,8 +70,10 @@ AzureMetrics
 1. **Confirm the DB is genuinely idle** - some monthly batch jobs have
    long inter-run gaps. Cross-check with `dm_db_resource_stats` and the
    application's job scheduler.
-2. **Backup before delete** (Azure SQL automatic backup retention is 7-
-   35 days; a long-term backup snapshot is cheap insurance).
+2. **Backup before delete** (Azure SQL point-in-time restore retention is
+   configurable from 1 to 35 days and defaults to 7; a long-term retention
+   backup is cheap insurance). Note that PITR backups are deleted with the
+   database - only an LTR backup survives the drop.
 3. **Move long-tail dev databases to Basic tier or Serverless** - Basic
    is ~$5/month per DB, Serverless auto-pauses after inactivity (Gen5
    1-vCore can drop to ~$15/month for idle workloads).

--- a/skills/cloud-finops/playbooks/azure-orphan-disks.md
+++ b/skills/cloud-finops/playbooks/azure-orphan-disks.md
@@ -32,7 +32,7 @@ that left source disks in place. A 1 TB Premium SSD orphan accrues
 // Azure Resource Graph - find all unattached managed disks
 resources
 | where type =~ "microsoft.compute/disks"
-| where managedBy == ""
+| where isempty(managedBy)   // catches both null and empty-string
 | extend size_gb     = toint(properties.diskSizeGB)
 | extend tier        = tostring(sku.name)
 | extend created     = todatetime(properties.timeCreated)
@@ -42,22 +42,24 @@ resources
 | order by size_gb desc
 ```
 
-For attribution-grade cost per orphan disk, join to the FOCUS export or
-Cost Management billing data:
+Resource Graph carries inventory, not cost - there is no billing table to
+join against inside ARG. To get cost per orphan disk, export the orphan list
+above and join it to billing data outside Resource Graph, keying on the
+resource ID (lowercased on both sides; ARG returns mixed case and the cost
+exports do not):
 
-```kusto
-// Azure Cost Management export joined to Resource Graph orphan list
-costManagementBillingData
-| where ResourceType == "microsoft.compute/disks"
-  and CostInBillingCurrency > 0
-| summarize cost30d = sum(CostInBillingCurrency) by ResourceId
-| join kind=inner (
-    resources
-    | where type =~ "microsoft.compute/disks" and managedBy == ""
-    | project ResourceId = id, name
-  ) on ResourceId
-| order by cost30d desc
-```
+- **FOCUS export / Cost Management export** (recommended): join on
+  `ResourceId` from the export to `id` from the query above, filtering
+  `ServiceCategory == "Storage"`.
+- **Cost Management Query API**: `POST` to
+  `/providers/Microsoft.CostManagement/query` scoped to the subscription,
+  grouped by `ResourceId`, with a filter on
+  `ResourceType = "microsoft.compute/disks"`.
+
+If you only need a ranking rather than exact cost, the `size_gb` and `tier`
+columns from the inventory query are enough to sort by rough monthly spend -
+Premium SSD (`Premium_LRS`) costs several times Standard HDD (`Standard_LRS`)
+per GB, so tier dominates the ordering.
 
 ## Fix
 
@@ -65,7 +67,7 @@ costManagementBillingData
    the snapshot retains all data; deletion of a Premium SSD without a
    snapshot is irreversible).
 2. Delete disks where:
-   - `managedBy == ""` for > 30 days
+   - `isempty(managedBy)` for > 30 days
    - No matching VM in the snapshot history
    - No matching backup vault recovery point
 3. Set the **VM disk deletion option to "Delete"** at VM creation time

--- a/skills/cloud-finops/playbooks/cross-cloud-coding-agent-token-waste.md
+++ b/skills/cloud-finops/playbooks/cross-cloud-coding-agent-token-waste.md
@@ -12,9 +12,11 @@ confidence: likely
 
 Agentic coding tools (Claude Code, Cursor, GitHub Copilot, Codex, and the
 open-source CLIs) bill by the token, and the whole conversation history is
-re-sent as input on every turn. Input is roughly 85% of a session's cost, so
-spend compounds with conversation length rather than with the number of tasks
-completed. The result is a cost line that grows faster than headcount or output,
+re-sent as input on every turn, so spend compounds with conversation length
+rather than with the number of tasks completed. In the sessions OptimNow has
+metered, input dominates - on the order of 85% of session cost - but the exact
+split varies with cache configuration and task shape, so measure your own
+before building a business case on it. The result is a cost line that grows faster than headcount or output,
 driven by mechanisms that never surface on a monthly dashboard: a broken cache
 prefix, quadratic context re-ingestion, self-validation loops, and every request
 defaulting to the frontier model. Unlike a cloud resource there is no instance to
@@ -57,10 +59,27 @@ npx ccusage@latest            # daily / session breakdown across detected agents
 ```
 
 ```bash
-# 2. Per-session drill-down: route an agent through a local proxy meter (tokview)
-#    to see per-tool token spend and re-sent results that multiply the bill.
-#    token-optimizer and CodeBurn run named waste detectors and price them in $.
+# 2. Per-session drill-down: route the agent through a local proxy meter to see
+#    per-tool token spend, including large tool results that get re-sent into
+#    every later turn and silently multiply the input bill.
+uv tool install token-viewer     # or: pipx install token-viewer
+tokview show --watch             # terminal 1: live dashboard
+tokview wrap claude              # terminal 2: run the agent through the proxy
 ```
+
+```bash
+# 3. Named waste detectors, priced in dollars. CodeBurn reads the session files
+#    the agents already write and scans for low cache-hit ratios, unused MCP
+#    servers, and bloated context files, with copy-paste fixes.
+npx codeburn                     # interactive dashboard by task / model / tool
+npx codeburn optimize            # waste scan with estimated token and $ savings
+```
+
+All three read local session data - no API keys leave the machine, which is
+usually what unblocks the security review. Tool homepages:
+[ccusage](https://github.com/ccusage/ccusage),
+[tokview](https://github.com/chopratejas/tokview),
+[CodeBurn](https://github.com/getagentseal/codeburn).
 
 Two independent signals raise confidence from possible to likely: for example a
 low cache-read ratio AND tokens-per-task above the team's P90. A single signal on
@@ -71,11 +90,12 @@ its own (no budget cap, say) is worth fixing but is not proof of active waste.
 Safest-first. Measure before you optimise, and validate any token-saving tool on
 your own workload before a fleet rollout.
 
-1. **Meter first.** Deploy a log-reading meter (ccusage, tokview, or CodeBurn)
+1. **Meter first.** Deploy a log-reading meter (ccusage, CodeBurn) or a
+   local proxy meter (tokview)
    across every agent so you have tokens, cache-hit ratio, and cost per session
    per developer. Everything below is guesswork without this baseline.
 2. **Fix the cache before anything else.** Cache-read is roughly 90% cheaper than
-   fresh input, and input is roughly 85% of session cost, so the cached prefix is
+   fresh input, and input dominates session cost, so the cached prefix is
    the single biggest lever. Turn on prompt caching, keep the system prompt and
    static context stable, and avoid mid-session model switches that throw the warm
    cache away.
@@ -97,15 +117,18 @@ your own workload before a fleet rollout.
 ## Anti-pattern
 
 - Rolling out compression or token-saving plugins fleet-wide on vendor claims
-  without an A/B test. Measured results range from roughly 8% savings to roughly
-  13% more tokens; the deciding factor is whether the plugin preserves the cached
-  prefix on your workload.
+  without an A/B test. Published and self-measured results span both directions -
+  from single-digit percentage savings to a net token *increase* - and the
+  deciding factor is whether the plugin preserves the cached prefix on your
+  workload. Run the A/B before the rollout, not after.
 - Optimising the per-token rate card (swapping to a cheaper model) while ignoring
   cache-read discounts and context re-ingestion, which dominate the bill. Evaluate
   cost per completed task, not price per million tokens.
-- Reacting to a viral headline figure as if it were typical. A widely-cited
-  five-figure coding-agent bill was driven by quadratic context re-ingestion, not
-  runaway usage: diagnose the mechanism in your own logs before acting.
+- Reacting to a viral headline figure as if it were typical. The large
+  coding-agent bills that circulate are usually driven by a specific mechanism
+  (quadratic context re-ingestion, a broken cache prefix, an unbounded agent
+  loop) rather than by ordinary heavy usage: diagnose the mechanism in your own
+  logs before acting on someone else's number.
 - Banning agents outright to control spend. That pushes the workload onto personal
   accounts (shadow AI) and destroys attribution. Prefer per-key budgets and
   routing over prohibition.

--- a/skills/cloud-finops/playbooks/gcp-idle-gke-autopilot.md
+++ b/skills/cloud-finops/playbooks/gcp-idle-gke-autopilot.md
@@ -10,13 +10,25 @@ confidence: likely
 
 ## Problem
 
-GKE Autopilot bills per-pod CPU / memory / ephemeral-storage requested,
-plus a flat **management fee** (~$0.10/cluster/hour = ~$72/month per
-cluster) regardless of workload activity. Even when no user workloads
-run, Autopilot keeps system-managed pods alive (control-plane logging,
-metrics agent, GMP collectors, networking). Dev / test / sandbox
-clusters left running over weekends and abandoned-after-the-PoC
-clusters accumulate this management fee silently.
+GKE charges a flat **cluster management fee** (~$0.10/cluster/hour =
+~$72/month per cluster) regardless of workload activity. Even when no user
+workloads run, Autopilot keeps system-managed pods alive (control-plane
+logging, metrics agent, GMP collectors, networking). Dev / test / sandbox
+clusters left running over weekends and abandoned-after-the-PoC clusters
+accumulate this fee silently.
+
+Two caveats before you build a business case on the management fee:
+
+- **The GKE free tier covers one zonal or Autopilot cluster per billing
+  account**, so the *first* idle cluster may cost nothing in management fee.
+  The waste is real from the second cluster onward - and organisations with
+  the pattern this playbook describes usually have many.
+- **Autopilot's workload billing depends on the compute class.** The
+  per-pod-request model applies to the general-purpose class; Autopilot also
+  supports node-based billing for some workloads (Performance and Accelerator
+  compute classes bill for the underlying node, not the pod request). Check
+  which class the workloads use before assuming zero pods means zero
+  workload cost.
 
 ## Symptoms
 
@@ -49,7 +61,7 @@ ORDER BY cost_30d DESC;
 # For each suspect cluster, count user-namespace pods
 gcloud container clusters get-credentials <cluster> --region <region> --project <project>
 kubectl get pods --all-namespaces \
-  -o json | jq '[.items[] | select(.metadata.namespace | startswith("kube-") | not) | select(.metadata.namespace != "gmp-system")] | length'
+  -o json | jq '[.items[] | select(.metadata.namespace | test("^(kube-|gke-|gmp-)") | not)] | length'
 ```
 
 ## Fix


### PR DESCRIPTION
Stacked on #118. Addresses F3 and the playbook items from Appendix A.

These are the blocks readers copy-paste, so a query that returns empty reads as "no waste found" — the worst failure mode a playbook has.

## Four broken queries
- **aws-gpu-instance-oversized** queried CloudWatch `AWS/EC2` for `GPUUtilization`. EC2 publishes no GPU metrics natively — that name belongs to SageMaker. Switched to `CWAgent` / `nvidia_smi_utilization_gpu`, stated the agent prerequisite, and added a `list-metrics` call so an empty result can be told apart from an idle GPU.
- **azure-orphan-disks** joined a **nonexistent** Azure Resource Graph table (`costManagementBillingData`) presented as runnable. ARG carries inventory, not cost. Replaced with the two real routes (FOCUS/Cost Management export, Cost Management Query API). Also `managedBy == ""` → `isempty(managedBy)`.
- **aws-sagemaker-idle-endpoint** — `Invocations` is published *per production variant*, so querying on `EndpointName` alone returns no datapoints, reading as idle whether or not it is. Added the required `VariantName` dimension plus a describe-endpoint call. The CUR pattern `%SageMaker:host-%` matched nothing; real usage types look like `USE1-Host:ml.m5.xlarge`.
- **azure-idle-sql-database** — `strcat(split(id,"/")[8])` returns a dynamic, not a string. Symptom threshold (<10/day over 14d = 140) contradicted the query (<100 total). Added the diagnostic-settings prerequisite, without which `AzureMetrics` has no rows and silence looks like idleness.

## Appendix A items
NAT namespace is `AWS/NATGateway` not `NATGateway/`; cross-AZ is $0.01/GB each direction; GKE free tier and node-billed compute classes were both omitted from the Autopilot premise; SageMaker serverless is compute-duration billing, not "per-request"; an `InitialVariantWeight` ramp sat inside an EC2-scoped playbook.

**The coding-agent playbook's detection block was three comment lines naming tools with no runnable command.** All three exist — verified `ccusage`, `tokview` and `CodeBurn` — so the block now carries real install/run commands with homepage links. "token-optimizer" did not exist; it was CodeBurn's `optimize` subcommand. Several unsourced load-bearing figures are now either attributed with a measure-your-own caveat or described by mechanism.

## New: Detection-block checklist
Added to `playbooks/README.md` — run it live or state the prerequisite, check the namespace/table/dimension exists, distinguish "no results" from "no data", don't present pseudo-code as runnable. Those four rules describe exactly the defects fixed here.

No playbook frontmatter changed, so facets and MCP behaviour are untouched (66 tests still pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)