### PR TITLE
Emit a routing file, not a 1MB inline dump, from the single-file targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
       - name: CLAUDE.md structure tree in sync
         run: bash scripts/check-docs-drift.sh
 
+      - name: Installer artefacts within the size ceiling
+        run: bash scripts/check-artefact-size.sh
+
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -26,6 +26,8 @@ curl -sL https://raw.githubusercontent.com/OptimNow/cloud-finops-skills/main/ins
 ./install.sh --list              # list supported tools
 ./install.sh --dry-run           # print what would happen
 ./install.sh --user              # install at $HOME paths (Claude Code)
+./install.sh --inline            # cursor/windsurf/codex/aider: embed the whole
+                                 # library instead of a routing file (~1MB)
 ./install.sh --dest <dir>        # override target directory
 ```
 
@@ -88,9 +90,13 @@ installer locally.
 ./install.sh --tool cursor
 ```
 
-Writes `<project>/.cursor/rules/cloud-finops.mdc` (single rule with the full skill body
-+ Cursor frontmatter). Cursor auto-loads `.cursor/rules/`. Trigger by asking a FinOps
-question in chat.
+Writes `<project>/.cursor/rules/cloud-finops.mdc` - the SKILL.md router plus an index
+of every reference and playbook, with Cursor frontmatter. Cursor auto-loads
+`.cursor/rules/`. Trigger by asking a FinOps question in chat.
+
+The rule does **not** embed the reference bodies. Pair it with the
+[MCP server](#mcp-server-cross-tool) so Cursor can fetch them on demand, or keep a
+local checkout of the skill. See [Routing file vs `--inline`](#routing-file-vs---inline).
 
 ### Windsurf
 
@@ -99,7 +105,9 @@ question in chat.
 ```
 
 Writes `<project>/.windsurf/rules/cloud-finops.md` with Windsurf rule frontmatter
-(`trigger: model_decision`).
+(`trigger: model_decision`). Like the Cursor rule this is a routing file, not the
+full library - Windsurf enforces a per-rule character limit far below the size of
+the reference set. See [Routing file vs `--inline`](#routing-file-vs---inline).
 
 ### ChatGPT (Custom GPT)
 
@@ -185,11 +193,13 @@ elsewhere.
 ./install.sh --tool codex
 ```
 
-Writes `<project>/AGENTS.md` (or `AGENTS-cloud-finops.md` if `AGENTS.md` already exists,
-to avoid clobbering). Codex CLI reads `AGENTS.md` as project-level context.
+Writes `<project>/AGENTS.md` (or `AGENTS-cloud-finops.md` if a foreign `AGENTS.md`
+already exists, to avoid clobbering - a re-run recognises its own output and
+overwrites in place). Codex CLI reads `AGENTS.md` as project-level context.
 
-For richer retrieval (per-reference fetch + faceted query), pair this with the MCP
-server below.
+This is a routing file. For the reference bodies, pair it with the MCP server below -
+that is the intended pairing, not an optional extra. See
+[Routing file vs `--inline`](#routing-file-vs---inline).
 
 ### Aider
 
@@ -197,9 +207,9 @@ server below.
 ./install.sh --tool aider
 ```
 
-Writes `<project>/CONVENTIONS.md` (or `CONVENTIONS-cloud-finops.md` if one exists).
-Aider auto-reads `CONVENTIONS.md`. Default coverage is the four general references
-(AWS, Azure, GCP, AI). Add specific references at runtime with:
+Writes `<project>/CONVENTIONS.md` (or `CONVENTIONS-cloud-finops.md` if a foreign one
+exists). Aider auto-reads `CONVENTIONS.md`. This is a routing file; add specific
+references at runtime with:
 
 ```bash
 aider --read skills/cloud-finops/references/finops-bedrock.md ...
@@ -223,6 +233,34 @@ the way Claude / Cursor do. Use as a lightweight context hint, not a full skill 
 
 Copies the skill to `<project>/.kiro/powers/cloud-finops/`. Kiro uses `POWER.md` as the
 entry point.
+
+### Routing file vs `--inline`
+
+The four single-file targets - Cursor, Windsurf, Codex CLI, Aider - emit a **routing
+file** by default: the SKILL.md router, an index of every reference and playbook with
+its description and facets, and instructions for fetching a body on demand. That is
+about 27 KB (~7K tokens).
+
+They used to inline the entire reference library. As the library grew that reached
+roughly 1 MB (~250K tokens) per artefact, which overflows or dominates the context
+window of every tool that loads it, and sits far above Windsurf's documented per-rule
+character limit. Nothing measured the artefacts, so the regression was invisible -
+the installer reported success either way. `scripts/check-artefact-size.sh` now runs
+in CI to keep it that way.
+
+**The routing file assumes the model can reach the bodies.** Pair it with the MCP
+server below, or keep a local checkout of the skill - the generated file explains both
+paths and tells the model to say so rather than answer from memory if neither is
+available.
+
+If you want the old behaviour - no MCP server, no checkout, everything embedded:
+
+```bash
+./install.sh --tool cursor --inline
+```
+
+Expect the size trade-off that comes with it. The installer prints a warning
+describing what you got in either mode.
 
 ### MCP server (cross-tool)
 

--- a/install.sh
+++ b/install.sh
@@ -13,6 +13,11 @@
 #   ./install.sh --grouped             ChatGPT only: produce a grouped build that bundles
 #                                      the same content by domain into a handful of files
 #                                      instead of one file per reference. Easier to upload.
+#   ./install.sh --inline              Single-file targets (cursor, windsurf, codex,
+#                                      aider): inline the entire reference library
+#                                      instead of emitting a routing file. Produces
+#                                      a ~1MB artefact - only useful without the MCP
+#                                      server and without a local checkout.
 #   ./install.sh --dest <dir>          Override the project / target directory
 #   ./install.sh --help                Show this help
 #
@@ -71,6 +76,7 @@ DRY_RUN=""
 USER_LEVEL=""
 DEST_OVERRIDE=""
 GROUPED=""
+INLINE=""
 
 cleanup() { [[ -n "$TMPDIR" ]] && rm -rf "$TMPDIR" 2>/dev/null || true; }
 trap cleanup EXIT
@@ -144,6 +150,98 @@ write_concat_body() {
       echo "---"
       echo
     done
+  fi
+}
+
+# Routing body: SKILL.md (the router) + a one-line index of every reference and
+# playbook + instructions for fetching a body on demand.
+#
+# This is the default for the single-file targets (cursor, windsurf, codex,
+# aider). The alternative - inlining the whole library, which write_concat_body
+# does - produces a ~1MB artefact (~250K tokens) that overflows or dominates
+# any context window, and Windsurf's per-rule character limit is orders of
+# magnitude below it. The library was a fraction of its current size when that
+# approach was chosen. `--inline` restores it for anyone who wants it.
+#
+# The routing contract only works if the model can actually reach the bodies,
+# so the header states both retrieval paths explicitly.
+write_routing_body() {
+  strip_frontmatter "$SRC_DIR/skills/cloud-finops/SKILL.md"
+  cat <<'EOF'
+
+---
+
+## Retrieving a reference or playbook
+
+The routing tables above name files that are **not inlined in this artefact**.
+Fetch a body one of two ways:
+
+1. **cloud-finops MCP server** (recommended). `pip install cloud-finops-mcp`,
+   then wire it into this tool's MCP config. Tools:
+   - `get_reference(name)` / `list_references()` / `find_references(domain=, capability=, phase=, persona=, maturity=)`
+   - `get_playbook(name)` / `list_playbooks()` / `find_playbooks(scope=, service=, waste_category=, confidence=)`
+2. **Local checkout.** If this project has the skill installed on disk, read
+   `skills/cloud-finops/references/<name>.md` or
+   `skills/cloud-finops/playbooks/<slug>.md` directly.
+
+If neither is available, say so rather than answering from memory - the whole
+point of this skill is that billing mechanics come from the reference files,
+not from model recall.
+
+---
+
+## Reference index
+
+EOF
+  local ref desc name
+  for ref in "$SRC_DIR/skills/cloud-finops/references"/*.md; do
+    name=$(basename "$ref" .md)
+    desc=$(awk '/^>/{sub(/^> ?/,""); print; exit}' "$ref" | head -c 220)
+    echo "- \`$name\` - $desc"
+  done
+  if [[ -d "$SRC_DIR/skills/cloud-finops/playbooks" ]]; then
+    cat <<'EOF'
+
+## Playbook index
+
+Named-pattern runbooks. Format: slug - scope / waste category / confidence.
+
+EOF
+    local pb slug scope cat conf
+    for pb in "$SRC_DIR/skills/cloud-finops/playbooks"/*.md; do
+      [[ "$(basename "$pb")" == "README.md" ]] && continue
+      slug=$(basename "$pb" .md)
+      scope=$(awk -F': *' '/^scope:/{print $2; exit}' "$pb")
+      cat=$(awk -F': *' '/^waste_category:/{print $2; exit}' "$pb")
+      conf=$(awk -F': *' '/^confidence:/{print $2; exit}' "$pb")
+      echo "- \`$slug\` - ${scope:-?} / ${cat:-?} / ${conf:-?}"
+    done
+  fi
+  echo
+}
+
+# Emit either the routing body (default) or the full inlined library
+# (--inline). Single-file targets call this rather than either builder.
+write_body() {
+  if [[ -n "$INLINE" ]]; then
+    write_concat_body
+  else
+    write_routing_body
+  fi
+}
+
+# Explain to the user which shape they just got and how the model reaches the
+# reference bodies from it.
+routing_hint() {
+  [[ -n "$DRY_RUN" ]] && return 0
+  if [[ -n "$INLINE" ]]; then
+    dim "  --inline: the full reference library is embedded (~1MB). Expect this to"
+    dim "  dominate or overflow the tool's context window."
+  else
+    dim "  This is a routing file: SKILL.md plus an index, not the full library."
+    dim "  Install the MCP server so the model can fetch bodies on demand:"
+    dim "    pip install cloud-finops-mcp   (then: ./install.sh --tool mcp for config)"
+    dim "  Or keep a local checkout - the routing file explains both paths."
   fi
 }
 
@@ -290,6 +388,7 @@ install_cursor() {
   do_write "$target" build_cursor_rule
   ok "Cursor: rule written -> $target"
   dim "  Cursor auto-loads .cursor/rules/. Trigger by asking a FinOps question in chat."
+  routing_hint
 }
 
 build_cursor_rule() {
@@ -302,13 +401,14 @@ alwaysApply: false
 ---
 
 EOF
-  write_concat_body
+  write_body
 }
 
 install_windsurf() {
   local target="${DEST_OVERRIDE:-$PWD}/.windsurf/rules/cloud-finops.md"
   do_write "$target" build_windsurf_rule
   ok "Windsurf: rule written -> $target"
+  routing_hint
 }
 
 build_windsurf_rule() {
@@ -319,7 +419,7 @@ description: Expert FinOps guidance for cloud, AI, SaaS, and data-platform spend
 ---
 
 EOF
-  write_concat_body
+  write_body
 }
 
 install_chatgpt() {
@@ -681,7 +781,7 @@ install_codex() {
   ok "Codex CLI: agent context written -> $target"
   dim "  Codex reads AGENTS.md from project root. If AGENTS-cloud-finops.md was used,"
   dim "  manually merge into your existing AGENTS.md (or rename when ready)."
-  dim "  The cloud-finops MCP server is the cleaner cross-agent path - see --tool mcp."
+  routing_hint
 }
 
 build_codex_agents_md() {
@@ -694,7 +794,7 @@ This file injects Cloud FinOps expertise into your Codex CLI session. Source:
 https://github.com/OptimNow/cloud-finops-skills
 
 EOF
-  write_concat_body
+  write_body
 }
 
 install_aider() {
@@ -707,8 +807,9 @@ install_aider() {
   fi
   do_write "$target" build_aider_conventions
   ok "Aider: conventions written -> $target"
-  dim "  Aider auto-reads CONVENTIONS.md. For more references, add via --read flags:"
+  dim "  Aider auto-reads CONVENTIONS.md. Pull individual references at runtime:"
   dim "    aider --read skills/cloud-finops/references/finops-bedrock.md ..."
+  routing_hint
 }
 
 build_aider_conventions() {
@@ -720,23 +821,12 @@ EOF
   cat <<'EOF'
 
 When asked about cloud cost, AI cost, SaaS cost, commitment strategy, rightsizing,
-tagging, or FinOps practice questions, apply the guidance below. Default coverage
-is the four most general areas (AWS, Azure, GCP, AI). For richer coverage on
-Bedrock, Vertex AI, Databricks, Microsoft Fabric, Snowflake, OCI, etc., add the
-specific references via `aider --read skills/cloud-finops/references/<file>.md`.
+tagging, or FinOps practice questions, apply the guidance below. Pull the specific
+reference you need with `aider --read skills/cloud-finops/references/<file>.md`,
+or wire up the cloud-finops MCP server and fetch on demand.
 
 EOF
-  strip_frontmatter "$SRC_DIR/skills/cloud-finops/SKILL.md"
-  for ref in finops-aws.md finops-azure.md finops-gcp.md finops-for-ai.md; do
-    if [[ -f "$SRC_DIR/skills/cloud-finops/references/$ref" ]]; then
-      echo
-      echo "---"
-      echo
-      echo "## Reference: $ref"
-      echo
-      cat "$SRC_DIR/skills/cloud-finops/references/$ref"
-    fi
-  done
+  write_body
 }
 
 install_copilot() {
@@ -869,6 +959,7 @@ main() {
       --dry-run)  DRY_RUN=1; shift ;;
       --user)     USER_LEVEL=1; shift ;;
       --grouped)  GROUPED=1; shift ;;
+      --inline)   INLINE=1; shift ;;
       --dest)     DEST_OVERRIDE="${2:?--dest requires a value}"; shift 2 ;;
       --dir)      DEST_OVERRIDE="${2:?--dir requires a value}"; shift 2 ;;  # legacy alias
       --list)     list_tools; exit 0 ;;

--- a/scripts/check-artefact-size.sh
+++ b/scripts/check-artefact-size.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# check-artefact-size.sh - keep the single-file installer artefacts small
+# enough to actually load.
+#
+# The 2026-08 review (F5) found cursor / windsurf / codex emitting ~1MB files
+# (~250K tokens) and aider ~445KB. They had grown with the reference library
+# and nothing measured them, so the regression was invisible: the installer
+# reported success and the artefact silently overflowed or dominated the
+# target tool's context window.
+#
+# The default build is now a routing file plus an index. This check builds
+# every single-file target into a scratch directory and fails if one crosses
+# the ceiling, so the inlining regression cannot come back unnoticed.
+#
+# `--inline` artefacts are intentionally huge and are not checked here.
+#
+# Usage: ./scripts/check-artefact-size.sh
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# Roughly 4 chars per token, so 200000 bytes is ~50K tokens - comfortably
+# loadable by every target tool while leaving room for the library to grow.
+# Raise deliberately if the routing file legitimately grows; do not raise to
+# accommodate re-inlining the reference bodies.
+MAX_BYTES=200000
+
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+echo "Building single-file targets into $WORKDIR ..."
+bash install.sh --tool cursor   --dest "$WORKDIR" >/dev/null
+bash install.sh --tool windsurf --dest "$WORKDIR" >/dev/null
+bash install.sh --tool codex    --dest "$WORKDIR" >/dev/null
+bash install.sh --tool aider    --dest "$WORKDIR" >/dev/null
+bash install.sh --tool copilot  --dest "$WORKDIR" >/dev/null
+
+ARTEFACTS=(
+  ".cursor/rules/cloud-finops.mdc"
+  ".windsurf/rules/cloud-finops.md"
+  "AGENTS.md"
+  "CONVENTIONS.md"
+  ".github/copilot-instructions.md"
+)
+
+errors=0
+for rel in "${ARTEFACTS[@]}"; do
+  path="$WORKDIR/$rel"
+  if [[ ! -f "$path" ]]; then
+    echo "MISSING: expected artefact $rel was not produced" >&2
+    errors=$((errors + 1))
+    continue
+  fi
+  size="$(wc -c < "$path" | tr -d ' ')"
+  if (( size > MAX_BYTES )); then
+    echo "TOO BIG: $rel is $size bytes (ceiling $MAX_BYTES)" >&2
+    errors=$((errors + 1))
+  else
+    printf 'OK: %-38s %8s bytes\n' "$rel" "$size"
+  fi
+done
+
+if (( errors > 0 )); then
+  cat >&2 <<'MSG'
+
+FAIL: one or more installer artefacts exceed the size ceiling.
+
+The single-file targets are meant to emit a routing file (SKILL.md plus a
+reference/playbook index) and point retrieval at the cloud-finops MCP server
+or a local checkout. If a build is inlining reference bodies again, fix the
+builder rather than raising MAX_BYTES.
+MSG
+  exit 1
+fi
+
+echo "OK: all single-file artefacts under $MAX_BYTES bytes."


### PR DESCRIPTION
Stacked on #119. Addresses F5.

## The problem, measured
| Artefact | Before | After |
|---|---:|---:|
| `.cursor/rules/cloud-finops.mdc` | 1,031,654 B | **27,304 B** |
| `.windsurf/rules/cloud-finops.md` | 1,031,219 B | **26,869 B** |
| `AGENTS.md` (codex) | 1,031,240 B | **26,994 B** |
| `CONVENTIONS.md` (aider) | 445,406 B | **27,161 B** |

Each was ~250K tokens — overflowing or dominating the context window of the tool loading it, and far above Windsurf's documented per-rule limit. **Nothing in the repo built or measured these**, so the regression was invisible: the installer reported success either way.

## The fix
The four single-file targets now emit a **routing file**: the SKILL.md router, a one-line index of every reference and playbook with facets, and an explicit retrieval contract naming both paths — the cloud-finops MCP server, or a local checkout.

**The retrieval contract matters more than the size.** The old inlining existed because SKILL.md routes to files by name, and a routing table pointing at absent files is worse than useless. The generated file now states both ways to reach a body and instructs the model to *say so rather than answer from memory* if neither is available — the honest failure mode for a skill whose whole premise is that billing mechanics come from the references.

`--inline` restores the old behaviour for anyone with neither the MCP server nor a checkout.

**Aider needed its own fix**: `build_aider_conventions` had a separate inlining loop over the four largest references rather than calling the shared builder, so it would have kept emitting 445KB.

## New CI gate
`scripts/check-artefact-size.sh` builds all five single-file targets and fails above 200,000 bytes. Verified in both directions — passes on this tree, and fails with a clear diagnosis when the builder is forced back to inlining.

Both modes idempotent across two runs; routing file carries all 29 references and 25 playbooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)