### PR TITLE
Re-anchor load-bearing claims to primary sources; add a sourcing rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -617,6 +617,22 @@ a `description` field for the Claude.ai upload skill loader (see "Content rules"
 - Only `name` and `description` are required in the YAML frontmatter
 - Do not add a `license` field to the frontmatter (it renders as visible text in Claude.ai)
 
+**Sourcing**
+- **Mechanics claims cite provider documentation, not newsletters.** Anything that
+  states how billing actually works - eligibility, payment options, retirement dates,
+  retention windows, rate multipliers - must link to the provider's own docs. A
+  secondary source (newsletter, vendor blog, community post) is acceptable only as a
+  *lead*, and the claim must then either be confirmed primarily or carry an explicit
+  sourcing note saying it is unconfirmed. The 2026-08 review found a Redshift RI claim
+  that a newsletter had scoped wrongly (the change applied to RG instances, not to
+  1-year RIs generally) - that class of error is what this rule prevents.
+- **Cite papers by title, not by bare identifier.** An `arXiv:NNNN.NNNNN` with no title
+  cannot be sanity-checked by a reader and looks indistinguishable from a hallucinated
+  citation. Include author, title, and link.
+- **Name a vendor only with a viability caveat** if it is early-stage. Recommending a
+  seed-stage tool into a client's production path is a continuity risk the reference
+  should flag, not bury.
+
 **License**
 - All content is licensed under [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/)
 - Credit OptimNow as the original author

--- a/skills/cloud-finops/references/finops-agentic.md
+++ b/skills/cloud-finops/references/finops-agentic.md
@@ -49,12 +49,18 @@ as "agents":
 
 - **Refinement is the sink.** ~60% of an agentic task's cost sits in checking,
   repairing, and re-verifying - not in generating the first answer (59.4%
-  review/refinement share, 53.9% average input-token share; arXiv:2601.14470,
-  analysis of 20 production agentic *coding* workflows - the mechanism generalises,
-  exact ratios vary by workload).
+  review/refinement share, 53.9% average input-token share). Source: Salim et al.,
+  *Tokenomics: Quantifying Where Tokens Are Used in Agentic Software Engineering*,
+  [arXiv:2601.14470](https://arxiv.org/abs/2601.14470) - measured on the ChatDev
+  framework across design, coding, completion, review, testing and documentation
+  stages. The mechanism generalises; exact ratios vary by workload.
 - **Agentic tasks consume ~1,000x the tokens** of comparable single-turn or chat
-  interactions (arXiv:2604.22750; consistent with Anthropic's multi-agent research
-  system write-up). Long-lived context is an operating asset and a dominant cost.
+  interactions, with input rather than output tokens driving the cost. Source:
+  *How Do AI Agents Spend Your Money? Analyzing and Predicting Token Consumption in
+  Agentic Coding Tasks*, [arXiv:2604.22750](https://arxiv.org/abs/2604.22750) -
+  eight frontier models on SWE-bench Verified; consistent with Anthropic's
+  multi-agent research system write-up. Long-lived context is an operating asset
+  and a dominant cost.
 - **Multi-model by default:** ~3.5 different models per agent run on average, often
   across providers (Pay-i-reported). Single-provider cost views structurally
   under-count agent cost - attribution must be per task, across providers.

--- a/skills/cloud-finops/references/finops-aws.md
+++ b/skills/cloud-finops/references/finops-aws.md
@@ -184,7 +184,11 @@ Source: https://docs.aws.amazon.com/savingsplans/latest/userguide/plan-types.htm
    accounts, this is a relevant governance and optimisation detail: reserved
    capacity is now more likely to be consumed by ASG-launched instances without
    manual placement configuration, which affects how you track capacity
-   utilisation. Source: https://finopsweekly.com/news/aws-updates-2026-07-02/
+   utilisation. **Sourcing note:** this behaviour is reported by a secondary
+   newsletter source and has not been confirmed against AWS documentation. Verify
+   against the EC2 Auto Scaling docs before relying on it in a commitment-coverage
+   model - if ASGs do not in fact prioritise reservations, idle-reservation risk is
+   higher than this section implies.
 
 4. **Convertible RIs provide mid-term liquidity.** EC2 Instance Savings Plans offer
    similar flexibility at equal or better discount depth, but they are locked for
@@ -2226,12 +2230,14 @@ Is the database workload stable and predictable (90+ days of consistent usage)?
         │
         ├── Redshift
         │   → Reserved Nodes for stable provisioned clusters
-        │     - As of July 2026, 1-year Redshift RIs support All Upfront
-        │       and Partial Upfront payment options alongside the existing
-        │       No Upfront term, adding commitment flexibility. All Upfront
-        │       yields the deepest discount; Partial Upfront balances
-        │       discount depth against capital outlay.
-        │       Source: https://finopsweekly.com/news/aws-updates-2026-07-02/
+        │     - All three payment options (No Upfront, Partial Upfront,
+        │       All Upfront) have long been available on RA3 and earlier
+        │       node types. The June 2026 change added Partial and All
+        │       Upfront to **RG instance** reservations specifically - it
+        │       is not a general expansion of 1-year Redshift RI terms.
+        │       All Upfront yields the deepest discount (~42% on 1-year),
+        │       Partial ~41%, No Upfront ~20%.
+        │       Source: https://aws.amazon.com/about-aws/whats-new/2026/06/amazon-redshift-ri-upfront-pricing-rg-instances/
         │   → For variable workloads: Redshift Serverless (no RI, pay
         │     per RPU-hour) may be cheaper than committed idle capacity
         │

--- a/skills/cloud-finops/references/finops-azure.md
+++ b/skills/cloud-finops/references/finops-azure.md
@@ -111,7 +111,7 @@ to be layered, not chosen in isolation.
 | Azure Hybrid Benefit (AHB) | Up to 40% (Windows), 55% (SQL) | Highest - no commitment, no lock-in | Licensing overlay | None | VMs, SQL Database, SQL MI, Red Hat/SUSE Linux |
 | Spot Virtual Machines | Up to 90% | Variable - can be evicted with 30s notice | None (market-priced) | None | VMs, VMSS, AKS node pools |
 
-**Note on one-year Reserved VM Instances:** As of July 1, 2026, Azure is retiring one-year Reserved VM Instances for select older VM series. This affects new purchases and renewals for these specific series. Three-year reservations remain available for all VM series. When planning reservation strategies, verify current eligibility for one-year terms on your target VM series.
+**Note on one-year Reserved VM Instances:** As of July 1, 2026, Azure is retiring one-year Reserved VM Instances for select older VM series. This affects new purchases and renewals for these specific series. Three-year reservations remain available for all VM series. When planning reservation strategies, verify current eligibility for one-year terms on your target VM series. Source: https://learn.microsoft.com/en-us/azure/cost-management-billing/reservations/manage-legacy-vm-reservations-after-july-1-2026
 
 **Critical distinctions:**
 

--- a/skills/cloud-finops/references/finops-gcp.md
+++ b/skills/cloud-finops/references/finops-gcp.md
@@ -321,7 +321,7 @@ identify which principal is over-consuming committed slots, and to enforce
 per-principal budget guardrails inside a single shared reservation.
 
 Sources: https://docs.cloud.google.com/bigquery/docs/reservations-assignments (primary),
-https://finopsweekly.com/news/gcp-updates-2026-07-02/
+https://finopsweekly.com/news/gcp-updates-2026-07-02/ (secondary source - verify against Google Cloud docs)
 
 **Frame for clients**: BigQuery commitments trade flexibility for
 predictability, and often performance for predictability. The right
@@ -553,7 +553,9 @@ service - enabling stronger cost-allocation governance for Bigtable workloads
 specifically. Bind allocation tags (team, cost-centre, environment) at instance
 creation and enforce them via policy so no Bigtable instance can be provisioned
 untagged. See `finops-tagging.md` for the broader tag enforcement strategy.
-Source: https://finopsweekly.com/news/gpc-updates-2026-07-10/
+**Sourcing note:** reported by a secondary newsletter source only (the previously
+cited URL also carried a typo and may not resolve). Confirm Bigtable tag-binding GA
+status against Google Cloud documentation before designing enforcement around it.
 
 **Excessive Shard Count In Gcp Bigtable**
 Service: GCP BigTable | Type: Inefficient Configuration

--- a/skills/cloud-finops/references/finops-snowflake.md
+++ b/skills/cloud-finops/references/finops-snowflake.md
@@ -112,7 +112,13 @@ the query window. Two queries with similar execution times can have very differe
 credit attributions if one ran on a busy warehouse and the other had the warehouse
 to itself.
 
-**Retention:** 365 days in `ACCOUNT_USAGE`, 14 days in `INFORMATION_SCHEMA.QUERY_ATTRIBUTION_HISTORY`.
+**Retention:** 365 days in `ACCOUNT_USAGE` (confirmed against Snowflake docs). The view
+also exists in `ORGANIZATION_USAGE` for multi-account estates, carrying most of the same
+columns - that is the one to use when attributing spend across accounts. `INFORMATION_SCHEMA`
+equivalents generally retain far less (Snowflake documents a 7-day-to-6-month range
+depending on the view); **verify the specific retention for your account before building
+a pipeline that assumes a number** rather than relying on a figure quoted second-hand.
+Source: https://docs.snowflake.com/en/sql-reference/account-usage
 
 **Practical FinOps query:** top 50 queries by credits last 30 days, joined to
 `QUERY_HISTORY` for the SQL text - this surfaces the actual heavy hitters that
@@ -306,6 +312,13 @@ Search Optimization can enable significant cost savings when selectively applied
 Service: Snowflake Query Processing | Type: Suboptimal Query Routing and Warehouse Utilization
 
 Organizations may experience unnecessary Snowflake spend due to inefficient query-to-warehouse routing, lack of dynamic warehouse scaling, or failure to consolidate workloads during low-usage periods. Third-party platforms offer solutions to address these inefficiencies: Sundeck enables highly customizable, SQL-based control over the query lifecycle through user-defined rules (Flows, Hooks, Conditions).
+
+**Vendor-risk caveat.** The named vendors below are early-stage companies, not
+incumbents - Sundeck was founded in 2022 and remains seed-stage. Naming a specific
+tool in a client recommendation carries continuity risk that a platform feature does
+not: run the usual vendor-viability check (funding stage, customer references, exit
+path for your data and rules) before recommending one into a production query path,
+and prefer native Snowflake controls where they are sufficient.
 
 - Implement customizable query lifecycle management platforms (e.g., Sundeck) if granular control is required and in-house SQL/DevOps expertise is available
 - Deploy AI-driven warehouse optimization platforms (e.g., Keebo) for organizations prioritizing ease of use and autonomous cost management


### PR DESCRIPTION
Stacked on #121. Addresses F14. Four claims verified against primary sources — one was wrong, two confirmed, the rest now carry explicit sourcing notes.

## Confirmed — no change needed
- **Azure's 1 February 2027 reservation-exchange retirement.** The review called this the highest-value single verification in the repo, since the file's whole commitment doctrine rests on it and Microsoft has slipped a comparable date before. **Confirmed** by Microsoft Learn and the Microsoft FinOps blog — the date, the one-final-exchange right, and the no-savings-plan carve-out all hold as written.
- **Both arXiv citations are real and accurate.** The review flagged them as classic hallucinated-citation risk. `arXiv:2601.14470` is *"Tokenomics: Quantifying Where Tokens Are Used in Agentic Software Engineering"* and reports exactly the 59.4% / 53.9% figures cited; `arXiv:2604.22750` is *"How Do AI Agents Spend Your Money?"* and reports the 1000× figure with input tokens driving cost. Both now cite author and title with a link — a bare arXiv ID can't be sanity-checked by a reader and reads like a fabrication even when it isn't.

## Corrected — exactly the failure mode the review predicted
**The Redshift RI claim was scoped wrongly.** The file said 1-year Redshift RIs gained All Upfront and Partial Upfront in July 2026. Those options have existed on RA3 and earlier for years; AWS's June 2026 announcement added them to **RG instance** reservations specifically. Rewritten with the real scope, approximate discount depths (~42% / ~41% / ~20%), and the AWS what's-new link.

**Snowflake `QUERY_ATTRIBUTION_HISTORY` retention.** The 365-day ACCOUNT_USAGE figure is confirmed. The asserted 14-day INFORMATION_SCHEMA figure is not — the documented range is 7 days to 6 months by view — so it now says verify rather than quoting second-hand. Added `ORGANIZATION_USAGE`, the right view for multi-account attribution, which was missing.

## Flagged rather than removed
- **EC2 ASG reservations-first** and **Bigtable tag-binding GA** rest on newsletter sourcing alone (the GCP URL also carried a `gpc` typo). Both keep their content but now name what to verify and what breaks if wrong — for ASG, that idle-reservation risk is higher than the section implies.
- **Sundeck** is real and active but seed-stage (founded 2022). Recommending an early-stage vendor into a client's production query path is a continuity risk, so the section carries a viability caveat and a preference for native controls — rather than deleting the recommendation or leaving it unqualified.

## New: Sourcing rules in CLAUDE.md
Codifies the three lessons — mechanics claims cite provider docs (a secondary source is a *lead*, not a citation); papers are cited by title, not bare identifier; early-stage vendors are named only with a viability caveat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)