### PR TITLE
Confirm the Gemini CLI target; record measured seam analysis for the file split

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -343,6 +343,42 @@ GitHub issues, which track in-flight work.
   section above and should produce a follow-up Lessons learned entry
   describing the un-freeze evidence.
 
+- **P1 - Split `finops-aws.md` and `finops-azure.md`.** Surfaced by the 2026-08-02
+  review (F15). The skill's two-level progressive disclosure works at the first level
+  (idle cost ~250 tokens; SKILL.md ~5.5K) but fails at the second: the routing table
+  maps roughly 30 AWS topics to a single 2,893-line file, so a routine Savings Plans
+  question costs ~50K tokens, most of it CloudFront, S3 Files and SageMaker material
+  irrelevant to the question. Median-file queries cost a reasonable ~22K. The
+  playbooks (~2-3K tokens each) are the model of the right granularity.
+
+  **Measured section sizes (2026-08-02), so the seams do not have to be re-derived:**
+
+  | File | Section | Lines | Share |
+  |---|---|---|---|
+  | finops-aws.md (2,893) | AWS Optimization Patterns | 1,436 | 49% |
+  | | Commitment discounts | 578 | 20% |
+  | | everything else (10 sections) | ~880 | 31% |
+  | finops-azure.md (3,211) | Commitment discounts | 609 | 19% |
+  | | Azure Optimization Patterns | 456 | 14% |
+  | | everything else (20 sections) | ~2,150 | 67% |
+
+  **Proposed split, consistent across both:** `core` / `commitments` / `patterns`.
+  AWS drops to ~880 lines of core, which fixes the reported problem outright. Azure
+  is messier and needs a consolidation pass first - it currently carries near-duplicate
+  commitment content at four separate offsets ("Commitment discounts" at line 97,
+  "Compute rightsizing" at 706 and "Compute rightsizing fundamentals" at 1,949,
+  "Database commitment decision tree and fundamentals" at 2,027, "Commitment portfolio"
+  at 2,197). That duplication is itself worth fixing and is probably a pipeline-append
+  artefact; splitting before consolidating would bake it into two files instead of one.
+
+  **Blast radius** (why this is its own PR, not a rider): each new file needs FCP
+  frontmatter and a footer, plus routing rows in SKILL.md and POWER.md, entries in
+  README, AGENTS.md, llms.txt and the CLAUDE.md structure tree (now CI-gated by
+  `scripts/check-docs-drift.sh`), the install.sh per-tool routing tables, an MCP data
+  re-sync, and a regenerated `fcp-coverage.md`. Deliberately not attempted as part of
+  the review-remediation batch - a botched split of the two most-loaded files is worse
+  than a deferred one.
+
 - **WasteLine extension to Azure and GCP.** `finops-waste-detection-playbooks.md` covers the
   eight-category waste taxonomy and references the WasteLine appliance for AWS automation;
   Azure and GCP coverage currently routes to the in-cloud pattern catalogues

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -187,6 +187,16 @@ Copies to `~/.gemini/skills/cloud-finops/`. This target always installs at `$HOM
 `--user` is not needed and has no effect on it. Use `--dest <dir>` to install
 elsewhere.
 
+Gemini CLI implements the same `SKILL.md` standard as Claude Code and Codex CLI, so
+the skill installs unmodified. It discovers user skills in `~/.gemini/skills/` (with
+`~/.agents/skills/` as an alias) and reads `SKILL.md` either at the root or one
+directory deep - `~/.gemini/skills/cloud-finops/SKILL.md` is the second form. At
+session start it injects each enabled skill's name and description into the system
+prompt and adds the skill directory to the agent's allowed file paths, so the
+reference files are readable on demand. For a project-scoped install instead, use
+`--dest .gemini/skills` to write the workspace-level location.
+Source: https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/skills.md
+
 ### OpenAI Codex CLI
 
 ```bash

--- a/install.sh
+++ b/install.sh
@@ -767,6 +767,9 @@ install_gemini_cli() {
   fi
   do_copy_dir "$SRC_DIR/skills/cloud-finops" "$target"
   ok "Gemini CLI: skill copied -> $target"
+  dim "  Gemini CLI implements the SKILL.md standard - it discovers user skills in"
+  dim "  ~/.gemini/skills/ and reads SKILL.md one directory deep, which is this layout."
+  dim "  For a project-scoped install instead: --dest .gemini/skills"
 }
 
 install_codex() {


### PR DESCRIPTION
Stacked on #122. Last in the stack. Two findings with opposite outcomes.

## F13 — the gemini-cli target is correct, not speculative
The review suspected `~/.gemini/skills/cloud-finops/` might not be a real context surface and suggested removing the target if not. **It's real.** Gemini CLI implements the same SKILL.md standard as Claude Code and Codex CLI, discovers user skills in `~/.gemini/skills/` (alias `~/.agents/skills/`), and reads SKILL.md either at the skills-dir root or one directory deep — the latter is exactly what the installer writes. At session start it injects each skill's name and description into the system prompt and adds the directory to the agent's allowed paths.

Documented with the upstream source; the installer now prints the discovery behaviour and the `--dest .gemini/skills` project-scoped variant. **No code change was needed — the install was right.**

## F15 — the split is deferred, with the analysis banked
Splitting `finops-aws.md` (2,893 lines) and `finops-azure.md` (3,211) is the correct fix, but it touches SKILL.md, POWER.md, README, AGENTS.md, llms.txt, the CLAUDE.md tree (now CI-gated), install.sh routing, the MCP data sync and fcp-coverage.md. **A botched split of the two most-loaded files is a worse outcome than a deferred one**, so rather than attempt it at the tail of a remediation batch, the Roadmap now carries the measured section sizes:

| File | Section | Lines | Share |
|---|---|---:|---:|
| finops-aws.md | AWS Optimization Patterns | 1,436 | **49%** |
| | Commitment discounts | 578 | 20% |
| finops-azure.md | Commitment discounts | 609 | 19% |
| | Azure Optimization Patterns | 456 | 14% |

Two findings that shape the work:
- **AWS is dominated by one section** — the pattern catalogue is half the file. With commitments that's 69% in two self-contained blocks, leaving ~880 lines of core. Splitting AWS fixes the reported problem almost outright.
- **Azure is structurally disordered** — near-duplicate commitment and rightsizing content at *five* separate offsets (lines 97, 706, 1,949, 2,027, 2,197), probably a pipeline-append artefact. Splitting before consolidating would bake the duplication into two files instead of one, so the Roadmap sequences consolidation first.

Proposed shape is consistent across both (core / commitments / patterns), with the blast radius written down so it can be scoped as its own PR.

---

## Stack summary
This completes the nine-PR remediation of `REVIEW.md`: #115 installer · #116 content+taxonomy · #117 MCP · #118 CI gates · #119 playbooks · #120 artefact size · #121 pricing · #122 sourcing · this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)