### PR TITLE
Add CI gates for description length and doc drift; SHA-pin all actions

### DIFF
--- a/.github/workflows/auto-tag-on-plugin-bump.yml
+++ b/.github/workflows/auto-tag-on-plugin-bump.yml
@@ -39,7 +39,7 @@ jobs:
       skip: ${{ steps.check_tag.outputs.skip }}
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           fetch-depth: 0   # need full history so `git tag` sees existing tags
 
@@ -151,12 +151,12 @@ jobs:
       contents: read
     steps:
       - name: Checkout tagged commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           ref: ${{ needs.tag-and-release.outputs.tag }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.12'
 
@@ -189,7 +189,7 @@ jobs:
         run: python -m build
 
       - name: Upload artefacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: pypi-dist
           path: mcp_server/dist/
@@ -210,7 +210,7 @@ jobs:
       id-token: write   # required for PyPI trusted publishing (OIDC)
     steps:
       - name: Download artefacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: pypi-dist
           path: dist/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
       - name: FCP frontmatter coverage (--check)
         run: bash scripts/fcp-coverage.sh --check
@@ -27,8 +27,11 @@ jobs:
       - name: llms.txt reference list in sync
         run: bash scripts/check-llms-txt.sh
 
+      - name: CLAUDE.md structure tree in sync
+        run: bash scripts/check-docs-drift.sh
+
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.12'
 
@@ -37,6 +40,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
+
+      # Needs PyYAML, so it runs after the install above rather than with the
+      # other drift checks.
+      - name: SKILL.md description within the claude.ai limit
+        run: bash scripts/check-skill-description.sh
 
       - name: Sync references into bundled data/
         working-directory: mcp_server

--- a/.github/workflows/marketplace-version-check.yml
+++ b/.github/workflows/marketplace-version-check.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
       - name: Check marketplace.json metadata.version matches plugin.json
         run: bash scripts/check-marketplace-version.sh

--- a/.github/workflows/mcp-install-smoke.yml
+++ b/.github/workflows/mcp-install-smoke.yml
@@ -45,10 +45,10 @@ jobs:
         python: ['3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: ${{ matrix.python }}
 

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -41,7 +41,7 @@ jobs:
       version: ${{ steps.version.outputs.version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           # push:tags -> github.ref is refs/tags/<tag>; default checkout grabs
           # the tagged commit. workflow_dispatch -> use the explicit tag input
@@ -49,7 +49,7 @@ jobs:
           ref: ${{ inputs.tag || github.ref }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.12'
 
@@ -97,7 +97,7 @@ jobs:
         run: ls -lh mcp_server/dist/
 
       - name: Upload artefacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: pypi-dist
           path: mcp_server/dist/
@@ -115,7 +115,7 @@ jobs:
       url: https://pypi.org/p/cloud-finops-mcp
     steps:
       - name: Download artefacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: pypi-dist
           path: dist/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
       - name: Build zip of cloud-finops skill folder
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -646,10 +646,15 @@ Good test patterns:
 - [ ] YAML FCP frontmatter included on the new file (see "Reference-file frontmatter")
 - [ ] Routing table updated in both SKILL.md and POWER.md
 - [ ] README directory listing and "What this skill covers" section updated
-- [ ] CLAUDE.md "Repository structure" directory listing updated
+- [ ] CLAUDE.md "Repository structure" directory listing updated (CI-gated by
+      `scripts/check-docs-drift.sh` - a reference missing from the tree, or a
+      tree entry with no file behind it, fails the `CI` workflow)
 - [ ] AGENTS.md and llms.txt updated to reflect the new reference (the llms.txt
       "Key files" list is CI-gated by `scripts/check-llms-txt.sh` - a missing or
-      stale entry fails the `CI` workflow, so this can't drift silently)
+      stale entry fails the `CI` workflow, so this can't drift silently).
+      AGENTS.md deliberately does not enumerate references - it shows a
+      truncated tree and defers to CLAUDE.md - so there is nothing to update
+      there unless the new file changes what AGENTS.md says about the repo.
 - [ ] install.sh per-tool routing updated: ChatGPT inline routing table, Gemini
       grouped knowledge, and Cursor description must mention the new domain
 - [ ] File ends with the OptimNow / CC BY-SA footer. References use
@@ -677,7 +682,9 @@ Good test patterns:
       `marketplace version in sync` workflow), `mcp_server/pyproject.toml`.
 - [ ] Marketplace description in `.claude-plugin/marketplace.json` reflects the new
       reference file count and topic list (can ride the release PR)
-- [ ] SKILL.md description stays under 1024 characters
+- [ ] SKILL.md description stays under 1024 characters (CI-gated by
+      `scripts/check-skill-description.sh`, which also warns above 950 so the
+      ceiling is visible before it is hit)
 - [ ] No em dashes in any public content
 - [ ] No sensitive or internal files included
 - [ ] Content is practical and based on how billing actually works, not on documentation summaries

--- a/scripts/check-docs-drift.sh
+++ b/scripts/check-docs-drift.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# check-docs-drift.sh - keep the hand-maintained doc listings in step with the
+# reference files on disk.
+#
+# `check-llms-txt.sh` already gates llms.txt. The 2026-08 review (F24) noted
+# that the rest of the PR checklist's doc-sync items rely on a human reading
+# the checklist. This closes the one that actually enumerates every reference:
+# the CLAUDE.md "Repository structure" tree.
+#
+# AGENTS.md deliberately does NOT enumerate references - it shows a truncated
+# tree and points at CLAUDE.md for the full listing - so there is nothing there
+# to drift, and it is intentionally not checked. If AGENTS.md ever starts
+# listing individual reference files, extend this script to cover it.
+#
+# Two checks, mirroring check-llms-txt.sh:
+#   1. Every skills/cloud-finops/references/*.md appears in the CLAUDE.md tree.
+#   2. Every reference filename in that tree block exists on disk.
+#
+# Usage:
+#   ./scripts/check-docs-drift.sh    Report drift; exit 1 if any is found.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+REF_DIR="skills/cloud-finops/references"
+CLAUDE_MD="CLAUDE.md"
+errors=0
+
+# The reference entries in the CLAUDE.md tree are the lines indented under
+# `└── references/`, i.e. they start with the tree prefix at that depth.
+# Scoping to that block keeps top-level entries (fcp-coverage.md, README.md)
+# from being mistaken for references.
+# Match on the indent only. Two mawk (the Ubuntu default awk) constraints shape
+# this: it does not support regex interval expressions, so `│ {7}` matches
+# nothing; and it is byte-oriented, so a bracket expression over multibyte tree
+# glyphs like `[├└]` becomes a set of stray bytes rather than a set of
+# characters. A literal prefix of `│` plus seven spaces avoids both.
+listed="$(awk '
+  /└── references\/ / { inblock = 1; next }
+  inblock && /^│       / { print; next }
+  inblock { inblock = 0 }
+' "$CLAUDE_MD" | grep -oE '[a-z0-9-]+\.md' | sort -u)"
+
+if [[ -z "$listed" ]]; then
+  echo "FAIL: could not find the references block in the $CLAUDE_MD tree." >&2
+  echo "      The tree format changed - update this script to match." >&2
+  exit 1
+fi
+
+# Check 1: every reference file appears in the tree.
+for f in "$REF_DIR"/*.md; do
+  base="$(basename "$f")"
+  if ! grep -qx "$base" <<<"$listed"; then
+    echo "MISSING: $base exists but is not in the $CLAUDE_MD structure tree" >&2
+    errors=$((errors + 1))
+  fi
+done
+
+# Check 2: every filename in the tree block points at a real file.
+while IFS= read -r base; do
+  [[ -f "$REF_DIR/$base" ]] || {
+    echo "STALE: $CLAUDE_MD lists $base which does not exist in $REF_DIR" >&2
+    errors=$((errors + 1))
+  }
+done <<<"$listed"
+
+count="$(find "$REF_DIR" -maxdepth 1 -name '*.md' -type f | wc -l | tr -d ' ')"
+if [[ $errors -gt 0 ]]; then
+  echo "FAIL: $errors CLAUDE.md sync error(s). Update the 'Repository structure' tree." >&2
+  exit 1
+fi
+echo "OK: CLAUDE.md structure tree lists all $count references, no stale entries."

--- a/scripts/check-skill-description.sh
+++ b/scripts/check-skill-description.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# check-skill-description.sh - guard the SKILL.md frontmatter description length.
+#
+# Claude.ai's skill uploader rejects a description over 1024 characters. The
+# description is edited by most content PRs (every new domain wants a mention),
+# and nothing else in CI notices when it grows. At the time this check was
+# written it stood at 987 of 1024 - one more domain away from breaking the
+# claude.ai upload path silently.
+#
+# Fails above HARD_LIMIT. Warns above WARN_LIMIT so the ceiling is visible
+# before it is hit rather than at the moment it breaks.
+#
+# Usage: ./scripts/check-skill-description.sh
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SKILL_MD="$REPO_ROOT/skills/cloud-finops/SKILL.md"
+
+HARD_LIMIT=1024
+WARN_LIMIT=950
+
+if [[ ! -f "$SKILL_MD" ]]; then
+  echo "ERROR: $SKILL_MD not found." >&2
+  exit 1
+fi
+
+# Extract the frontmatter `description:` value, including folded continuation
+# lines, and report its character count. Done in Python because the value spans
+# multiple lines and YAML folding rules decide the real length.
+length="$(python3 - "$SKILL_MD" <<'PY'
+import sys
+
+try:
+    import yaml
+except ImportError:
+    print("ERROR: PyYAML is required (pip install pyyaml).", file=sys.stderr)
+    raise SystemExit(1)
+
+text = open(sys.argv[1], encoding="utf-8").read()
+if not text.startswith("---"):
+    print("ERROR: SKILL.md has no YAML frontmatter.", file=sys.stderr)
+    raise SystemExit(1)
+
+parts = text.split("---", 2)
+if len(parts) < 3:
+    print("ERROR: SKILL.md frontmatter is not terminated.", file=sys.stderr)
+    raise SystemExit(1)
+
+fm = yaml.safe_load(parts[1]) or {}
+desc = fm.get("description")
+if not isinstance(desc, str) or not desc.strip():
+    print("ERROR: SKILL.md frontmatter has no 'description' field.", file=sys.stderr)
+    raise SystemExit(1)
+
+print(len(desc))
+PY
+)"
+
+if (( length > HARD_LIMIT )); then
+  echo "FAIL: SKILL.md description is $length characters, over the $HARD_LIMIT limit." >&2
+  echo "      claude.ai rejects a skill whose description exceeds $HARD_LIMIT chars," >&2
+  echo "      so this would break the upload path. Tighten it before merging." >&2
+  exit 1
+fi
+
+if (( length > WARN_LIMIT )); then
+  echo "WARN: SKILL.md description is $length of $HARD_LIMIT characters."
+  echo "      Little headroom left - consider tightening it in this PR."
+  exit 0
+fi
+
+echo "OK: SKILL.md description is $length of $HARD_LIMIT characters."

--- a/scripts/fcp-coverage.sh
+++ b/scripts/fcp-coverage.sh
@@ -159,7 +159,12 @@ while IFS= read -r f; do
       fi
     done <<< "$sec"
   fi
-done < <(find "$REF_DIR" -maxdepth 1 -name "*.md" -type f | sort)
+# LC_ALL=C so the ordering is byte-wise and identical everywhere. A plain
+# `sort` uses the caller's locale, which orders "finops-azure.md" and
+# "finops-azure-openai.md" differently under en_US.UTF-8 than under C - enough
+# to make `--check` fail on a developer machine (or a differently-configured CI
+# runner) against a matrix generated elsewhere.
+done < <(find "$REF_DIR" -maxdepth 1 -name "*.md" -type f | LC_ALL=C sort)
 
 # ---- Render fcp-coverage.md -----------------------------------------------
 total_caps=0


### PR DESCRIPTION
Stacked on #117. Prevents three whole classes of drift from recurring.

## F18 — SKILL.md description length
It stood at **987 of the 1024 characters** claude.ai permits, edited by most content PRs and watched by nothing. `scripts/check-skill-description.sh` fails above 1024 and warns above 950, so the ceiling is visible *before* it's hit rather than at the moment the upload path breaks.

## F24 — doc drift, gated where it can actually drift
The review suggested extending the llms.txt checker to AGENTS.md. But **AGENTS.md doesn't enumerate references** — it shows a truncated tree and defers to CLAUDE.md, so there's nothing there to drift. The real surface is the CLAUDE.md "Repository structure" tree, which lists all 29 references and was gated by nothing.

`scripts/check-docs-drift.sh` mirrors `check-llms-txt.sh` in both directions. The AGENTS.md decision is recorded in the PR checklist so it's a conscious accept, not an oversight.

## F23 — SHA-pin all actions
**Fifteen uses across six workflows** were on mutable tags, including in the workflows holding `contents: write` and the PyPI OIDC identity. Pinned to the commit each moving tag currently resolves to, with the exact version in a trailing comment (checkout v4.4.0, setup-python v5.6.0, upload-artifact v4.6.2, download-artifact v4.3.0). This pins what's already running — it does not upgrade majors.

## Plus a live CI hazard found while doing the above
`scripts/fcp-coverage.sh` piped `find` into a bare `sort`, ordering `finops-azure.md` / `finops-azure-openai.md` differently under a UTF-8 locale than under C. **`fcp-coverage.sh --check` runs in CI**, so a runner whose locale differed from the machine that generated the committed matrix would fail on pure ordering. Now `LC_ALL=C sort`; verified byte-identical under both locales with no diff to the committed matrix.

## Verification
Every gate exercised in both directions — an unlisted new reference and a stale tree entry both fail `check-docs-drift`; an oversized description fails `check-skill-description`. All six workflow files parse as YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
*Replaces #118, which GitHub auto-closed when its stacked base branch was deleted on merge. Same branch, same commit.*