### PR TITLE
Release 1.28.0: review remediation, file split, and CI hardening

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,12 +6,12 @@
   },
   "metadata": {
     "description": "Cloud Financial Management references and tooling by OptimNow.",
-    "version": "1.27.0"
+    "version": "1.28.0"
   },
   "plugins": [
     {
       "name": "cloud-finops",
-      "description": "Expert FinOps guidance for cloud, AI, SaaS, and data-platform spend. Reference files spanning AWS (incl. SageMaker operational FinOps and GPU instance rightsizing), Azure, GCP, Anthropic, Bedrock, Azure OpenAI, Vertex AI, Databricks, Microsoft Fabric, Snowflake, OCI, AI coding tools, agentic FinOps (agent cost anatomy, x402/MPP), FinOps Framework 2024+2026, GreenOps (AWS Sustainability Console, CSRD engagement framing), self-hosted vs managed AI inference decisioning, anomaly management, allocation and showback, chargeback (incl. Finance and accounting prerequisites), onboarding workloads (migration-time cost hygiene + M&A), Kubernetes (cross-cluster EKS/GKE/AKS discipline), waste-detection playbooks (seven-category taxonomy backed by OptimNow's WasteLine appliance) plus RAG-friendly named-pattern playbooks across AWS, Azure, GCP and cross-cloud (incl. SageMaker idle endpoint, notebook auto-shutdown, MME consolidation, oversized GPU, multi-GPU underutilization, MIG candidate, GPU for CPU-bound workload, outdated GPU generation, coding-agent token waste), SaaS asset management, and ITAM. Open source, model-agnostic, refreshed monthly.",
+      "description": "Expert FinOps guidance for cloud, AI, SaaS, and data-platform spend. Reference files spanning AWS (core, commitments and pattern catalogue as separate files; incl. SageMaker operational FinOps and GPU instance rightsizing), Azure (likewise split), GCP, Anthropic, Bedrock, Azure OpenAI, Vertex AI, Databricks, Microsoft Fabric, Snowflake, OCI, AI coding tools, agentic FinOps (agent cost anatomy, x402/MPP), FinOps Framework 2024+2026, GreenOps (AWS Sustainability Console, CSRD engagement framing), self-hosted vs managed AI inference decisioning, anomaly management, allocation and showback, chargeback (incl. Finance and accounting prerequisites), onboarding workloads (migration-time cost hygiene + M&A), Kubernetes (cross-cluster EKS/GKE/AKS discipline), waste-detection playbooks (eight-category taxonomy incl. egress / data transfer, backed by OptimNow's WasteLine appliance) plus RAG-friendly named-pattern playbooks across AWS, Azure, GCP and cross-cloud (incl. SageMaker idle endpoint, notebook auto-shutdown, MME consolidation, oversized GPU, multi-GPU underutilization, MIG candidate, GPU for CPU-bound workload, outdated GPU generation, coding-agent token waste), SaaS asset management, and ITAM. Open source, model-agnostic, refreshed monthly.",
       "source": "./",
       "strict": true,
       "skills": ["./skills/cloud-finops"]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloud-finops",
-  "version": "1.27.0",
+  "version": "1.28.0",
   "description": "Expert FinOps guidance for cloud, AI, SaaS, and data-platform spend (multi-provider, model-agnostic).",
   "author": {
     "name": "OptimNow",

--- a/mcp_server/pyproject.toml
+++ b/mcp_server/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cloud-finops-mcp"
-version = "1.27.0"
+version = "1.28.0"
 description = "MCP server exposing the OptimNow Cloud FinOps skill (reference library + named-pattern playbooks) as queryable tools."
 readme = "README.md"
 license = { text = "CC-BY-SA-4.0" }


### PR DESCRIPTION
Dedicated release PR — bumps all three version files together per the release-train rule. None of the ten PRs since 1.27.0 touched a version file; this is the deliberate publish act for all of them.

**Minor bump**: user-visible installer behaviour changed and four new reference files shipped, but nothing removed a documented capability.

| File | 1.27.0 → 1.28.0 |
|---|---|
| `.claude-plugin/plugin.json` | ✅ |
| `.claude-plugin/marketplace.json` `metadata.version` | ✅ (CI-gated to match) |
| `mcp_server/pyproject.toml` | ✅ |

## What ships

All from the 2026-08-02 repository review:

- **#115 Installer correctness** — exec bits, the `~/.claude/mcp.json` path fix (it isn't read by Claude Code), genuine idempotency, atomic copy, honest dry-run
- **#116 Content + eight-category taxonomy** — MariaDB, Convertible RI terms, public-IPv4 charging, H100 SM count; egress as Category 8 with WasteLine narrowed to 1-7
- **#117 MCP hardening** — a hollow wheel can no longer pass the smoke test; loud frontmatter failures; facet vocabulary pinned to data
- **#124 CI gates** — description length, structure-tree drift, 15 actions SHA-pinned
- **#119 Playbook queries** — four that couldn't run now do
- **#120 Installer artefacts** — ~1MB → ~27KB via routing file + MCP retrieval
- **#121 Pricing** — Fast mode corrected 6× → 2× and scoped to Opus-tier; 200K/1M contradiction resolved
- **#122 Sourcing** — Redshift claim rescoped, arXiv citations titled, newsletter claims flagged
- **#123 Gemini CLI** — confirmed real, no change needed
- **#125 File split** — AWS Savings Plans query: ~44K → ~8.3K tokens (**-82%**); Azure commitments: ~43K → ~13.6K (**-69%**)

Marketplace description updated for the split provider files and the eight-category taxonomy, as the checklist requires of a release PR.

## Pre-publish verification

Because merging this triggers the tag, GitHub Release, and PyPI publish, I exercised the publish path rather than trusting CI alone:

- Wheel **built at 1.28.0**, installed into a clean venv
- **Three-phase smoke test passes**, including the phase-3 content assertion added in #117 — the specific gate against publishing a hollow bundle
- Serves **33 references / 25 playbooks**; `__version__` reports `1.28.0`
- All five drift/size gates + `fcp-coverage --check` pass

## Note

Merging this bumps `plugin.json` on `main`, which fires `auto-tag-on-plugin-bump` → tag `v1.28.0` → GitHub Release → PyPI publish. That's the intended and irreversible step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)