### PR TITLE
Slim SKILL.md and POWER.md entry points for token efficiency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -563,7 +563,9 @@ Follow these five steps whenever you add a new domain:
 
 2. **Add a routing entry in SKILL.md**
    - Add a row to the "Domain routing" table with the query topic and file path
-   - Add a row to the "Reference files" table with the filename, description, and approximate line count
+   - (The old "Reference files" descriptive table was removed in the 2026-08
+     token-efficiency pass - the routing table is now the single catalogue.
+     Do not reintroduce a second per-file table.)
 
 3. **Add a routing entry in POWER.md**
    - Add a row to the "Domain routing" table (same format as SKILL.md)
@@ -705,8 +707,12 @@ Good test patterns:
       `skills/cloud-finops/playbooks/README.md` (frontmatter schema, Problem /
       Symptoms / Detection / Fix / Anti-pattern / See also sections, OptimNow
       CC BY-SA footer), and update the named-
-      pattern parenthetical in SKILL.md, POWER.md, and the ChatGPT / grouped
-      routing tables in install.sh.
+      pattern parenthetical in the ChatGPT / grouped routing tables in
+      install.sh. SKILL.md and POWER.md carry representative examples only
+      (since the 2026-08 token-efficiency pass) and defer to
+      `playbooks/README.md` for the full list - only extend their examples
+      if the new pattern is a distinct new family (new provider or new
+      waste category), not for every added playbook.
       (Exact reference/playbook counts were removed from prose across the repo in
       2026-07 precisely so they no longer need hand-bumping - do not reintroduce
       hardcoded "N references / N playbooks" counts; use "the reference library"

--- a/skills/cloud-finops/POWER.md
+++ b/skills/cloud-finops/POWER.md
@@ -217,15 +217,17 @@ When activated, follow the reasoning sequence below for every response.
 
 ## How to use this power
 
-This power covers cloud, AI, SaaS, and adjacent technology spend domains. Use
-`references/optimnow-methodology.md` as a reasoning lens (diagnose before prescribing,
-connect cost to value, recommend progressively); then load the domain reference(s)
-matching the query.
+This power covers cloud, AI, SaaS, and adjacent technology spend domains. Apply the
+OptimNow lens to every answer: diagnose before prescribing, connect cost to value,
+recommend progressively. Then load the domain reference(s) matching the query. Load
+`references/optimnow-methodology.md` in full only for strategy, engagement-design, or
+methodology questions - not for routine billing-mechanics queries.
 
 ### Domain routing
 
 | Query topic | Load reference |
 |---|---|
+| OptimNow methodology, engagement approach, four pillars, FinOps strategy design, practice positioning | `references/optimnow-methodology.md` |
 | AI costs, LLM inference, token economics, agentic cost patterns, AI ROI, AI cost allocation, GPU cost attribution, GPU telemetry, DCGM metrics, "GPU utilization is misleading", tensor core activity, GPU memory bandwidth, RAG harness costs | `references/finops-for-ai.md` |
 | Agentic FinOps, true agents vs pipelines vs workflows, agentic cost anatomy, cost per completed task, cost-safe agent architecture, agent-initiated payments, x402, MPP, agent wallets | `references/finops-agentic.md` |
 | AI investment governance, AI Investment Council, stage gates, incremental funding, AI value management, AI practice operations | `references/finops-ai-value-management.md` |
@@ -258,12 +260,12 @@ matching the query.
 | Onboarding workloads, migration-time cost hygiene, intake gate, mandatory tags at go-live, 60-90 day forecast-then-commit rule, double-bubble cost (parallel-run source and target), migration cost estimate vs actuals, network-cost trap (data-centre to cloud), M&A integration patterns, FOCUS-during-migration, architecture review integration, post-migration FinOps owner | `references/finops-onboarding-workloads.md` |
 | Kubernetes FinOps, K8s cost allocation, OpenCost, Kubecost, GKE Cost Allocation, EKS Split Cost Allocation, AKS Cost Analysis, FOCUS-emitting K8s allocation, container rightsizing (VPA, p95/p99 with safety margins), node-level autoscaling (Karpenter, Cluster Autoscaler), Pod Disruption Budgets, Spot diversification, idle node cost, node efficiency KPI | `references/finops-kubernetes.md` |
 | Waste detection playbooks, orphaned resources, idle resources, overprovisioned resources, commitment mismatches, schedule blindness, modernization opportunities, AI/ML inefficiency, egress / data transfer waste, cross-AZ egress cost, two-signal classification, classification confidence (obvious / likely / possible), realised vs potential savings, WasteLine appliance, OptimNow waste taxonomy | `references/finops-waste-detection-playbooks.md` |
-| Named waste pattern (zombie NAT, snapshot sprawl, idle ELB, cross-AZ egress, oversized RDS, orphan EBS, orphan Azure disks, App Service overprovisioning, Log Analytics ingestion sprawl, idle Azure SQL, idle GKE Autopilot, orphan Persistent Disks, Cloud Functions cold starts, schedule blindness, untagged spend drift, idle SageMaker endpoint, always-on SageMaker notebook, SageMaker endpoint sprawl / MME consolidation, oversized GPU instance, multi-GPU underutilized, MIG candidate, GPU for CPU-bound workload, outdated GPU generation, agent-loop flat-line burn, coding-agent token waste) | `playbooks/<slug>.md` (see `playbooks/README.md` for the full list) |
+| Named waste pattern (e.g. zombie NAT, snapshot sprawl, idle ELB, cross-AZ egress, orphan Azure disks, Log Analytics ingestion sprawl, idle GKE Autopilot, idle SageMaker endpoint, oversized GPU instance, agent-loop flat-line burn) | `playbooks/<slug>.md` (see `playbooks/README.md` for the full pattern list) |
 | Multi-domain query | Load all relevant references, synthesise |
 
 ### Reasoning sequence (apply to every response)
 
-1. **Apply the methodology lens** (`references/optimnow-methodology.md`) - diagnose before prescribing, connect cost to value, recommend progressively
+1. **Apply the OptimNow lens** - diagnose before prescribing, connect cost to value, recommend progressively (load `references/optimnow-methodology.md` in full only for strategy or engagement questions)
 2. **Load** the domain reference(s) matching the query
 3. **Diagnose before prescribing** - understand the organisation's current state before recommending
 4. **Connect cost to value** - every recommendation should link spend to a business outcome
@@ -287,23 +289,10 @@ These six principles from the FinOps Foundation (2026 framework) underpin every 
 
 ## The three phases (Inform → Optimize → Operate)
 
-FinOps is an iterative cycle, not a linear progression. Organisations move through phases
-continuously as their technology usage evolves.
-
-**Inform** - establish visibility and allocation
-- Cost data is accessible and attributed to owners
-- Shared costs are allocated with defined methods
-- Anomaly detection is active
-
-**Optimize** - improve rates and usage efficiency
-- Commitment discounts (RIs, Savings Plans, CUDs) are actively managed
-- Rightsizing and waste elimination are running continuously
-- Unit economics are tracked
-
-**Operate** - operationalise through governance and automation
-- FinOps is embedded in engineering and finance workflows
-- Policies are enforced through automation, not manual review
-- Accountability is distributed, not centralised
+FinOps is an iterative cycle, not a linear progression: Inform (visibility, allocation,
+anomaly detection), Optimize (commitment discounts, rightsizing, unit economics),
+Operate (governance and automation embedded in engineering and finance workflows).
+See `references/finops-framework.md` for the full phase model.
 
 ---
 

--- a/skills/cloud-finops/SKILL.md
+++ b/skills/cloud-finops/SKILL.md
@@ -23,15 +23,17 @@ description: >
 
 ## How to use this skill
 
-This skill covers cloud, AI, SaaS, and adjacent technology spend domains. Use
-`references/optimnow-methodology.md` as a reasoning lens (diagnose before prescribing,
-connect cost to value, recommend progressively); then load the domain reference(s)
-matching the query.
+This skill covers cloud, AI, SaaS, and adjacent technology spend domains. Apply the
+OptimNow lens to every answer: diagnose before prescribing, connect cost to value,
+recommend progressively. Then load the domain reference(s) matching the query. Load
+`references/optimnow-methodology.md` in full only for strategy, engagement-design, or
+methodology questions - not for routine billing-mechanics queries.
 
 ### Domain routing
 
 | Query topic | Load reference |
 |---|---|
+| OptimNow methodology, engagement approach, four pillars, FinOps strategy design, practice positioning | `references/optimnow-methodology.md` |
 | AI costs, LLM inference, token economics, agentic cost patterns, AI ROI, AI cost allocation, GPU cost attribution, GPU telemetry, DCGM metrics, "GPU utilization is misleading", tensor core activity, GPU memory bandwidth, RAG harness costs | `references/finops-for-ai.md` |
 | Agentic FinOps, true agents vs pipelines vs workflows, agentic cost anatomy, cost per completed task, cost-safe agent architecture, agent-initiated payments, x402, MPP, agent wallets | `references/finops-agentic.md` |
 | AI investment governance, AI Investment Council, stage gates, incremental funding, AI value management, AI practice operations | `references/finops-ai-value-management.md` |
@@ -64,12 +66,12 @@ matching the query.
 | Onboarding workloads, migration-time cost hygiene, intake gate, mandatory tags at go-live, 60-90 day forecast-then-commit rule, double-bubble cost (parallel-run source and target), migration cost estimate vs actuals, network-cost trap (data-centre to cloud), M&A integration patterns, FOCUS-during-migration, architecture review integration, post-migration FinOps owner | `references/finops-onboarding-workloads.md` |
 | Kubernetes FinOps, K8s cost allocation, OpenCost, Kubecost, GKE Cost Allocation, EKS Split Cost Allocation, AKS Cost Analysis, FOCUS-emitting K8s allocation, container rightsizing (VPA, p95/p99 with safety margins), node-level autoscaling (Karpenter, Cluster Autoscaler), Pod Disruption Budgets, Spot diversification, idle node cost, node efficiency KPI | `references/finops-kubernetes.md` |
 | Waste detection playbooks, orphaned resources, idle resources, overprovisioned resources, commitment mismatches, schedule blindness, modernization opportunities, AI/ML inefficiency, egress / data transfer waste, cross-AZ egress cost, two-signal classification, classification confidence (obvious / likely / possible), realised vs potential savings, WasteLine appliance, OptimNow waste taxonomy | `references/finops-waste-detection-playbooks.md` |
-| Named waste pattern (zombie NAT, snapshot sprawl, idle ELB, cross-AZ egress, oversized RDS, orphan EBS, orphan Azure disks, App Service overprovisioning, Log Analytics ingestion sprawl, idle Azure SQL, idle GKE Autopilot, orphan Persistent Disks, Cloud Functions cold starts, schedule blindness, untagged spend drift, idle SageMaker endpoint, always-on SageMaker notebook, SageMaker endpoint sprawl / MME consolidation, oversized GPU instance, multi-GPU underutilized, MIG candidate, GPU for CPU-bound workload, outdated GPU generation, agent-loop flat-line burn, coding-agent token waste) | `playbooks/<slug>.md` (see `playbooks/README.md` for the full list) |
+| Named waste pattern (e.g. zombie NAT, snapshot sprawl, idle ELB, cross-AZ egress, orphan Azure disks, Log Analytics ingestion sprawl, idle GKE Autopilot, idle SageMaker endpoint, oversized GPU instance, agent-loop flat-line burn) | `playbooks/<slug>.md` (see `playbooks/README.md` for the full pattern list) |
 | Multi-domain query | Load all relevant references, synthesise |
 
 ### Reasoning sequence (apply to every response)
 
-1. **Apply the methodology lens** (`references/optimnow-methodology.md`) - diagnose before prescribing, connect cost to value, recommend progressively
+1. **Apply the OptimNow lens** - diagnose before prescribing, connect cost to value, recommend progressively (load `references/optimnow-methodology.md` in full only for strategy or engagement questions)
 2. **Load** the domain reference(s) matching the query
 3. **Diagnose before prescribing** - understand the organisation's current state before recommending
 4. **Connect cost to value** - every recommendation should link spend to a business outcome
@@ -94,23 +96,10 @@ These six principles from the FinOps Foundation (2026 framework) underpin every 
 
 ## The three phases (Inform → Optimize → Operate)
 
-FinOps is an iterative cycle, not a linear progression. Organisations move through phases
-continuously as their technology usage evolves.
-
-**Inform** - establish visibility and allocation
-- Cost data is accessible and attributed to owners
-- Shared costs are allocated with defined methods
-- Anomaly detection is active
-
-**Optimize** - improve rates and usage efficiency
-- Commitment discounts (RIs, Savings Plans, CUDs) are actively managed
-- Rightsizing and waste elimination are running continuously
-- Unit economics are tracked
-
-**Operate** - operationalise through governance and automation
-- FinOps is embedded in engineering and finance workflows
-- Policies are enforced through automation, not manual review
-- Accountability is distributed, not centralised
+FinOps is an iterative cycle, not a linear progression: Inform (visibility, allocation,
+anomaly detection), Optimize (commitment discounts, rightsizing, unit economics),
+Operate (governance and automation embedded in engineering and finance workflows).
+See `references/finops-framework.md` for the full phase model.
 
 ---
 
@@ -128,46 +117,6 @@ continuously as their technology usage evolves.
 Always assess maturity before recommending solutions. A Crawl organisation needs visibility
 before optimisation. Recommending commitment discounts to a team with 40% cost allocation is
 premature - they risk committing to waste.
-
----
-
-## Reference files
-
-| File | Contents |
-|---|---|
-| `optimnow-methodology.md` | OptimNow reasoning philosophy, 4 pillars, engagement principles, tools |
-| `finops-for-ai.md` | AI cost management, LLM economics, harness cost surface, unit economics, ROI framework, GPU telemetry (DCGM metric reference, "GPU utilization is misleading") |
-| `finops-agentic.md` | Agentic FinOps: workflow vs pipeline vs true agent cost behaviour, agentic cost anatomy, cost-safe agent architecture, agent-initiated payments (x402 / MPP) |
-| `finops-ai-value-management.md` | AI investment governance: AI Investment Council, stage gates, incremental funding, practice operations, value metrics |
-| `finops-genai-capacity.md` | GenAI capacity models: provisioned vs shared, traffic shape, spillover (incl. Vertex AI default-PAYG), waste types, cross-provider comparison |
-| `finops-ai-self-hosted-vs-managed.md` | Self-hosted vs managed AI inference: per-token vs per-hour billing, hidden cost surface (operational, reliability, compliance, talent), 5-criteria maturity rubric, hybrid routing patterns, eight client diagnostic questions, six anti-patterns |
-| `finops-aws.md` | AWS FinOps core: CUR + Data Exports for FOCUS 1.2, Cost Explorer hourly + resource-level, compute rightsizing entry points, SageMaker operational FinOps (billed-while-idle, deployment pattern selection, MME / Inference Components, notebook hygiene), cost allocation, governance tools, quick wins, database cost optimisation, CloudFront flat-rate plans, S3 Files, multi-organisation billing |
-| `finops-aws-commitments.md` | AWS commitment discounts: Savings Plans (Compute, EC2 Instance, SageMaker AI, Database), Reserved Instances incl. Convertible terms, Spot, the commitment decision tree, portfolio liquidity and phased purchasing, EDP negotiation |
-| `finops-aws-patterns.md` | AWS optimisation pattern catalogue: the enumerated per-service inefficiency list with signal and remediation. A lookup surface - prefer `playbooks/aws-*.md` for named patterns with runnable detection |
-| `finops-bedrock.md` | AWS Bedrock: model pricing, provisioned throughput, Application Inference Profiles, Bedrock Projects, prompt caching with 1-hour TTL, IAM Principal Cost Allocation, CloudWatch metrics, cost allocation |
-| `finops-azure.md` | Azure FinOps core: Cost Management and FOCUS exports, Retail Prices API, compute rightsizing (VM cost model and SKU naming through Advisor calibration and the band Advisor misses), Log Analytics 5-lever cost control, snapshot/backup management, AKS in depth (NAP, Azure Linux 2), database optimisation, tagging and Azure Policy governance, storage tiering, networking cost, cost allocation, agentic FinOps, EA-to-MCA contractual mechanics |
-| `finops-azure-commitments.md` | Azure commitment discounts: Reservations, Savings Plans, Azure Hybrid Benefit, Spot, compute and database commitment decision trees, portfolio liquidity under the 1 February 2027 exchange retirement, phased purchasing, MACC alignment, commitment sizing methodology |
-| `finops-azure-patterns.md` | Azure optimisation pattern catalogue: the enumerated per-service inefficiency list with signal and remediation. A lookup surface - prefer `playbooks/azure-*.md` for named patterns with runnable detection |
-| `finops-azure-openai.md` | Azure OpenAI / AI Foundry: PTU reservations (locality constraint), reservation discount path, spillover, GPT model pricing, prompt caching, fine-tuning costs |
-| `finops-anthropic.md` | Anthropic billing: Claude Opus/Sonnet/Haiku pricing, Fast mode and Managed Agents (flagged emerging-assumption), per-model long-context picture, prompt caching, Batch API, governance |
-| `finops-gcp.md` | GCP FinOps: cost-data foundations (Cloud Billing console, BigQuery billing export standard / detailed / pricing, FOCUS export, Pricing API), Sustained Use Discounts, Committed Use Discounts (resource-based vs Flexible/spend-based with current 28%/46% depths), Compute SKU vCPU/RAM split, Spot VMs, BigQuery commitment model, Cloud Carbon Footprint location-based vs market-based, GKE cost attribution, 26 inefficiency patterns |
-| `finops-vertexai.md` | GCP Vertex AI billing: Gemini pricing, provisioned throughput (default-PAYG spillover), batch prediction, Cloud Monitoring metrics |
-| `finops-tagging.md` | Tagging strategy, IaC enforcement, virtual tagging, MCP automation |
-| `finops-framework.md` | FinOps Foundation framework 2026 (4 domains, 22 capabilities including the new Executive Strategy Alignment and the renames Workload Optimization -> Usage Optimization, Architecting for Cloud -> Architecting & Workload Placement, Cloud Sustainability -> Sustainability, Benchmarking -> KPIs & Benchmarking, Policy & Governance -> Governance, Policy & Risk, FinOps Tools & Services -> Automation, Tools & Services), personas, principles, phases |
-| `finops-databricks.md` | Databricks FinOps: cost data foundations (system.billing.usage, budget policies, serverless and model-serving attribution), allocation and governance (workspace + DBU executor patterns, Azure VM RI vs DBU clarification, DBCU commitments, Photon and serverless multipliers, amortised vs PAYG split, monthly cadence, sequencing), 18 inefficiency patterns |
-| `finops-fabric.md` | Microsoft Fabric capacity FinOps: F-SKU model, Capacity Units and 24-hour CU smoothing, throttling behaviour, manual pause / resume, Reserved Capacity, Pro/PPU to Fabric migration governance trap, shared-capacity allocation models, Capacity Metrics app, Pro vs PPU vs F-SKU breakeven |
-| `finops-snowflake.md` | Snowflake FinOps: credit model, modern cost-management primitives (QUERY_ATTRIBUTION_HISTORY, Budgets including AI feature budgets, resource-monitor scope limit, Cortex governance), 13 optimisation patterns |
-| `finops-ai-dev-tools.md` | AI coding tools: Cursor (Pro/Ultra/Teams/Enterprise), Claude Code, GitHub Copilot (transition to AI Credits 1 June 2026), Windsurf, OpenAI Codex (incl. GPT-5.5), billing models, cost attribution, optimisation levers |
-| `finops-oci.md` | OCI FinOps: cost-data foundations (Cost Reports, FOCUS Reports, cost-tracking tags, OCI Budgets, Universal Credits) and 6 inefficiency patterns |
-| `finops-sam.md` | SaaS asset management: discovery, licence optimisation, renewal governance, SMPs, shadow IT, AI transition |
-| `finops-itam.md` | FinOps-ITAM collaboration: BYOL mechanics, marketplace channel governance, vendor co-management, consumption monitoring, joint operating model |
-| `greenops-cloud-carbon.md` | GreenOps: carbon measurement, carbon-aware workloads, region selection, GHG Protocol |
-| `finops-anomaly-management.md` | Cost anomaly management as a standalone Inform-phase capability: native tooling per cloud (AWS Cost Anomaly Detection, Azure Cost Management, GCP Budgets), threshold philosophy (absolute dollars + percentage), layered detection across service / region / account / tag, the masked-anomaly failure mode, new-region detection, Security integration, Crawl/Walk/Run progression |
-| `finops-allocation-showback.md` | Cost allocation and showback. FOCUS cost columns (EffectiveCost vs BilledCost) with AWS legacy mapping (amortised / unblended) and blended-cost trap warning. Defensible allocation keys table, shared-services hard cases (network, observability, security, ingress), InvoiceId reconciliation, unallocated > 10% as tagging signal, showback report design and routing, data-quality dispute process, Crawl/Walk/Run progression |
-| `finops-chargeback.md` | Chargeback as a distinct discipline from allocation. Soft-to-hard chargeback maturity ladder, Finance and accounting prerequisites for hard chargeback (ERP readiness in SAP CO / Oracle / Workday / NetSuite, inter-BU P&L impact and incentive alignment, transfer pricing for intercompany recharges, cross-border tax incl. VAT / Pillar 2 / GILTI, SOX-equivalent controls), decision-owner table mapping prerequisites to Finance roles, methodology dispute process, chargeback-revolt anti-pattern, Walk/Run progression. Strict prerequisite is finops-allocation-showback.md |
-| `finops-onboarding-workloads.md` | Migration-time cost hygiene. Intake gate that prevents new workloads landing untagged / unallocated / unforecast (mandatory checklist + three implementation patterns: PR gate, cutover gate, pre-prod gate), the 60-90 day forecast-then-commit rule for fresh workloads (and exceptions), double-bubble cost (source + target parallel-run) with explicit shutoff discipline, migration-cost-estimate-vs-actuals trap (network-cost differences between data-centre and cloud), M&A integration playbook (months 1-12 sequence), FOCUS-during-migration logic, cost-aware architecture review integration, post-migration FinOps owner |
-| `finops-kubernetes.md` | Kubernetes as the cross-cluster discipline (EKS / GKE / AKS). Tooling choice (OpenCost / Kubecost / cloud-native), FOCUS-emitting K8s allocation with K8s-labels-to-FOCUS-Tags mapping, container rightsizing methodology (VPA recommendation-only, p99 + 30% memory safety, p95 + 50% CPU safety, per-workload rollout), node-level autoscaling (Karpenter > CA where available, consolidation tuning, PDB requirements, Spot diversification across instance types and AZs), idle node cost as Platform overhead. Provider-specific deep cuts stay in finops-aws.md / finops-azure.md / finops-gcp.md |
-| `finops-waste-detection-playbooks.md` | OptimNow's eight-category waste taxonomy (orphaned, idle, overprovisioned, commitment mismatches, schedule blindness, modernization, AI/ML inefficiency, egress / data transfer) with patterns and detection examples per category. Two-signal classification rule, three-tier confidence (obvious / likely / possible), realised vs potential savings discipline. Operational tooling: WasteLine appliance for AWS (49 detection rules across Categories 1-7, read-only, proposal-only remediation; egress is doctrine-only); for Azure and GCP, points to in-cloud catalogues. Category 7 (AI/ML) cross-links to dedicated playbooks for SageMaker and GPU waste patterns. Crawl/Walk/Run progression from manual quarterly hunt to continuous Fargate-scheduled detection |
 
 ---
 


### PR DESCRIPTION
PR B of the token-efficiency series. **Stacked on #127** - review and merge #127 first; GitHub will retarget this PR to main automatically.

## What changes

**SKILL.md: ~23 KB (~5.8K tokens) → ~12 KB (~3.1K tokens)**, paid on every skill invocation:

- **Removed the "Reference files" descriptive table** (~11 KB). It duplicated the domain routing table with long prose descriptions. The routing table is now the single catalogue and gains an explicit row for `optimnow-methodology.md`.
- **Methodology loading is now conditional.** The three-principle OptimNow lens (diagnose before prescribing, connect cost to value, recommend progressively) is inlined in the entry point and still applies to every answer. The full `optimnow-methodology.md` (~2.2K tokens) is loaded only for strategy, engagement-design, or methodology questions - not for routine billing-mechanics queries.
- **Three-phases section compressed** to a summary plus a pointer at `finops-framework.md`. The six principles and the maturity quick-reference table stay - they are compact and behavioural.
- **Named-waste-pattern routing row shortened** to representative examples plus the `playbooks/README.md` index pointer. The full 25-pattern enumeration stays in the install.sh ChatGPT routing tables, where the target model cannot browse a directory index.

**POWER.md** mirrors the same changes (it never had the descriptive table; the keyword list is required for Kiro activation and stays).

**CLAUDE.md** contributor doctrine updated to match: no more Reference-files-table step, and the playbook-parenthetical checklist item now scopes to install.sh only.

**install.sh needs no change**: it concatenates SKILL.md verbatim into every generated artefact, so the diet propagates to all installer targets automatically.

## Estimated saving

~2.7K tokens on every skill invocation, plus ~2.2K on every non-strategy query that previously loaded the methodology file - roughly 4-5K tokens per routine billing question.

## Validation

- All five CI check scripts pass locally (docs-drift, llms-txt, skill-description, marketplace-version, artefact-size)
- No em dashes introduced; British spelling kept
- The pipeline fingerprint marker (`fp:`) on the principles section is untouched
- No version bumps (content PR, release-train rule)

🤖 Generated with [Claude Code](https://claude.com/claude-code)