### PR TITLE
AI pricing verification pass: correct all AI pricing data against provider primary sources

### DIFF
--- a/skills/cloud-finops/playbooks/aws-gpu-instance-oversized.md
+++ b/skills/cloud-finops/playbooks/aws-gpu-instance-oversized.md
@@ -13,7 +13,7 @@ confidence: likely
 GPU instances are the most expensive on-demand SKUs in EC2. A `g5.xlarge`
 (A10G, 24 GB) is ~$1.00/hour ~= $730/month; a `g5.12xlarge` (4 x A10G)
 is ~$5.67/hour ~= $4,140/month; a `p4d.24xlarge` (8 x A100 40 GB) is
-~$32.77/hour ~= $23,920/month. Picking an instance with more GPU compute
+~$21.96/hour ~= $16,030/month. Picking an instance with more GPU compute
 and memory than the workload uses is one of the highest-dollar waste
 patterns in AWS - and one of the hardest to spot, because the basic
 GPU-utilisation metric most teams reach for (`nvidia-smi`'s `GPU-Util`,

--- a/skills/cloud-finops/playbooks/aws-mig-candidate.md
+++ b/skills/cloud-finops/playbooks/aws-mig-candidate.md
@@ -16,7 +16,7 @@ memory. On AWS, MIG is available on `p4d` / `p4de` (A100 40 GB / 80 GB)
 and `p5` / `p5e` / `p5en` (H100 / H200). A workload that uses well under
 1/7 of an A100 or H100 - measured by both compute fraction and memory -
 is paying for a whole GPU when it could share the hardware via MIG. With
-`p4d.24xlarge` at ~$33/hour (8 x A100) and `p5.48xlarge` at ~$98/hour (8 x
+`p4d.24xlarge` at ~$22/hour (8 x A100) and `p5.48xlarge` at ~$55/hour (8 x
 H100), running multiple light workloads on a MIG-partitioned single
 server can recover 4-7x of the GPU bill compared to one GPU per workload.
 

--- a/skills/cloud-finops/playbooks/aws-multi-gpu-underutilized.md
+++ b/skills/cloud-finops/playbooks/aws-multi-gpu-underutilized.md
@@ -13,7 +13,7 @@ confidence: obvious
 High-end GPU instances pack multiple GPUs in a single server: `g5.48xlarge`
 (8 x A10G), `p4d.24xlarge` (8 x A100 40 GB), `p4de.24xlarge` (8 x A100 80
 GB), `p5.48xlarge` (8 x H100). Pricing is for the whole server: ~$16/hour
-for `g5.48xlarge`, ~$33/hour for `p4d.24xlarge`, ~$98/hour for
+for `g5.48xlarge`, ~$22/hour for `p4d.24xlarge`, ~$55/hour for
 `p5.48xlarge`. When the workload runs on a single GPU and the other seven
 sit idle, the customer is paying 7/8 of the bill for thin air. This is one
 of the highest-confidence waste patterns: per-GPU telemetry shows it

--- a/skills/cloud-finops/playbooks/aws-outdated-gpu-generation.md
+++ b/skills/cloud-finops/playbooks/aws-outdated-gpu-generation.md
@@ -90,10 +90,11 @@ to enumerate live instances and tag-check ownership.
 
 ## Anti-pattern
 
-- Comparing only **hourly rates**. A `p5.48xlarge` ($98/hour) looks vastly
-  more expensive than a `p3.16xlarge` ($24.48/hour) - but on the right
-  workload the H100 can deliver 5-10x the throughput, making the
-  cost-per-inference half. The decision must be cost per unit of work.
+- Comparing only **hourly rates**. A `p5.48xlarge` (~$55/hour after the June
+  2025 AWS GPU price cuts) looks far more expensive than a `p3.16xlarge`
+  ($24.48/hour) - but on the right workload the H100 delivers 5-10x the
+  throughput, cutting cost-per-inference to a fraction. The decision must be
+  cost per unit of work.
 - Assuming framework compatibility. PyTorch ≤ 1.10 has no native H100
   support; some custom CUDA kernels need rewrites. Always run a
   representative inference / training step on the new hardware before

--- a/skills/cloud-finops/playbooks/aws-sagemaker-idle-endpoint.md
+++ b/skills/cloud-finops/playbooks/aws-sagemaker-idle-endpoint.md
@@ -14,7 +14,7 @@ A SageMaker real-time endpoint is billed at the underlying instance hourly
 rate as long as the endpoint is provisioned, whether traffic flows through
 it or not. A small `ml.m5.xlarge` endpoint costs ~$170/month; a single
 `ml.g4dn.xlarge` GPU endpoint costs ~$540/month; an `ml.p4d.24xlarge`
-endpoint costs ~$27,500/month. Forgotten demo endpoints, A/B test variants
+endpoint costs ~$18,400/month. Forgotten demo endpoints, A/B test variants
 that were never decommissioned, and "we might need it again" endpoints are
 among the highest-density waste patterns in any AWS account running ML.
 

--- a/skills/cloud-finops/playbooks/aws-sagemaker-notebook-always-on.md
+++ b/skills/cloud-finops/playbooks/aws-sagemaker-notebook-always-on.md
@@ -67,8 +67,9 @@ actually running anything in there".
 
 1. **Stop** the notebook (do not delete) once confirmed idle:
    `aws sagemaker stop-notebook-instance --notebook-instance-name <name>`.
-   Stopping releases the instance charge but preserves the attached EBS
-   volume (~$0.10/GB/month) and the notebook contents.
+   Stopping releases the instance charge but preserves the attached ML
+   storage volume (~$0.14/GB/month - SageMaker notebook storage bills above
+   the plain EC2 EBS gp2 rate) and the notebook contents.
 2. **Attach an auto-shutdown LCC** so the instance never ends up always-on
    again. AWS publishes a reference script that runs every 5 minutes,
    detects kernel idle time, and stops the instance after N hours of

--- a/skills/cloud-finops/references/finops-ai-dev-tools.md
+++ b/skills/cloud-finops/references/finops-ai-dev-tools.md
@@ -88,20 +88,28 @@ Cursor has two cost layers: a fixed subscription and variable usage-based token 
 | Plan | Seat cost | Included usage | Overage billing |
 |---|---|---|---|
 | Hobby (free) | $0 | Limited requests and completions | Not available |
-| Pro | $20/month | $20 in usage credits | Per token at model rates |
-| Business | $40/seat/month | $20 in usage credits per seat | Per token at model rates |
+| Pro | $20/month | $20/month usage pool | Per token at model rates |
+| Pro+ | Higher individual tier | ~3x the Pro usage pool | Per token at model rates |
+| Ultra | Top individual tier | ~20x the Pro usage pool | Per token at model rates |
+| Teams Standard (was "Business") | $40/seat/month | Usage pool per seat | Per token at model rates |
+| Teams Premium | $120/seat/month | Larger pool per seat | Per token at model rates |
 | Enterprise | Custom | Custom | Custom |
 
-Annual billing on Pro reduces the seat cost to ~$16/month.
+Annual billing on Pro reduces the seat cost to ~$16/month. Cursor renames and
+restructures tiers frequently - verify the current lineup at cursor.com/pricing
+before building a seat forecast.
 
 ### Token rate variability
 
 Token rates depend on which model handles the request. This is the highest-leverage cost
 variable. The range is wide:
 
-- **Auto mode** (Cursor's default routing): ~$1.25/MTok input, ~$6.00/MTok output
-- **Budget models** (e.g. Composer 2 Standard): ~$0.50/MTok input
-- **Premium models** (e.g. Claude Opus 4.6): ~$5.00/MTok input, ~$25.00/MTok output
+- **Auto mode** (Cursor's default routing): the earlier flat Auto rate was retired -
+  Auto now bills at the API rate of whichever model it routes to, so its cost tracks
+  the routing mix rather than a fixed figure
+- **First-party models** (Composer, Grok variants): included in the plan's "Cursor
+  Models" pool with no separately published per-token rate
+- **Premium models** (e.g. the Claude Opus family): $5.00/MTok input, $25.00/MTok output
 
 A 10-50x gap exists between the cheapest and most expensive models available in Cursor.
 Even small shifts in model distribution across a team show up on the invoice fast.
@@ -151,7 +159,7 @@ each with a different billing model.
 
 | Plan | Cost | What you get |
 |---|---|---|
-| Pro | $20/month | Claude Code access, Sonnet 4.6 and Opus 4.6, moderate token budget |
+| Pro | $20/month | Claude Code access, current Sonnet and Opus models, moderate token budget |
 | Max 5x | $100/month | 5x the Pro usage allowance |
 | Max 20x | $200/month | 20x the Pro usage allowance |
 
@@ -166,8 +174,8 @@ standard API rates:
 | Model | Input ($/MTok) | Output ($/MTok) |
 |---|---|---|
 | Claude Haiku 4.5 | $1.00 | $5.00 |
-| Claude Sonnet 4.6 | $3.00 | $15.00 |
-| Claude Opus 4.6 | $5.00 | $25.00 |
+| Claude Sonnet 5 / 4.6 | $3.00 | $15.00 (Sonnet 5 introductory $2/$10 through 31 August 2026) |
+| Claude Opus 5 / 4.8 / 4.6 | $5.00 | $25.00 |
 
 Anthropic's own data indicates the average Claude Code user on API key mode costs ~$6/day,
 with 90% of users staying under $12/day. At sustained full-time usage, expect
@@ -200,15 +208,9 @@ Codex is OpenAI's coding agent, available through ChatGPT and as a CLI tool.
 **ChatGPT subscription (default):** Codex CLI usage draws from your ChatGPT plan limits
 at no extra per-token charge. ChatGPT Plus at $20/month is the cheapest access path.
 
-**API key mode:** when switched to API key mode, Codex bills per token at standard OpenAI
-API rates:
-
-| Model | Input ($/MTok) | Output ($/MTok) |
-|---|---|---|
-| codex-mini-latest | $1.50 | $6.00 |
-| GPT-5 | $1.25 | $10.00 |
-
-API rates. **This file deliberately does not carry an OpenAI rate card.** A previous
+**API key mode:** when switched to API key mode, Codex bills per token at standard
+OpenAI API rates for the current Codex-facing models (GPT-5.x-Codex variants).
+**This file deliberately does not carry an OpenAI rate card.** A previous
 version listed GPT-4o and o1-series rates under an "as of March 2026" heading and then
 noted, in the same block, that GPT-5.5 had superseded them - a table that was known to
 be stale at the moment it was read is worse than no table, because it invites a
@@ -256,10 +258,11 @@ billing.
 | Plan | Seat cost | Notes |
 |---|---|---|
 | Free | $0 | Limited completions |
-| Pro | $10/month | Individual developers |
-| Pro+ | $39/month | Higher limits, premium models |
+| Pro | $10/month | Individual developers (~$15 in AI credits included) |
+| Pro+ | $39/month | Higher limits, premium models (~$70 in credits) |
+| Max | $100/month | Top individual tier (~$200 in credits) |
 | Business | $19/seat/month | Admin controls, audit logs, IP indemnity |
-| Enterprise | $39/seat/month | Requires GH Enterprise Cloud ($21/seat/month extra) |
+| Enterprise | $39/seat/month | Requires GH Enterprise Cloud ($21/seat/month extra); ~3,900 credits/user |
 
 Overage charges apply at $0.04 per premium request beyond the monthly allocation.
 
@@ -285,22 +288,28 @@ since a usage-based charge often lands differently from a per-seat one.
 Source: https://docs.github.com/en/copilot/how-tos/manage-and-track-spending/prepare-for-your-move-to-usage-based-billing
 
 Enterprise total cost of ownership is $60/seat/month when including the required GitHub
-Enterprise Cloud subscription - a detail that often surprises procurement.
+Enterprise Cloud subscription - a detail that often surprises procurement. Note GitHub
+flags the $21 GHEC rate as "for the first 12 months", so model the post-year-1 renewal
+above $60.
 
-### Windsurf
+### Windsurf (now "Devin Desktop")
 
-Windsurf overhauled its pricing in March 2026, replacing variable credits with fixed quota
-tiers:
+Windsurf overhauled its pricing in March 2026, retiring the credit system in favour of
+daily/weekly usage quotas, and rebranded to **Devin Desktop** in June 2026 (windsurf.com
+now redirects to devin.ai - expect the vendor name change to surface in invoices and
+SaaS-management inventories).
 
-| Plan | Cost | Credits | Notes |
+| Plan | Cost | Usage model | Notes |
 |---|---|---|---|
-| Individual tiers | $20 / $40 / $200 per month | Fixed quota per tier | More predictable than token-based |
-| Teams | $40/seat/month | 500 credits/seat | Centralised billing, admin analytics |
+| Free | $0 | Limited quota | - |
+| Pro | $20/month | Daily/weekly usage quota | The former $40 mid-tier no longer exists |
+| Max | $200/month | Larger quota | Top individual tier |
+| Teams | $40/seat/month | Quota per seat | Centralised billing, admin analytics |
 | Enterprise | Custom | Per-seat allocation | SSO, compliance |
 
-Windsurf uses a credit system where each credit costs $0.04 and maps to the underlying
-model provider's API price plus a 20% margin. Add-on credits are available at $10 for 250
-(individual) or $40 for 1,000 (Teams/Enterprise).
+Usage beyond the included quota bills at underlying model API pricing. The legacy
+credit mechanics ($0.04/credit with a 20% margin, add-on credit packs) were retired
+with the March 2026 overhaul and survive only on historical invoices.
 
 ---
 
@@ -493,15 +502,15 @@ becomes a cost problem when:
 
 ---
 
-## Pricing comparison (March 2026)
+## Pricing comparison (verified August 2026)
 
 | Tool | Type | Seat cost | Token / usage model | Enterprise option | Proxy-compatible |
 |---|---|---|---|---|---|
-| **Cursor** | Seat + usage | $20 (Pro) / $40 (Business) | $20 included credits + per-token overage | Yes (custom) | No (vendor-mediated) |
-| **Claude Code** | BYOK or subscription | $20 (Pro) / $100 (Max 5x) / $200 (Max 20x) | API key: $3-$25/MTok depending on model | Via Anthropic Enterprise | Yes (API key mode) |
-| **OpenAI Codex** | BYOK or subscription | $20 (ChatGPT Plus) and up | API key: $1.25-$10/MTok depending on model | Via OpenAI Enterprise | Yes (API key mode) |
-| **GitHub Copilot** | Seat + usage | $10 (Pro) / $19 (Business) / $39 (Enterprise) | $0.04/premium request overage | Yes ($60/seat total with GH Enterprise Cloud) | No (vendor-mediated) |
-| **Windsurf** | Seat + usage | $20-$200 (individual) / $40 (Teams) | Credit-based ($0.04/credit, provider cost + 20% margin) | Yes (custom) | No (vendor-mediated) |
+| **Cursor** | Seat + usage | $20 (Pro) / $40 (Teams Standard) / $120 (Teams Premium) | Usage pool per plan + per-token overage at model rates | Yes (custom) | No (vendor-mediated) |
+| **Claude Code** | BYOK or subscription | $20 (Pro) / $100 (Max 5x) / $200 (Max 20x) | API key: $1-$25/MTok depending on model | Via Anthropic Enterprise | Yes (API key mode) |
+| **OpenAI Codex** | BYOK or subscription | $20 (ChatGPT Plus) and up | API key: per-token at current Codex-model rates (see OpenAI pricing page) | Via OpenAI Enterprise | Yes (API key mode) |
+| **GitHub Copilot** | Seat + usage | $10 (Pro) / $100 (Max) / $19 (Business) / $39 (Enterprise) | AI-credit overage priced on underlying model cost (legacy $0.04/request retired June 2026) | Yes ($60/seat total with GH Enterprise Cloud) | No (vendor-mediated) |
+| **Windsurf (Devin Desktop)** | Seat + usage | $20 (Pro) / $200 (Max) / $40 (Teams) | Daily/weekly quota + API-priced overage (credits retired March 2026) | Yes (custom) | No (vendor-mediated) |
 
 ---
 

--- a/skills/cloud-finops/references/finops-ai-self-hosted-vs-managed.md
+++ b/skills/cloud-finops/references/finops-ai-self-hosted-vs-managed.md
@@ -57,7 +57,7 @@ benchmark on per-token cost without weighing operational reality.
 
 | Vendor | Pricing dimension | Optimisation levers |
 |---|---|---|
-| Anthropic API | Input/output tokens, separate caches, separate batch | Prompt caching (1h TTL, 90% off), Batch API (50% off), model selection (Haiku/Sonnet/Opus), Fast mode for compute-allocated tiers |
+| Anthropic API | Input/output tokens, separate caches, separate batch | Prompt caching (1h TTL, 90% off reads), Batch API (50% off), model selection (Haiku/Sonnet/Opus). Note: Fast mode is a speed *premium* (2x, Opus-tier only, research preview), not a cost lever |
 | OpenAI API | Input/output tokens, cached tokens, batch, fine-tuned variants | Cached tokens (auto), Batch API (50% off), model selection, fine-tuning vs prompting tradeoff |
 | AWS Bedrock | Input/output tokens, provisioned throughput (model units), batch | On-demand vs PT, Application Inference Profiles for cost allocation, prompt caching, batch inference |
 | Azure OpenAI | Input/output tokens, PTU reservations, batch | PTU reservations with locality constraint, AOAI spillover, regional placement, fine-tuning costs |

--- a/skills/cloud-finops/references/finops-anthropic.md
+++ b/skills/cloud-finops/references/finops-anthropic.md
@@ -63,10 +63,10 @@ Total cost is now shaped by a combination of variables that FinOps must track ex
 | Claude Opus 4.6 | $5 | $25 | 1M | |
 | Claude Sonnet 5 | $3 | $15 | 1M | Introductory $2/$10 through 31 August 2026 |
 | Claude Sonnet 4.6 | $3 | $15 | 1M | |
-| Claude Haiku 4.5 | $1 | $5 | 200K | The only current model still on a 200K window |
+| Claude Haiku 4.5 | $1 | $5 | 200K | 200K window - the 1M window applies to 4.6-generation and later models only (the still-active Opus 4.5 and Sonnet 4.5 are likewise 200K) |
 
 **Two FinOps consequences of this table.** First, the Opus tier has held $5/$25 across
-four generations, so a model upgrade inside that tier is a capability change at
+five generations (4.5 through 5), so a model upgrade inside that tier is a capability change at
 constant unit cost - there is no rate negotiation to run, and no reason to stay on an
 older Opus for price reasons. Second, Fable 5 sits at 2x Opus pricing, which makes
 "use the most capable model" a materially different decision from "use the newest
@@ -79,16 +79,21 @@ usage. Flag it now if Sonnet 5 carries meaningful volume.
 ### Fast mode pricing
 
 Fast mode runs the same model at higher output tokens per second, at premium
-pricing. It is **not a general tier** - the scope is narrow enough that it is easy
-to over-plan for:
+pricing. It is in **research preview** and it is **not a general tier** - the scope
+is narrow enough that it is easy to over-plan for:
 
 | Model | Standard | Fast mode | Premium |
 |---|---|---|---|
 | Claude Opus 5 | $5 / $25 | $10 / $50 | 2x |
-| Claude Opus 4.8 | $5 / $25 | Supported (verify current rate) | - |
+| Claude Opus 4.8 | $5 / $25 | $10 / $50 | 2x |
 
 - **No Sonnet or Haiku Fast tier exists.** Fast mode is Opus-tier only.
-- **Opus 4.7 Fast mode has been removed** - requesting it returns an error.
+- **Opus 4.7 Fast mode has been removed** - requesting it returns an error. On
+  **Opus 4.6** the failure mode is quieter: requests with `speed: "fast"` run at
+  standard speed and bill at standard rates, so a misconfigured client pays
+  nothing extra but silently loses the latency it thinks it bought.
+- Fast mode pricing applies **across the full context window**, including
+  requests over 200K input tokens - there is no separate long-context tier on top.
 - **Claude API only**, including Managed Agents. Not available on Amazon Bedrock,
   Google Cloud, or Microsoft Foundry, so a Bedrock-based estate cannot use it at all.
 - **Not compatible with the Batch API or Priority Tier.**
@@ -105,7 +110,7 @@ an hour; the ceiling is 24 hours. Results are retained 29 days.
 | Model | Input ($/MTok) | Output ($/MTok) |
 |---|---|---|
 | Claude Opus 5 Batch | $2.50 | $12.50 |
-| Claude Sonnet 5 Batch | $1.50 | $7.50 |
+| Claude Sonnet 5 Batch | $1.50 | $7.50 ($1 / $5 introductory through 31 August 2026) |
 | Claude Haiku 4.5 Batch | $0.50 | $2.50 |
 
 Batch is the single largest rate lever available without a commercial negotiation.
@@ -114,7 +119,9 @@ completion - which makes it a workload-classification exercise, not a procuremen
 
 ### Modifiers
 
-- **US-only inference** (`inference_geo`): x1.1 on all token categories
+- **US-only inference** (`inference_geo`): x1.1 on all token categories.
+  Claude 4.6 and later models only - earlier models return a 400 error if the
+  parameter is set
 - **5-minute cache writes**: x1.25 on base input price
 - **1-hour cache writes**: x2 on base input price
 - **Cache reads**: x0.1 on base input price (90% discount)
@@ -123,27 +130,25 @@ completion - which makes it a workload-classification exercise, not a procuremen
 **Cache break-even depends on the TTL, and the 1-hour TTL is not a free upgrade.**
 At the 5-minute TTL a prefix pays for itself on the second request (1.25x write +
 0.1x read = 1.35x, versus 2x uncached). At the 1-hour TTL the doubled write cost
-needs at least three reads (2x + 0.2x = 2.2x versus 3x). Choose the 1-hour TTL for
-bursty traffic with gaps longer than five minutes, not as a default.
+needs at least two reads (2x + 0.2x = 2.2x versus 3x uncached). Choose the 1-hour
+TTL for bursty traffic with gaps longer than five minutes, not as a default.
 
 ### Tool charges
 
 | Tool | Pricing |
 |---|---|
 | Web search | $10 per 1,000 searches + standard input token costs for search results |
-| Code execution | 1,550 free hours/month per org, then $0.05/hour/container (minimum billed execution time applies) |
+| Code execution | 1,550 free hours/month per org, then $0.05/hour/container (5-minute minimum billed execution time). **Free** when the request also includes web search or web fetch (tool versions `20260209` or later) |
 
 ---
 
 ## Claude Managed Agents: new cost dimension
 
-> **Status (June 2026).** Managed Agents is a documented beta with a published API
-> surface, not the early community reporting an earlier version of this section was
-> based on. The architecture below is from Anthropic's documentation. **Per-unit
-> pricing for the runtime itself is still the part to verify** - the token cost of
-> model calls inside a session bills at ordinary rates against your organisation's
-> limits, but confirm the container/runtime charge against current docs before
-> quoting a number in an engagement.
+> **Status (verified August 2026).** Managed Agents is a documented beta with a
+> published API surface and, since this section was last revised, **published
+> pricing**: tokens at standard model rates plus session runtime at **$0.08 per
+> session-hour**. The architecture and billing model below are from Anthropic's
+> documentation.
 
 ### What Managed Agents are
 
@@ -172,21 +177,33 @@ Three properties change the cost shape versus plain API calls:
 
 ### Billing model differences from standard API
 
-Unlike token-based API calls, Managed Agents introduce new cost drivers:
+> **Corrected against primary documentation (August 2026).** An earlier version of
+> this section listed speculative cost drivers - session-persistence storage,
+> CPU/memory resource tiers, data-transfer charges, and idle-time costs - sourced
+> from pre-pricing community reporting. Anthropic's published billing model has
+> exactly **two dimensions**, and the docs contradict the idle-cost claim directly.
 
-| Cost driver | Description |
-|---|---|
-| Runtime hours | Compute time for agent execution environment |
-| Session persistence | Storage and state management costs |
-| Resource allocation | CPU/memory tiers for agent containers |
-| Invocation frequency | Number of agent activations |
-| Data transfer | Input/output between agent and external systems |
+| Dimension | Rate | Metering |
+|---|---|---|
+| Tokens | Standard model rates (see pricing table above) | All tokens consumed by the session. Prompt-caching multipliers apply identically; Fast mode premium applies if the agent's `model.speed` is `"fast"`; the 1.1x US-residency multiplier applies if `model.inference_geo` is `"us"` |
+| Session runtime | $0.08 per session-hour | Metered to the millisecond, and **only while the session status is `running`**. Time spent `idle`, `rescheduling`, or `terminated` is not billed |
+
+Two exclusions matter for cost modelling:
+
+- **The Batch API discount does not apply** - sessions are stateful and interactive;
+  there is no batch mode.
+- **Not available on partner-operated cloud platforms** (Bedrock, Google Cloud).
+  On Claude Platform on AWS, session charges convert to CCUs at the standard rate.
+- Session runtime **replaces** the code-execution container-hour billing - you are
+  not billed container hours on top of it.
 
 ### FinOps implications
 
-- **Different cost unit**: Shifts from per-token to per-runtime-hour pricing
-- **Always-on costs**: Persistent sessions may incur costs even when idle
-- **Resource tiering**: Different agent sizes/capabilities at different price points
+- **Two meters, not one**: token spend still dominates for most workloads (a
+  one-hour Opus 5 session consuming 50K in / 15K out is ~$0.63 of tokens and $0.08
+  of runtime), but long-running low-token agents invert that ratio
+- **Idle time is free** - there is no always-on charge for a session waiting on
+  input, so keeping sessions open is an attribution question, not a cost one
 - **Harder attribution**: Agent costs spread across multiple invocations vs discrete API calls
 
 ---
@@ -221,8 +238,11 @@ on 7 February 2026.
   They are billed at the Fast mode rate from token one, even if plan usage remains.
 - **Sticky across sessions**: Once enabled in Claude Code, Fast mode persists unless
   explicitly disabled. This makes it an unintentional overage driver.
-- **Retroactive context repricing**: Switching to Fast mode mid-session reprices the
-  entire conversation context at full Fast mode uncached input token rates.
+- **Cache loss on speed switch**: Changing `speed` mid-session invalidates the
+  prompt cache, so the next request re-reads the whole conversation context at
+  full Fast mode uncached input rates. The effect on the bill resembles a
+  retroactive repricing, but the mechanism is a lost cache, not a recharge of
+  earlier requests.
 - **Not available via cloud provider routes**: Fast mode is explicitly unavailable on
   Amazon Bedrock, Google Vertex AI, and Microsoft Azure Foundry. This fragments spend
   away from consolidated cloud agreements toward direct Anthropic invoices.

--- a/skills/cloud-finops/references/finops-azure-openai.md
+++ b/skills/cloud-finops/references/finops-azure-openai.md
@@ -42,8 +42,9 @@ are handled through Azure.
 | Fine-tuning | Training token charges + hosting charges for fine-tuned deployments |
 | Image / audio | Billed in units (images per resolution, audio per second) - separate from tokens |
 
-**Key cost driver:** output tokens are approximately 3× more computationally expensive
-than input tokens. High output-ratio workloads carry disproportionately higher costs.
+**Key cost driver:** output tokens are billed at 4-8x the input rate on current
+Azure OpenAI models (GPT-4.1 $2/$8 per MTok = 4x; GPT-5 $1.25/$10 = 8x). High
+output-ratio workloads carry disproportionately higher costs.
 
 ### Deployment Locality
 
@@ -54,7 +55,7 @@ performance, compliance posture, and cost.
 |---|---|---|
 | **Global** | Traffic routed across regions for best availability and throughput | Lowest |
 | **Data Zone (US or EU)** | Processing within all regions of a chosen zone (e.g., all EU regions) | Slightly higher |
-| **Regional** | Processing and storage within a single Azure region (e.g., Germany, Australia) | Comparable to Data Zone |
+| **Regional** | Processing and storage within a single Azure region (e.g., Germany, Australia) | Comparable to Data Zone for standard token rates; provisioned (PTU) hourly rates run materially higher - verify per model |
 
 **Key trade-offs:**
 - Global deployment offers the best performance and lowest cost but provides no data
@@ -103,8 +104,9 @@ keep separate:
    the price comparison most often quoted; for some models, hourly PTU at 100%
    utilisation is more expensive than the equivalent PAYG token spend, which is why
    provisioned capacity at this price point is mainly a performance and SLA purchase.
-3. **PTU + Reservation** - committing to PTU capacity for 1 month, 1 year, or 3 years
-   via an Azure reservation produces meaningful discounts off the hourly PTU rate.
+3. **PTU + Reservation** - committing to PTU capacity for **1 month or 1 year**
+   via an Azure reservation produces meaningful discounts off the hourly PTU rate
+   (no 3-year PTU reservation exists, unlike classic Azure compute reservations).
    Microsoft's current docs frame reservations as "considerable discounts" on
    provisioned throughput, with many consistent workloads finding reserved PTU a
    better value than hourly PTU or PAYG.
@@ -151,8 +153,11 @@ requiring more PTUs.
   and reassign its PTUs to the new model - no new reservation required
 - **Decoupled reservation and deployment:** a PTU reservation does not guarantee that
   model capacity will be available for your chosen model
-- **Built-in spillover:** overflow traffic automatically routes to standard (PAYG) tier
-  instead of returning HTTP 429
+- **Spillover available, but opt-in:** overflow traffic can route to a standard
+  (PAYG) deployment instead of returning HTTP 429 - it must be configured
+  (`spilloverDeploymentName` on the deployment, or the `x-ms-spillover-deployment`
+  request header) and requires a matching standard deployment of the same
+  model/version in the same resource
 - **Two waste types:** idle allocated capacity (PTUs assigned but underutilized) and
   unallocated capacity (PTUs reserved but not assigned to any deployment)
 
@@ -169,10 +174,9 @@ for during the wait.
 |---|---|
 | Consistent 24/7 workload, latency-sensitive | Strong candidate |
 | Frequent model updates expected | PTU flexibility is the key advantage here |
-| Data privacy / PII requirement | Provisioned endpoints exclude data from training |
-| Bursty traffic with spillover tolerance | Acceptable - spillover is built in |
-| Cost reduction as primary goal (GPT-5) | Caution - provisioned may be more expensive |
-| Cost reduction as primary goal (GPT-4.1) | Viable at high utilization (+27% at 100%) |
+| Data privacy / PII requirement | Not a PTU differentiator - Azure excludes prompts/completions from foundation-model training on **all** deployment types, standard included. The PTU privacy argument is isolation and predictable latency, not training exclusion |
+| Bursty traffic with spillover tolerance | Acceptable - spillover is available once configured |
+| Cost reduction as primary goal | Caution - run the break-even against the reservation-discounted rate for your model and utilisation curve. Microsoft prices PTUs in $/PTU/hour only; any $/MTok "provisioned premium" figure you encounter is a derived estimate, not a published rate |
 
 ### PTU governance checklist
 
@@ -189,11 +193,15 @@ for during the wait.
 
 ## Spillover mechanics
 
-Azure is currently the only hyperscaler with built-in spillover for GenAI capacity.
+Azure offers native spillover for GenAI capacity - as does GCP Vertex AI, where
+Provisioned Throughput overage spills to pay-as-you-go **by default**. Azure's
+spillover is opt-in: it must be configured per deployment.
 
-When provisioned capacity is fully utilized, overflow requests automatically route to
-the standard PAYG tier. No HTTP 429 errors are returned unless both provisioned and
-PAYG capacity are exhausted.
+Once configured, when provisioned capacity is fully utilised, overflow requests route
+to the designated standard PAYG deployment. Spillover triggers not only on capacity
+exhaustion (429) but also on long-context requests (400) and server errors (500/503).
+No HTTP 429 errors are returned to callers unless both provisioned and PAYG capacity
+are exhausted.
 
 ### Spillover cost implications
 
@@ -321,8 +329,11 @@ highest ROI for the effort.
 
 ### Prompt caching
 
-Azure OpenAI supports prompt caching (cached input tokens billed at ~75% discount).
-Effective for:
+Azure OpenAI supports prompt caching. The cached-input discount is **model-dependent**,
+not a flat rate: roughly 90% on GPT-5 ($0.125 cached vs $1.25 standard input), 75% on
+GPT-4.1, ~50% on GPT-4o, and up to 100% on Provisioned deployments. Newer model
+generations may also charge for cache **writes** - check the per-model pricing page
+rather than assuming reads-only billing. Effective for:
 - Long, repeated system prompts
 - RAG pipelines with consistent prefixes
 - Multi-turn conversations with stable context

--- a/skills/cloud-finops/references/finops-bedrock.md
+++ b/skills/cloud-finops/references/finops-bedrock.md
@@ -35,11 +35,12 @@ through a unified API.
 | Output tokens | Tokens generated in the response |
 | Model choice | Each model has its own per-token rate |
 | Capacity model | On-demand (PAYG) vs Provisioned Throughput |
-| Cross-region inference | Routes to alternate regions for availability; may affect cost |
+| Cross-region inference | Routes to alternate regions for availability; may affect cost. For Claude 4.5+ models, regional endpoints carry a 10% premium over global endpoints |
 | Batch inference | Asynchronous processing at discounted rates |
 
-**Key cost driver:** output tokens are approximately 3× more computationally expensive
-than input tokens. Workloads with high output ratios (agentic tasks, long-form generation)
+**Key cost driver:** output tokens are billed at roughly 4-5x the input rate on
+current Bedrock models (4x on Amazon Nova, 5x on Claude - e.g. Claude Sonnet $3/$15
+per MTok). Workloads with high output ratios (agentic tasks, long-form generation)
 carry disproportionately higher costs.
 
 ---
@@ -83,9 +84,13 @@ on token rates. Use for:
 
 ### How it works
 
-On AWS Bedrock, provisioned throughput is purchased as **model-specific units** for a
-fixed term (1 month or 6 months). Each unit provides a defined number of model units
-(MUs) - a measure of throughput capacity for that specific model.
+On AWS Bedrock, provisioned throughput is purchased as **model-specific units**, either
+with **no commitment** (billed hourly, deletable at any time) or for a fixed term
+(1 month or 6 months, with deeper hourly discounts for the longer term). Each purchase
+provides a defined number of model units (MUs) - a measure of throughput capacity for
+that specific model. The no-commitment option changes the risk profile below: model
+lock and utilisation risk apply to the term commitments, not to hourly provisioned
+capacity spun up for a burst.
 
 ### Key characteristics
 
@@ -94,8 +99,8 @@ fixed term (1 month or 6 months). Each unit provides a defined number of model u
   or purchase additional capacity.
 - **No spillover built in:** if provisioned capacity is exhausted, requests return HTTP 429
   unless you build custom failover logic to route overflow to on-demand.
-- **Capacity guarantee:** unlike Azure PTUs, a Bedrock provisioned throughput purchase
-  does guarantee availability of that model capacity.
+- **Capacity guarantee:** a Bedrock provisioned throughput purchase guarantees a
+  specific throughput level (input plus output tokens per minute) for that model.
 
 ### When provisioned throughput makes sense on Bedrock
 
@@ -103,7 +108,7 @@ fixed term (1 month or 6 months). Each unit provides a defined number of model u
 |---|---|
 | Consistent 24/7 workload, stable model choice | Strong candidate for provisioned |
 | Latency-sensitive, user-facing application | Justified for TTFT/OTPS improvement |
-| Data privacy requirement | Provisioned endpoints exclude data from training |
+| Data privacy requirement | Not a provisioned differentiator - Bedrock does not expose prompts or completions to model providers on any capacity mode |
 | Bursty or unpredictable traffic | On-demand or hybrid with manual failover logic |
 | Workload likely to switch models within 6 months | Avoid - model lock is a real risk |
 
@@ -159,8 +164,9 @@ propagates tags applied to that principal into the Cost and Usage Report and Cos
 
 **How it shows up in CUR 2.0:**
 
-- New column `line_item_iam_principal` containing the ARN of the caller (IAM user, role,
-  or assumed-role session)
+- A caller-identity column containing the ARN of the caller (IAM user, role, or
+  assumed-role session) - verify the exact column name in your export, as AWS
+  documentation describes the mechanism without naming the column
 - Tags applied to the IAM principal appear with an `iamPrincipal/` prefix  -
   e.g. `iamPrincipal/team`, `iamPrincipal/cost-centre`, `iamPrincipal/environment`
 - In Cost Explorer, these tags become available as a grouping and filter dimension
@@ -184,12 +190,13 @@ propagates tags applied to that principal into the Cost and Usage Report and Cos
   chargeback still needs to be built on top of the CUR
 
 **Coverage caveat:** some Bedrock features do not execute under the calling IAM role.
-**Guardrails** usage, notably, appears in CUR without the `line_item_iam_principal`
-value - only resource tags carry the attribution. IAM Principal Cost Allocation
-therefore does not eliminate the tagging requirement: teams still need tag discipline
-for guardrails and similar non-principal line items. Also note that CUR 2.0 exports
-can now be edited in place to add the IAM principal column - no need to recreate the
-export.
+**Guardrails** usage, notably, may appear in CUR without the caller-identity value -
+only resource tags carry the attribution (unconfirmed in AWS documentation; validate
+in your own CUR before relying on it). IAM Principal Cost Allocation therefore does
+not eliminate the tagging requirement: teams still need tag discipline for guardrails
+and similar non-principal line items. Note that a CUR 2.0 export created **before**
+enabling IAM principal attribution must be **recreated** - existing exports do not
+retroactively include identity data.
 
 **When to use it vs. account separation:**
 
@@ -246,16 +253,16 @@ Sources: https://docs.aws.amazon.com/bedrock/latest/userguide/cost-mgmt-applicat
 #### Bedrock Projects (organisational primitive, not a billing primitive)
 
 Bedrock **Projects** group agents, knowledge bases, prompt flows, and other resources
-under a named container with shared IAM and resource policies. Projects are an
-**organisational** primitive - they tidy up the AWS console and enforce access
-boundaries - but they do **not** introduce a new billing dimension by themselves.
-Cost attribution still flows through IAM principals, resource tags, and Application
-Inference Profiles.
+under a named container with shared IAM and resource policies. Since this section was
+first written, Projects have grown into a **billing attribution primitive** as well:
+tags assigned to a Bedrock Project are now listed as a first-class cost-attribution
+method in CUR, and AWS recommends Projects for application-level attribution on the
+newer Bedrock APIs. Cost attribution therefore flows through four channels: IAM
+principals, resource tags, Application Inference Profiles, and Project tags.
 
-Useful FinOps angle: when a team adopts Projects, take the opportunity to standardise
-the project name as a tag value across IAM roles and Application Inference Profiles
-under that project. The project name becomes a clean cost-allocation key in CUR 2.0
-without requiring a separate naming convention.
+Useful FinOps angle: when a team adopts Projects, standardise the project name as a
+tag value across IAM roles and Application Inference Profiles under that project, so
+the project tag in CUR and the principal/profile tags reconcile cleanly.
 
 ### SageMaker training job allocation
 
@@ -359,7 +366,8 @@ high-volume. Contrast with fine-tuning (static-knowledge injection) and RAG
 - **Mixture-of-experts models** (DeepSeek, Qwen) activate sub-models per query -
   often cheaper and faster per token, and viable on smaller hardware.
 - **Plan/execute splitting**: e.g. Claude Code "Opus Plan" mode uses Opus to plan and
-  Sonnet to execute; AWS-reported ~10-15% cheaper than Opus-only. The general pattern
+  Sonnet to execute, cutting cost versus Opus-only (no primary-source savings figure
+  is published; benchmark on your own workload). The general pattern
   (expensive model for decomposition, cheap model for execution) applies to any
   agentic architecture (see task decomposition in `finops-for-ai.md`).
 
@@ -395,9 +403,11 @@ cadence:
 
 **FinOps math:** the 1-hour write costs ~2x base, but a single cache write that
 serves 100 reads at 0.1x base saves roughly 90% on those input tokens. Break-even
-is reached after ~10 cache hits (5-min TTL) or ~20 cache hits (1-hour TTL). For
-agentic workflows that loop on the same context dozens of times, the savings are
-material - often the difference between economic and uneconomic at scale.
+versus not caching comes fast: **1 cache hit** at the 5-minute TTL (1.25x write +
+0.1x read = 1.35x, versus 2x uncached) and **2 cache hits** at the 1-hour TTL
+(2x + 0.2x = 2.2x, versus 3x uncached). For agentic workflows that loop on the
+same context dozens of times, the savings are material - often the difference
+between economic and uneconomic at scale.
 
 **Where caching matters most:**
 - Long system prompts (>1k tokens) reused across many requests

--- a/skills/cloud-finops/references/finops-for-ai.md
+++ b/skills/cloud-finops/references/finops-for-ai.md
@@ -404,19 +404,29 @@ whether failure is environment-changing, per use case, before funding.
 Treat model selection like instance rightsizing. Defaulting to the largest or latest model
 for every feature is the AI equivalent of running all workloads on ml.p4d.24xlarge.
 
-| Model tier | Use case | Cost ratio example |
-|---|---|---|
-| Small / fast (e.g. Claude Haiku, GPT-4o mini) | Classification, routing, simple Q&A | 1× |
-| Mid-tier (e.g. Claude Sonnet, GPT-4o) | Complex reasoning, code generation | 12× |
-| Large (e.g. Claude Opus, GPT-4) | Research, nuanced judgment | 60× |
+Anthropic's rate card (verified August 2026) shows the tier spread on the Claude side:
 
-As of March 2026, OpenAI's pricing structure demonstrates the cost impact of model selection:
+| Model tier | Use case | Cost ratio | Anthropic example (per 1M tokens) |
+|---|---|---|---|
+| Small / fast (Claude Haiku 4.5) | Classification, routing, simple Q&A | 1x | $1 input / $5 output |
+| Mid-tier (Claude Sonnet) | Complex reasoning, code generation | 3x | $3 input / $15 output |
+| Large (Claude Opus 5) | Research, nuanced judgment | 5x | $5 input / $25 output |
+| Frontier (Claude Fable 5) | Hardest reasoning, high-stakes work | 10x | $10 input / $50 output |
+
+OpenAI's pricing structure (rates verified August 2026, models one generation back)
+shows a much wider spread:
 
 | Model tier | Use case | Cost ratio example | OpenAI example (per 1M tokens) |
 |---|---|---|---|
 | Small / fast (e.g. GPT-4o mini) | Classification, routing, simple Q&A | 1x | $0.15 input / $0.60 output |
 | Mid-tier (e.g. GPT-4o) | Complex reasoning, code generation | 17x | $2.50 input / $10.00 output |
 | Large (e.g. o1) | Research, nuanced judgment | 100x | $15.00 input / $60.00 output |
+
+The spread is vendor-specific and compresses across generations: the Claude 3-era
+small-to-large ratio was roughly 60x, the current one is 5-10x, while OpenAI's
+mini-to-reasoning spread remains near 100x. Check the live rate card before building
+routing economics on a remembered ratio - the payoff from tiered routing depends
+directly on it.
 
 Implement tiered routing: classify query complexity first (cheap), then route to the
 appropriate model. Simple queries to small models, complex queries to large models.

--- a/skills/cloud-finops/references/finops-genai-capacity.md
+++ b/skills/cloud-finops/references/finops-genai-capacity.md
@@ -33,7 +33,10 @@ The default model. You pay per token consumed, drawing from a shared provider po
 
 - No upfront commitment
 - No performance guarantees - latency can spike during peak demand
-- No data privacy guarantees (data may be used for model training)
+- Same data-use terms as provisioned on the major hyperscalers: Azure, AWS Bedrock,
+  and Google all exclude customer prompts/completions from foundation-model training
+  on shared capacity too. The shared-tier trade-off is performance isolation, not
+  training exposure
 - Suitable for: early adoption, variable/unpredictable workloads, non-latency-sensitive use cases
 
 ### Provisioned capacity (reserved)
@@ -42,10 +45,11 @@ You purchase a fixed block of throughput for a defined term (monthly or annual).
 for that capacity 24/7 regardless of actual utilization.
 
 - Dedicated throughput - predictable latency
-- Typically includes data privacy guarantees (no training on your data)
+- Workload isolation (training exclusion is not the differentiator - the hyperscalers
+  apply it to shared capacity as well)
 - Comes with higher uptime SLAs
-- Suitable for: consistent high-volume workloads, latency-sensitive applications, production
-  workloads with privacy requirements
+- Suitable for: consistent high-volume workloads, latency-sensitive applications,
+  production workloads needing performance isolation
 
 ---
 
@@ -73,8 +77,8 @@ depends on your coverage target and actual utilization, not just the per-token r
 You have reserved capacity assigned to a model, but your workload does not use it.
 
 - Example: 100% reservation, 15% peak utilization → paying for 85% idle capacity
-- Amplified when running workloads with high output token ratios (output tokens are ~3×
-  more computationally expensive than input tokens)
+- Amplified when running workloads with high output token ratios (output tokens are
+  billed at 4-8x the input rate on current models)
 - Most common form of GenAI capacity waste
 
 ### Unallocated capacity (Azure-specific)
@@ -139,10 +143,17 @@ per million tokens at 100% utilization.
 **The result may be higher than pay-as-you-go**, even at full utilization. In that case,
 provisioned capacity is a performance and SLA purchase, not a cost-saving one.
 
-| Model | Standard input | Provisioned input | Delta at 100% utilization |
+| Model | Standard input | Provisioned input (derived) | Delta at 100% utilization |
 |---|---|---|---|
-| GPT-5 | $1.25/MTok | $2.08/MTok | +67% |
-| GPT-4.1 | $2.00/MTok | $2.55/MTok | +27% |
+| GPT-5 | $1.25/MTok | ~$2.08/MTok | +67% |
+| GPT-4.1 | $2.00/MTok | ~$2.55/MTok | +27% |
+
+*Sourcing note:* the provisioned $/MTok figures are **derived estimates** from a
+FinOps Foundation working-group analysis, not Microsoft-published rates - Microsoft
+prices PTUs only in $/PTU/hour, and the conversion depends on throughput assumptions
+and on which price point (hourly vs 1-month vs 1-year reservation) is used. Treat
+the deltas as illustrative of the pattern, and rebuild the math from current
+$/PTU/hour rates for any client decision.
 
 **Implication:** always compute your break-even utilization rate before purchasing.
 For some models, provisioned capacity never generates token-cost savings - it is purely
@@ -169,19 +180,22 @@ a performance and SLA product.
 | Model switching on renewal | Must re-purchase | Can upgrade within publisher family | Reassign PTUs dynamically |
 | Capacity guarantee | Yes - reservation = capacity | Yes | No - reservation ≠ guaranteed model availability |
 | Waste type | Idle allocated capacity | Idle allocated capacity | Idle allocated + unallocated capacity |
-| Spillover | Build yourself | Build yourself | Built-in |
+| Spillover | Build yourself | Default PAYG spillover (header-controlled) | Available, opt-in configuration |
 | Best for | Stable workloads, known model, cost predictability | GCP-native shops, Gemini ecosystem | Flexibility-first, frequent model updates |
 
 ---
 
 ## Data privacy and traffic segmentation
 
-Provisioned capacity typically guarantees that your data is not used to train future models.
-Shared capacity does not offer this guarantee.
+On the major hyperscalers, training exclusion applies to shared and provisioned
+capacity alike - do not buy provisioned capacity to obtain it. What provisioned
+capacity does add is workload isolation and, in some regulated contexts, a cleaner
+compliance narrative.
 
-**Traffic affinitization strategy:** route requests containing PII or confidential data
-to provisioned endpoints; route non-sensitive traffic to shared capacity. This reduces
-the required reservation size (and cost) while maintaining data privacy for sensitive workloads.
+**Traffic affinitization strategy:** where isolation (not training exclusion) is the
+requirement, route requests containing PII or confidential data to provisioned
+endpoints and non-sensitive traffic to shared capacity. This reduces the required
+reservation size (and cost) while keeping sensitive workloads on isolated capacity.
 
 ---
 

--- a/skills/cloud-finops/references/finops-vertexai.md
+++ b/skills/cloud-finops/references/finops-vertexai.md
@@ -39,41 +39,33 @@ provides access to Google's own models (Gemini family) and selected third-party 
 | Batch prediction | Asynchronous inference at discounted rates |
 | Region | Some models are available only in specific regions |
 
-**Key cost driver:** output tokens are approximately 3× more computationally expensive
-than input tokens. High output-ratio workloads (agentic tasks, long-form generation)
-carry disproportionately higher costs.
+**Key cost driver:** output tokens are billed at 4-8x the input rate on current
+Gemini SKUs (Gemini 2.0 Flash $0.15/$0.60 per MTok = 4x; Gemini 2.5 Pro $1.25/$10 =
+8x). High output-ratio workloads (agentic tasks, long-form generation) carry
+disproportionately higher costs.
 
 ---
 
 ## Model pricing reference
 
-### On-demand pricing structure - tokens AND characters
+### On-demand pricing structure
 
-Vertex AI on-demand pricing is per-million tokens for newer Gemini SKUs. **However,
-some Gemini APIs and earlier model versions still bill per 1,000 characters (input
-and output)** rather than per token. This is a real difference from AWS / OpenAI /
-Anthropic, which all bill per token.
-
-**Practical implications:**
-- Capacity-planning math from Anthropic or OpenAI engagements does not transpose
-  cleanly: 1,000 characters is roughly 250 tokens for English (ratio varies per
-  language - East Asian scripts can be 1:1 character-to-token, English is ~4:1).
-- Verify the unit on Vertex's pricing page per model before quoting. Two Gemini
-  variants on the same product family can use different units depending on model
-  version and surface (Vertex Studio, Vertex API, Gemini API).
-- For multilingual workloads, the character-based pricing is sometimes cheaper
-  than the token-based equivalent (the per-character rate can favour languages
-  that tokenise unfavourably under English-trained tokenisers).
+Vertex AI on-demand pricing for Gemini generative models is per-million tokens
+(verified August 2026). **Historical note:** Gemini 1.0/1.5-era surfaces billed some
+SKUs per 1,000 characters rather than per token; those surfaces are retired and no
+character-billed Gemini SKU remains on the current pricing page. If you encounter
+character-based line items in an old billing export, that is the era they date from -
+do not carry character-math into current capacity planning.
 
 Source: https://cloud.google.com/vertex-ai/generative-ai/pricing
 
-No minimum spend, no upfront commitment, regardless of unit.
+No minimum spend, no upfront commitment.
 
 | Model family | Relative cost tier | Notes |
 |---|---|---|
-| Gemini Flash (1.5, 2.0) | Low | High throughput, cost-optimised |
-| Gemini Pro (1.5, 2.0) | Mid | Balanced capability and cost |
-| Gemini Ultra / Advanced | High | Complex reasoning, multimodal |
+| Gemini Flash-Lite | Low | Cheapest tier, high-volume simple tasks |
+| Gemini Flash | Low-Mid | High throughput, cost-optimised (e.g. 2.0 Flash $0.15/$0.60 per MTok) |
+| Gemini Pro | High | Complex reasoning, multimodal (e.g. 2.5 Pro $1.25/$10 per MTok) |
 | Anthropic Claude Haiku | Low | Available via Vertex Model Garden |
 | Anthropic Claude Sonnet | Mid | Available via Vertex Model Garden |
 | Anthropic Claude Opus | High | Available via Vertex Model Garden |
@@ -104,11 +96,17 @@ and can switch between models within that publisher's portfolio.
 
 ### Key characteristics
 
-- **Publisher-locked, model-flexible:** you can switch from Gemini 2.0 Pro to Gemini 2.0 Flash
-  within the same reservation, but cannot switch from a Google model to an Anthropic model.
-- **Capacity floor, not ceiling:** you cannot reduce reserved capacity mid-term, even if
-  a newer model becomes more efficient. Efficiency gains reduce your effective cost per
-  output, but the reservation commitment remains at the original size.
+- **Publisher-locked, model-flexible:** you can switch between Gemini models within
+  the same reservation (a GSU is standard across Google models that support
+  Provisioned Throughput), but not from a Google model to an Anthropic model.
+  *Sourcing note:* the intra-publisher switch rule comes from a FinOps Foundation
+  working-group paper, not Google primary docs - confirm against the current
+  Provisioned Throughput purchase docs before quoting in an engagement.
+- **Capacity floor, not ceiling:** terms run 1 week to 1 year and unused throughput
+  does not carry over; treat reserved capacity as non-reducible mid-term (an explicit
+  no-downsize rule is not stated in Google primary docs - verify before committing).
+  Efficiency gains reduce your effective cost per output, but the reservation
+  commitment remains at the original size.
 - **Default spillover to pay-as-you-go.** As of current Google docs, supported Gemini
   Provisioned Throughput overages are billed as pay-as-you-go by default. Request
   headers control whether traffic is routed to dedicated capacity, shared/on-demand,
@@ -135,7 +133,7 @@ and can switch between models within that publisher's portfolio.
 |---|---|
 | Consistent 24/7 workload, Gemini-native stack | Strong candidate |
 | Latency-sensitive, user-facing application | Justified for TTFT/OTPS improvement |
-| Data privacy requirement | Provisioned endpoints exclude data from training |
+| Data privacy requirement | Not a provisioned differentiator - verify data-use terms, which apply per service, not per capacity mode |
 | Likely to upgrade Gemini versions mid-term | GCP reservation accommodates this |
 | Workload requiring cross-publisher flexibility | Azure PTU model better suited |
 | Bursty or unpredictable traffic | On-demand or hybrid with manual failover |
@@ -146,7 +144,9 @@ and can switch between models within that publisher's portfolio.
 - [ ] Load-test to validate vendor TPM estimate against actual input/output token mix
 - [ ] Calculate break-even utilization (provisioned unit cost ÷ on-demand equivalent)
 - [ ] Verify reserved publisher matches the model families your workloads will use
-- [ ] Build failover logic to on-demand for overflow traffic (spillover is not built in)
+- [ ] Decide the overflow policy explicitly: default spillover bills overage as PAYG;
+      use the `X-Vertex-AI-LLM-Request-Type` header (`dedicated` / `shared`) where
+      you need hard routing instead of silent variable cost
 - [ ] Set utilization alerts - target >80% to justify the reservation
 - [ ] Assess whether new model efficiency gains offset the fixed capacity floor
 
@@ -163,9 +163,10 @@ For Vertex AI:
 - Use `sku.description` to differentiate model inference, batch prediction, and
   provisioned throughput charges
 
-**AI Cost Summary Agent (Preview):** As of May 2026, GCP launched the AI Cost Summary
-Agent in preview, providing dedicated AI spend analysis across Gemini API and Vertex AI
-services through a Billing Overview widget. This native tool addresses the AI cost
+**AI Cost Summary Agent:** GCP's AI Cost Summary Agent provides dedicated AI spend
+analysis across Gemini API and Vertex AI services through a Billing Overview widget
+(check current preview/GA status in the Cloud Billing docs before relying on it in
+an engagement). This native tool addresses the AI cost
 visibility gap, offering spend attribution and insights specifically for AI workloads.
 
 **Limitation:** native billing does not provide token-level granularity per request.
@@ -219,31 +220,36 @@ contract, cost per generated email) for margin modelling as usage scales.
 ### Model right-sizing
 
 - Define a quality benchmark for your specific task
-- Test Gemini Flash vs Gemini Pro vs Gemini Ultra against that benchmark
+- Test Gemini Flash-Lite vs Gemini Flash vs Gemini Pro against that benchmark
 - Use the lowest-cost model that meets your quality threshold
 - For third-party models (Claude, Llama), apply the same benchmark process
 
 ### Prompt optimisation
 
 - Audit system prompt length - verbose instructions inflate every API call
-- Implement **Vertex AI Context Caching** where supported (Gemini Pro, Flash 1.5+) - see below
+- Implement **Vertex AI Context Caching** where supported (current Gemini Flash and Pro models) - see below
 - Truncate or summarize conversation history for multi-turn applications
 - Avoid sending redundant context in RAG pipelines
 
 ### Vertex AI Context Caching - direct lever for long-context workloads
 
-Vertex AI supports **explicit context caching** for selected Gemini models (Gemini
-Pro, Flash 1.5 and later). Equivalent in spirit to Anthropic / Bedrock prompt
-caching - cache a stable context once, reuse it across many requests at a steeply
-discounted input-token rate.
+Vertex AI supports **explicit context caching** for selected Gemini models.
+Equivalent in spirit to Anthropic / Bedrock prompt caching - cache a stable context
+once, reuse it across many requests at a steeply discounted input-token rate - but
+the pricing shape differs (verified August 2026):
 
 **Mechanics:**
-- Cache write: priced per cached token (or character) at a small premium over the
-  base input rate.
-- Cache hit (read): priced at a meaningfully lower rate than full input.
-- TTL: configurable cache lifetime (typically minutes to hours, model-dependent).
-- Minimum context size: caching is only beneficial above a token / character
-  threshold the model documents - small contexts do not break even.
+- Cache write: charged at **standard input-token rates** - unlike Anthropic and
+  Bedrock, there is no write premium.
+- Cache **storage**: explicit caches additionally bill per hour the cache is held,
+  roughly $1.00-$4.50 per 1M cached tokens per hour depending on model. This is
+  the cost component to watch - a large cache held for hours can outweigh the read
+  savings if traffic is thin.
+- Cache hit (read): 90% off the standard input rate on 2.5-generation and later
+  models (75% on 2.0-era models).
+- TTL: configurable cache lifetime.
+- Minimum context size: 2,048 tokens to create a cache - small contexts do not
+  qualify.
 
 **Where it matters:**
 - RAG pipelines with stable retrieved context across many user queries.


### PR DESCRIPTION
## Summary

Full verification of every concrete AI pricing claim in the skill against provider primary documentation, as of 2026-08-10. Seven parallel verification passes covered Anthropic, Azure OpenAI/PTU, AWS Bedrock, GCP Vertex AI, AI dev tools, GPU/self-hosted rates, and the cross-cutting AI files. Roughly 130 claims checked; everything a primary source contradicted is fixed, and figures no primary source can confirm are now flagged as such instead of stated as fact.

## Hard errors fixed

- **AWS GPU rates (5 playbooks)**: the June 2025 AWS GPU price cuts never landed here - `p5.48xlarge` is ~$55/hr (was quoted $98), `p4d.24xlarge` ~$22/hr (was $33), `ml.p4d.24xlarge` endpoint ~$18,400/month (was $27,500), notebook ML storage $0.14/GB-month (was $0.10)
- **Azure**: the 3-year PTU reservation does not exist (1-month and 1-year only); spillover is opt-in configuration, not automatic; "only hyperscaler with built-in spillover" removed (Vertex spills to PAYG by default)
- **Data-privacy framing (3 files)**: "shared capacity may train on your data" was wrong for all three hyperscalers - training exclusion applies to every capacity mode; provisioned capacity's real privacy argument is isolation
- **Anthropic Managed Agents**: billing section rewritten to the published model (tokens + $0.08/session-hour, idle time not billed), replacing speculative storage/resource-tier/data-transfer cost drivers
- **Cache break-even math (2 files)**: Bedrock said ~10-20 hits, Anthropic said three reads - the documented figure is 1-2 reads. Vertex had the opposite problem: no write premium exists there, but the real second cost (cache storage, ~$1-$4.50/1M tokens/hour) was missing
- **Bedrock CUR**: exports must be recreated to include IAM principal data (file said editable in place); Project tags are now a first-class CUR attribution method; no-commitment hourly provisioned option added
- **Model-tier ratios (finops-for-ai.md)**: Claude 3-era 12x/60x spread replaced with the current 1x/3x/5x/10x rate card

## Structural staleness fixed

- Cursor: retired flat Auto rate, old tier names (Pro+/Ultra/Teams Standard/Premium lineup added)
- Windsurf: Devin Desktop rebrand (June 2026), retired credit mechanics moved to legacy framing
- Copilot: Max $100 tier and per-plan credit allowances added; post-year-1 GHEC rate caveat
- Codex: stale codex-mini/GPT-5 rate table removed, honouring the file's own "no OpenAI rate card" doctrine
- Vertex: character-billing section retired, Gemini tier labels updated (no "Ultra" SKU ever existed on Vertex)
- "Output ~3x input" heuristic corrected to the billed 4-8x ratios in four files

## Unverifiable figures now flagged

Derived Azure PTU $/MTok premiums (Microsoft publishes $/PTU/hour only), the misattributed "AWS-reported 10-15%" Opus Plan saving, and Vertex publisher-switch rules (FinOps Foundation paper, not Google docs) now carry explicit sourcing notes per the repo sourcing rule.

## What checked out clean

Anthropic core rate card and Fast mode (2x, $10/$50, Opus 5/4.8, research preview - verified earlier on this branch), Batch/caching multipliers, tool charges, Claude plan prices, Copilot seat prices, current EC2 G5/G4dn/C7i and SageMaker hosting rates, GPU rental market ranges, x402 counters.

Content-only PR: no version bumps per the release-train rule. No routing, README, or llms.txt changes needed (no files added or renamed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
