### PR TITLE
Document fortnightly pipeline cadence; add retrieval-boundary API cost note

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,17 +100,27 @@ cloud-finops-skills/
 
 ## Content update pipeline
 
-The `pipeline/` folder contains a **monthly** content scanner (1st of each month
-at 9:00 AM CET via Windows Task Scheduler) that detects FinOps-relevant changes
-across ~30 sources and proposes updates to the reference files. It is gitignored
-and not part of the public distribution.
+The `pipeline/` folder contains a **fortnightly** content scanner (1st and 15th
+of each month at 9:00 AM CET via Windows Task Scheduler) that detects
+FinOps-relevant changes across ~30 sources and proposes updates to the reference
+files. It is gitignored and not part of the public distribution.
 
 **Cadence note (2026-05-15).** The pipeline was originally twice-monthly (1st
 and 15th). After the 2026-05-15 incident-and-recovery session (see Lessons
 learned below) it became clear each run requires 2-4 hours of focused human
-review for a typical 12-item batch. The 15th-of-month task is now disabled
-in Task Scheduler (preserved for re-enable if a mid-month refresh is needed).
-A monthly cadence trades some freshness for sustainable operating effort.
+review for a typical 12-item batch. The 15th-of-month task was disabled
+in Task Scheduler and the cadence dropped to monthly, trading some freshness
+for sustainable operating effort.
+
+**Cadence update (2026-08-10).** Restored to twice-monthly: the fortnightly
+rhythm matches the scan's 15-day lookback window, closing the coverage blind
+spots a monthly gap creates. The 1st-of-month runs additionally carry a
+rotating **AI-pricing re-verification pass** (one domain cluster per month,
+full surface quarterly) - the scan detects news from sources, but it cannot
+detect silent staleness in figures already sitting in the reference files,
+which is how the June 2025 AWS GPU price cuts went uncorrected for 14 months
+(fixed in PR #129). Procedure and rotation table in
+`pipeline/MONTHLY_WORKFLOW.md`.
 
 The pipeline is human-in-the-loop: nothing is changed automatically. Every
 proposed update goes through preview, approve/reject, and a guard-railed

--- a/skills/cloud-finops/references/finops-agentic.md
+++ b/skills/cloud-finops/references/finops-agentic.md
@@ -68,6 +68,14 @@ as "agents":
   capability has been falling (~6.67%/month compounding, Pay-i-reported), yet cost
   per completed task rises in most production workloads because task ambition grows
   faster than prices fall. Falling rate cards are not a savings forecast.
+- **Search/retrieval-boundary APIs** - for agents doing live web search or scraping,
+  vendors (Exa, Tavily, Firecrawl, Parallel, Valyu) meter the fetch separately from
+  model tokens - per credit, per page, or per scoped extraction - instead of the
+  agent paying full input-token rates to ingest raw page text. Compare that
+  vendor cost against the token cost of stuffing full pages into context; the
+  cheaper path depends on page size and how much of the page the task actually
+  needs. This is a fast-moving, mostly early-stage vendor category - check
+  viability before wiring one into a production path.
 
 **Three architectural pillars for cost-safe agents:**
 


### PR DESCRIPTION
## Summary

Two small updates riding together:

**CLAUDE.md - pipeline cadence.** The content pipeline returned to twice-monthly (1st and 15th, 9:00 CET) on 2026-08-10 - the fortnightly rhythm matches the scan's 15-day lookback window, closing the coverage blind spots a monthly gap creates. The 1st-of-month runs now also carry a rotating AI-pricing re-verification pass (one domain cluster per month, full surface quarterly), motivated by PR #129's findings: the scan detects news from sources but cannot detect silent staleness in figures already in the files. Historical cadence notes (2026-05-15 drop to monthly) are preserved; the operating procedure lives in the maintainer-local `pipeline/MONTHLY_WORKFLOW.md`.

**finops-agentic.md - retrieval-boundary APIs.** New cost-anatomy bullet: for agents doing live web search or scraping, vendors (Exa, Tavily, Firecrawl, Parallel, Valyu) meter the fetch separately from model tokens - per credit, per page, or per scoped extraction - instead of the agent paying full input-token rates to ingest raw page text. The bullet frames the comparison to run (vendor fetch cost vs token cost of full pages in context) and carries the early-stage vendor viability caveat per the repo sourcing rules.

Content-only PR: no version bump per the release-train rule. No routing or README changes (no new files or domains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
