### PR TITLE
Add MCP Apps (SEP-1865) playbook viewer prototype to the MCP server

### DIFF
--- a/mcp_server/src/cloud_finops_mcp/server.py
+++ b/mcp_server/src/cloud_finops_mcp/server.py
@@ -8,6 +8,7 @@ unit-tested without an MCP client.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 from mcp.server.fastmcp import FastMCP
@@ -15,6 +16,15 @@ from mcp.server.fastmcp import FastMCP
 from . import __version__
 from . import metadata as _metadata
 from . import tools as _tools
+
+# MCP Apps (SEP-1865, extension id io.modelcontextprotocol/ui) resource: a
+# self-contained HTML view that renders get_playbook()'s markdown as
+# structured sections instead of raw text. Prototype for the 2026-07-28 spec
+# - see ui/playbook_viewer.html for the iframe<->host wiring.
+PLAYBOOK_VIEWER_URI = "ui://cloud-finops/playbook-viewer"
+_PLAYBOOK_VIEWER_HTML = (
+    Path(__file__).resolve().parent / "ui" / "playbook_viewer.html"
+).read_text(encoding="utf-8")
 
 mcp = FastMCP(
     "cloud-finops",
@@ -118,7 +128,7 @@ def list_playbooks() -> dict[str, Any]:
     return _tools.list_playbooks()
 
 
-@mcp.tool()
+@mcp.tool(meta={"ui": {"resourceUri": PLAYBOOK_VIEWER_URI}})
 def get_playbook(name: str) -> dict[str, Any]:
     """Fetch the full markdown content of one playbook by slug.
 
@@ -130,8 +140,27 @@ def get_playbook(name: str) -> dict[str, Any]:
     Returns ``{"name": ..., "title": ..., "content": "...", "lines": N}``.
     On miss, returns ``{"error": ..., "suggestions": [...]}`` with up to
     three string-distance matches so the caller can self-correct.
+
+    A host with MCP Apps (SEP-1865) support may render this result via the
+    linked ``ui://cloud-finops/playbook-viewer`` resource instead of showing
+    the raw markdown.
     """
     return _tools.get_playbook(name)
+
+
+@mcp.resource(
+    PLAYBOOK_VIEWER_URI,
+    name="Playbook viewer",
+    mime_type="text/html;profile=mcp-app",
+)
+def playbook_viewer_ui() -> str:
+    """MCP Apps UI resource linked from ``get_playbook``.
+
+    Self-contained HTML/JS that renders the tool result's markdown as
+    labelled sections (Problem / Symptoms / Detection / Fix / Anti-pattern /
+    See also) inside the sandboxed iframe the host provides.
+    """
+    return _PLAYBOOK_VIEWER_HTML
 
 
 @mcp.tool()

--- a/mcp_server/src/cloud_finops_mcp/ui/playbook_viewer.html
+++ b/mcp_server/src/cloud_finops_mcp/ui/playbook_viewer.html
@@ -1,0 +1,401 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>Playbook viewer</title>
+<style>
+  :root {
+    color-scheme: light dark;
+    --fg: #1a1d23;
+    --fg-muted: #5b6370;
+    --bg: #ffffff;
+    --card-bg: #f7f8fa;
+    --border: #e2e5ea;
+    --code-bg: #eef0f3;
+    --accent-problem: #6b7280;
+    --accent-symptoms: #b45309;
+    --accent-detection: #1d4ed8;
+    --accent-fix: #15803d;
+    --accent-antipattern: #b91c1c;
+    --accent-seealso: #6b7280;
+    --badge-bg: #eef1ff;
+    --badge-fg: #3730a3;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --fg: #e7e9ec;
+      --fg-muted: #9aa2ad;
+      --bg: #15171c;
+      --card-bg: #1b1e24;
+      --border: #2a2e37;
+      --code-bg: #10141a;
+      --badge-bg: #232a4d;
+      --badge-fg: #b7c0ff;
+    }
+  }
+  * { box-sizing: border-box; }
+  html, body {
+    margin: 0;
+    padding: 0;
+    background: var(--bg);
+    color: var(--fg);
+    font-family: -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    font-size: 14px;
+    line-height: 1.5;
+  }
+  #root { padding: 16px 18px 28px; max-width: 780px; margin: 0 auto; }
+  .header { margin-bottom: 14px; }
+  .header h1 {
+    font-size: 19px;
+    margin: 0 0 8px;
+    font-weight: 650;
+  }
+  .badges { display: flex; flex-wrap: wrap; gap: 6px; }
+  .badge {
+    display: inline-block;
+    padding: 2px 9px;
+    border-radius: 999px;
+    background: var(--badge-bg);
+    color: var(--badge-fg);
+    font-size: 11.5px;
+    font-weight: 600;
+    letter-spacing: .01em;
+    text-transform: uppercase;
+  }
+  .section {
+    background: var(--card-bg);
+    border: 1px solid var(--border);
+    border-left: 4px solid var(--accent-problem);
+    border-radius: 8px;
+    padding: 12px 14px;
+    margin-bottom: 10px;
+  }
+  .section[data-kind="symptoms"] { border-left-color: var(--accent-symptoms); }
+  .section[data-kind="detection"] { border-left-color: var(--accent-detection); }
+  .section[data-kind="fix"] { border-left-color: var(--accent-fix); }
+  .section[data-kind="anti-pattern"] { border-left-color: var(--accent-antipattern); }
+  .section[data-kind="see-also"] { border-left-color: var(--accent-seealso); }
+  .section h2 {
+    font-size: 12.5px;
+    text-transform: uppercase;
+    letter-spacing: .04em;
+    margin: 0 0 8px;
+    color: var(--fg-muted);
+  }
+  .section :first-child { margin-top: 0; }
+  .section :last-child { margin-bottom: 0; }
+  .section p { margin: 0 0 8px; }
+  .section ul, .section ol { margin: 0 0 8px; padding-left: 20px; }
+  .section li { margin-bottom: 3px; }
+  .section pre {
+    background: var(--code-bg);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 10px 12px;
+    overflow-x: auto;
+    font-size: 12.5px;
+    margin: 0 0 8px;
+  }
+  .section code {
+    font-family: ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", monospace;
+  }
+  .section :not(pre) > code {
+    background: var(--code-bg);
+    padding: 1px 5px;
+    border-radius: 4px;
+    font-size: 12px;
+  }
+  .section strong { font-weight: 650; }
+  .footer-note {
+    color: var(--fg-muted);
+    font-size: 11.5px;
+    margin-top: 14px;
+    text-align: center;
+  }
+  .empty {
+    color: var(--fg-muted);
+    padding: 24px 4px;
+    text-align: center;
+  }
+  .empty .spinner {
+    width: 22px; height: 22px;
+    margin: 0 auto 10px;
+    border: 2px solid var(--border);
+    border-top-color: var(--accent-detection);
+    border-radius: 50%;
+    animation: spin 0.8s linear infinite;
+  }
+  @keyframes spin { to { transform: rotate(360deg); } }
+  .error {
+    color: var(--accent-antipattern);
+    background: var(--card-bg);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 12px 14px;
+    white-space: pre-wrap;
+    font-size: 12.5px;
+  }
+</style>
+</head>
+<body>
+<div id="root">
+  <div class="empty" id="empty-state">
+    <div class="spinner"></div>
+    Waiting for playbook data&hellip;
+  </div>
+</div>
+
+<script>
+(function () {
+  "use strict";
+
+  // --- MCP Apps host bridge -------------------------------------------
+  // Prototype of the SEP-1865 iframe<->host wiring: we announce readiness
+  // with ui/initialize, then react to the tool-result notification the
+  // host relays once get_playbook() returns. See
+  // https://github.com/modelcontextprotocol/ext-apps (2026-01-26 apps.mdx).
+
+  var SECTION_ORDER = [
+    "problem", "symptoms", "detection", "fix", "anti-pattern", "see-also"
+  ];
+  var SECTION_LABELS = {
+    "problem": "Problem",
+    "symptoms": "Symptoms",
+    "detection": "Detection",
+    "fix": "Fix",
+    "anti-pattern": "Anti-pattern",
+    "see-also": "See also"
+  };
+
+  function post(message) {
+    window.parent.postMessage(message, "*");
+  }
+
+  function slugifyHeading(text) {
+    return text.trim().toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "");
+  }
+
+  // Very small, dependency-free markdown-ish renderer scoped to what the
+  // bundled playbooks actually use: fenced code, bullet/numbered lists,
+  // bold, inline code, links, paragraphs. Not a general CommonMark parser.
+  function escapeHtml(s) {
+    return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  }
+
+  function renderInline(text) {
+    var out = escapeHtml(text);
+    out = out.replace(/`([^`]+)`/g, "<code>$1</code>");
+    out = out.replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>");
+    out = out.replace(/\[([^\]]+)\]\(([^)]+)\)/g, function (_, label, href) {
+      var safeHref = /^https?:\/\//.test(href) ? href : "#";
+      return '<a href="' + safeHref + '" target="_blank" rel="noopener noreferrer">' + label + "</a>";
+    });
+    return out;
+  }
+
+  function renderBody(md) {
+    var lines = md.split("\n");
+    var html = [];
+    var i = 0;
+    var listBuffer = null; // {tag, items}
+
+    function flushList() {
+      if (listBuffer) {
+        html.push(
+          "<" + listBuffer.tag + ">" +
+          listBuffer.items.map(function (it) { return "<li>" + renderInline(it) + "</li>"; }).join("") +
+          "</" + listBuffer.tag + ">"
+        );
+        listBuffer = null;
+      }
+    }
+
+    while (i < lines.length) {
+      var line = lines[i];
+
+      if (/^```/.test(line)) {
+        flushList();
+        var codeLines = [];
+        i++;
+        while (i < lines.length && !/^```/.test(lines[i])) {
+          codeLines.push(lines[i]);
+          i++;
+        }
+        html.push("<pre><code>" + escapeHtml(codeLines.join("\n")) + "</code></pre>");
+        i++; // skip closing fence
+        continue;
+      }
+
+      var bulletMatch = line.match(/^\s*[-*]\s+(.*)$/);
+      var numberedMatch = line.match(/^\s*\d+\.\s+(.*)$/);
+
+      if (bulletMatch) {
+        if (!listBuffer || listBuffer.tag !== "ul") { flushList(); listBuffer = { tag: "ul", items: [] }; }
+        listBuffer.items.push(bulletMatch[1]);
+        i++;
+        continue;
+      }
+      if (numberedMatch) {
+        if (!listBuffer || listBuffer.tag !== "ol") { flushList(); listBuffer = { tag: "ol", items: [] }; }
+        listBuffer.items.push(numberedMatch[1]);
+        i++;
+        continue;
+      }
+
+      // Wrapped continuation of the previous list item: indented, not a new
+      // bullet/number, not blank. Source markdown wraps long bullets like
+      // "- foo bar\n  baz" across two lines without repeating the marker.
+      if (listBuffer && listBuffer.items.length && /^\s+\S/.test(line)) {
+        listBuffer.items[listBuffer.items.length - 1] += " " + line.trim();
+        i++;
+        continue;
+      }
+
+      flushList();
+
+      if (line.trim() === "") { i++; continue; }
+
+      // Paragraph: consume until blank line / list / fence.
+      var paraLines = [line];
+      i++;
+      while (
+        i < lines.length &&
+        lines[i].trim() !== "" &&
+        !/^```/.test(lines[i]) &&
+        !/^\s*[-*]\s+/.test(lines[i]) &&
+        !/^\s*\d+\.\s+/.test(lines[i])
+      ) {
+        paraLines.push(lines[i]);
+        i++;
+      }
+      html.push("<p>" + renderInline(paraLines.join(" ")) + "</p>");
+    }
+    flushList();
+    return html.join("\n");
+  }
+
+  function parseFrontmatter(raw) {
+    var fm = {};
+    var body = raw;
+    if (raw.indexOf("---") === 0) {
+      var end = raw.indexOf("\n---", 3);
+      if (end !== -1) {
+        var block = raw.slice(3, end);
+        body = raw.slice(end + 4).replace(/^\n+/, "");
+        block.split("\n").forEach(function (line) {
+          var m = line.match(/^([a-zA-Z0-9_]+):\s*(.*)$/);
+          if (m) fm[m[1]] = m[2].trim();
+        });
+      }
+    }
+    return { fm: fm, body: body };
+  }
+
+  function parseSections(body) {
+    // Drop the leading "# Title" line, split the rest on "## Heading".
+    var withoutTitle = body.replace(/^#\s+.*\n+/, "");
+    var parts = withoutTitle.split(/\n(?=##\s+)/);
+    var sections = [];
+    parts.forEach(function (part) {
+      var m = part.match(/^##\s+(.*)\n?([\s\S]*)$/);
+      if (!m) return;
+      var label = m[1].trim();
+      var kind = slugifyHeading(label);
+      sections.push({ kind: kind, label: label, body: m[2] });
+    });
+    return sections;
+  }
+
+  function render(payload) {
+    var emptyState = document.getElementById("empty-state");
+    if (emptyState) emptyState.remove();
+
+    var root = document.getElementById("root");
+    var content = payload && payload.content;
+
+    if (payload && payload.error) {
+      root.innerHTML =
+        '<div class="error">No playbook loaded: ' + escapeHtml(payload.error) +
+        (payload.suggestions && payload.suggestions.length
+          ? "\n\nDid you mean: " + payload.suggestions.join(", ") + "?"
+          : "") +
+        "</div>";
+      return;
+    }
+
+    if (typeof content !== "string") {
+      root.innerHTML = '<div class="error">Unexpected tool result shape - no content string found.</div>';
+      return;
+    }
+
+    var parsed = parseFrontmatter(content);
+    var fm = parsed.fm;
+    var sections = parseSections(parsed.body);
+    var byKind = {};
+    sections.forEach(function (s) { byKind[s.kind] = s; });
+
+    var badgeValues = [fm.scope, fm.service, fm.waste_category, fm.confidence].filter(Boolean);
+
+    var out = [];
+    out.push('<div class="header">');
+    out.push("<h1>" + escapeHtml(payload.title || payload.name || "Playbook") + "</h1>");
+    if (badgeValues.length) {
+      out.push('<div class="badges">' + badgeValues.map(function (v) {
+        return '<span class="badge">' + escapeHtml(v) + "</span>";
+      }).join("") + "</div>");
+    }
+    out.push("</div>");
+
+    var orderedKinds = SECTION_ORDER.slice();
+    sections.forEach(function (s) { if (orderedKinds.indexOf(s.kind) === -1) orderedKinds.push(s.kind); });
+
+    orderedKinds.forEach(function (kind) {
+      var s = byKind[kind];
+      if (!s) return;
+      out.push('<div class="section" data-kind="' + kind + '">');
+      out.push("<h2>" + escapeHtml(SECTION_LABELS[kind] || s.label) + "</h2>");
+      out.push(renderBody(s.body));
+      out.push("</div>");
+    });
+
+    out.push('<div class="footer-note">Cloud FinOps Playbook by OptimNow &middot; rendered via MCP Apps (SEP-1865)</div>');
+
+    root.innerHTML = out.join("\n");
+  }
+
+  function extractPayload(params) {
+    if (params && params.structuredContent) return params.structuredContent;
+    if (params && Array.isArray(params.content)) {
+      for (var j = 0; j < params.content.length; j++) {
+        var block = params.content[j];
+        if (block && typeof block.text === "string") {
+          try { return JSON.parse(block.text); } catch (e) { /* not JSON, ignore */ }
+        }
+      }
+    }
+    return null;
+  }
+
+  window.addEventListener("message", function (event) {
+    var msg = event.data;
+    if (!msg || msg.jsonrpc !== "2.0") return;
+
+    if (msg.method === "ui/notifications/tool-result") {
+      var payload = extractPayload(msg.params);
+      if (payload) render(payload);
+      return;
+    }
+
+    // Some hosts may reply to our ui/initialize call with a result carrying
+    // an initial tool result inline rather than as a separate notification.
+    if (msg.id === 1 && msg.result) {
+      var inline = extractPayload(msg.result);
+      if (inline) render(inline);
+    }
+  });
+
+  post({ jsonrpc: "2.0", id: 1, method: "ui/initialize", params: { appCapabilities: {} } });
+})();
+</script>
+</body>
+</html>

--- a/mcp_server/tests/test_e2e.py
+++ b/mcp_server/tests/test_e2e.py
@@ -128,6 +128,47 @@ async def test_e2e_find_playbooks(server_params: StdioServerParameters) -> None:
                 assert pb["waste_category"] == "idle"
 
 
+@pytest.mark.asyncio
+async def test_e2e_playbook_viewer_ui_resource(
+    server_params: StdioServerParameters,
+) -> None:
+    """MCP Apps (SEP-1865) prototype: the UI resource is listed and readable."""
+    async with stdio_client(server_params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            resources = await session.list_resources()
+            uris = {str(r.uri) for r in resources.resources}
+            assert "ui://cloud-finops/playbook-viewer" in uris
+
+            viewer = next(
+                r for r in resources.resources if str(r.uri) == "ui://cloud-finops/playbook-viewer"
+            )
+            assert viewer.mimeType == "text/html;profile=mcp-app"
+
+            read_result = await session.read_resource(viewer.uri)
+            html = next(c.text for c in read_result.contents if hasattr(c, "text"))
+            assert "<!DOCTYPE html>" in html
+            assert "ui/initialize" in html
+            assert "ui/notifications/tool-result" in html
+
+
+@pytest.mark.asyncio
+async def test_e2e_get_playbook_tool_links_ui_resource(
+    server_params: StdioServerParameters,
+) -> None:
+    """``get_playbook``'s ``_meta.ui.resourceUri`` points at the UI resource."""
+    async with stdio_client(server_params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            result = await session.list_tools()
+            get_playbook_tool = next(t for t in result.tools if t.name == "get_playbook")
+            assert get_playbook_tool.meta is not None
+            assert (
+                get_playbook_tool.meta["ui"]["resourceUri"]
+                == "ui://cloud-finops/playbook-viewer"
+            )
+
+
 def _payload(result) -> dict:
     """Extract and JSON-decode the structured tool result."""
     if getattr(result, "structuredContent", None):


### PR DESCRIPTION
## What changed

Prototype of the **MCP Apps** extension (`io.modelcontextprotocol/ui`, SEP-1865, official in the 2026-07-28 MCP spec) for the `cloud-finops-mcp` server:

- **`mcp_server/src/cloud_finops_mcp/ui/playbook_viewer.html`** - self-contained HTML/JS UI resource. Performs the `ui/initialize` handshake, listens for `ui/notifications/tool-result`, and renders the playbook markdown as labelled colour-coded sections (Problem / Symptoms / Detection / Fix / Anti-pattern / See also) with badges from the frontmatter facets (scope / service / waste_category / confidence). Light/dark aware, zero external dependencies so it survives the host's sandboxed-iframe CSP.
- **`server.py`** - registers the resource at `ui://cloud-finops/playbook-viewer` (`mimeType: text/html;profile=mcp-app`) and links it from `get_playbook` via `_meta.ui.resourceUri`.
- **`tests/test_e2e.py`** - two new wire-level tests: the UI resource is listed and readable with the right mimeType, and `get_playbook`'s `_meta` carries the `resourceUri`.

## Why

The 2026-07-28 spec revision made MCP Apps an official extension with host support already shipped in Claude, ChatGPT, Goose, and VS Code. Rendering a playbook as structured UI instead of a wall of raw markdown is the one part of the new spec that concretely benefits this stdio server (the OAuth/stateless-core changes only concern remote HTTP servers).

## Reviewer notes

- **No SDK bump.** The pinned `mcp>=1.28,<2` already supports `meta=` on both `@mcp.tool()` and `@mcp.resource()`, serialising to `_meta` on the wire. The `<2` pin (post-incident guard) is untouched.
- **Verified via a mock host harness** simulating the SEP-1865 postMessage exchange with real playbook content (`aws-zombie-nat-gateway`). All six sections render in order; wrapped-bullet continuation lines were a real bug caught and fixed during this verification.
- **Not yet verified: real host-side rendering.** No host with confirmed end-to-end MCP Apps support was available during development; the harness only simulates the documented protocol.
- **Known limitation (accepted for a prototype):** the mini markdown renderer does not support truly nested lists - a sub-bullet renders as a sibling list. Would need a smarter parser if promoted beyond prototype.
- Hosts without MCP Apps support ignore the `_meta.ui` link and fall back to the existing raw-markdown behaviour - no regression for current clients.
- Content PR per the release-train rule: no version bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)