### PR TITLE
Content update - 16 Aug 2026

### DIFF
--- a/skills/cloud-finops/references/finops-agentic.md
+++ b/skills/cloud-finops/references/finops-agentic.md
@@ -93,6 +93,10 @@ context windows that balloon to hundreds of thousands of tokens. Effective archi
 use short-term memory for recent exchanges and long-term memory for persistent preferences
 and organisational context, with explicit token budgets for each layer.
 
+As of August 2026, Bedrock AgentCore memory, policy, and a new managed harness are
+available in AWS GovCloud (US-West), extending these pillars to regulated and government
+cloud environments for cost-governance planning. Source: AWS What's New - Bedrock.
+
 **3. Policy-generation over direct mutation**
 The safest agentic architecture for FinOps generates governance policies for human review
 rather than executing infrastructure changes directly. An agent that identifies idle
@@ -100,6 +104,17 @@ resources and drafts a Cloud Custodian policy or OpenOps rule for review is prod
 An agent that stops instances autonomously is not - regardless of how sophisticated its
 reasoning is. Governance, not technology capability, is the real constraint on autonomous
 FinOps agents.
+
+AgentCore's policy capability now supports natural-language-to-Cedar tool-access controls,
+consistent with the policy-generation-over-direct-mutation pillar above.
+
+**New cost surface - the managed harness.** AgentCore's managed harness is a declarative
+agent runtime that removes orchestration code. It bundles compute, environment, and
+observability into API calls, creating a new billing surface to track alongside AgentCore
+Payments. Give it its own cost-attribution treatment - similar to the Managed Agents
+session-runtime billing documented in finops-anthropic.md - so bundled runtime cost is
+not silently folded into token spend. As of August 2026, this is available in AWS GovCloud
+(US-West). Source: AWS What's New - Bedrock.
 
 ## Agents as cost actors: agent-initiated payments (x402 / MPP)
 

--- a/skills/cloud-finops/references/finops-ai-dev-tools.md
+++ b/skills/cloud-finops/references/finops-ai-dev-tools.md
@@ -197,6 +197,15 @@ question wherever developers can toggle it themselves.
   LiteLLM auto-detects Claude Code via User-Agent header
 - **Anthropic Console** - basic usage and billing data at the organisation level
 
+**Native gateway spend-limit warnings (as of August 2026).** Claude Code now surfaces
+gateway spend limits proactively in its usage warnings - showing the spending cap, the
+reset time, and the operator message - rather than only failing silently or after the
+fact. For teams enforcing per-user or per-team budget caps this improves cost-governance
+visibility and reduces surprise overage incidents. The practical effect is that ClaudeXray
+and LiteLLM are no longer needed *purely* for budget-cap visibility; they remain valuable
+for metadata injection, cross-tool aggregation, and analytics, but the cap-and-reset
+signal is now available natively.
+
 ---
 
 ## OpenAI Codex

--- a/skills/cloud-finops/references/finops-anthropic.md
+++ b/skills/cloud-finops/references/finops-anthropic.md
@@ -311,6 +311,14 @@ governance, but Finout's analysis suggests it is not yet a complete solution -
 notably around granular allocation and cross-workload attribution, and it does
 not cover raw API platform spend.
 
+**Additional native signal (as of August 2026):** Claude Code now surfaces gateway
+spend limit warnings proactively - displaying the spending cap, reset time, and
+operator message directly in usage warnings, rather than failing silently or only
+after the cap is hit. This gives teams enforcing per-user or per-team budget caps
+an additional native cost-governance signal alongside the July 2026 Enterprise
+admin tooling, reducing surprise overage incidents. See the "Cost tracking for
+Claude Code" section in `finops-ai-dev-tools.md` for detail.
+
 Sources: [Anthropic - New analytics and cost controls for Claude Enterprise](https://claude.com/blog/giving-admins-more-visibility-and-control-over-claude-usage-and-spend) (primary),
 [Anthropic keeps signaling where AI cost governance needs to go](https://www.finout.io/blog/anthropic-keeps-signaling-where-ai-cost-governance-needs-to-go.-its-not-all-the-way-there-yet) (Finout commentary).
 

--- a/skills/cloud-finops/references/finops-aws-patterns.md
+++ b/skills/cloud-finops/references/finops-aws-patterns.md
@@ -947,6 +947,16 @@ Many legacy workloads still run on older Elasticsearch versions  - particularly 
 - Be aware that upgrading from Elasticsearch 7.x may require reindexing or application compatibility changes
 - Where possible, consolidate or delete unused domains to eliminate unnecessary charges
 
+**Outdated OpenSearch Or Elasticsearch Domain Incurring Extended Support Charges**
+Service: AWS OpenSearch | Type: Outdated Resource
+
+When an OpenSearch or Elasticsearch domain remains on a version past its standard support window, AWS applies an Extended Support surcharge to continue supplying security patches. This is a direct, quantifiable cost-forecasting item analogous to the EKS Extended Support pattern, and the surcharge rate is scheduled to increase materially. As of August 2026, AWS is extending Extended Support patch coverage for legacy Elasticsearch (1.5-7.8) and OpenSearch (1.0-1.2, 2.3-2.9) versions by 12 months to November 2027 - but from November 2026 the Extended Support surcharge rises to equal 100% of instance pricing (an effective 2x compute cost) for domains still on those old versions. AWS has also published Standard/Extended Support timelines for additional versions (ES 6.8/7.9/7.10, OpenSearch 1.3, 2.11-2.19), with support windows ranging 1-3 years. AWS revises these windows periodically, so verify current support dates before budgeting.
+
+- Identify OpenSearch/Elasticsearch domains running versions past their standard support window (legacy ES 1.5-7.8, OpenSearch 1.0-1.2 and 2.3-2.9)
+- Prioritise upgrades ahead of the November 2026 surcharge doubling to 100% of instance price, and note the November 2027 cutoff for continued Extended Support coverage
+- Test upgrade compatibility in lower environments before applying in production, and decommission unused domains to eliminate unnecessary charges
+<<REPLACE>>
+
 **Outdated Opensearch Version Triggering Extended Support Charges**
 Service: AWS OpenSearch | Type: Inefficient Configuration
 

--- a/skills/cloud-finops/references/finops-aws.md
+++ b/skills/cloud-finops/references/finops-aws.md
@@ -130,6 +130,28 @@ right tool for detailed attribution and custom tooling.
 - **Cost anomaly detection** - ML-based anomaly alerts (set up before you need them)
 - **Cost categories** - virtual tags for billing-layer cost allocation
 
+### AWS Managed Dashboards (zero-setup native visibility)
+
+As of August 2026, AWS Billing and Cost Management offers a set of curated
+Managed Dashboards that come pre-populated with your account data at no
+additional cost and require no setup. There are five dashboards: Cost Overview,
+Trends, Compute, Database, and Reservations and Savings Plans.
+
+**Why this matters for FinOps:**
+- A fast-start visibility baseline for organisations beginning or standardising
+  their FinOps practice - a zero-setup native alternative or complement to
+  custom CUR / Data Exports-based dashboards. Particularly useful at Crawl
+  maturity, before a team has invested in Athena or a warehouse pipeline.
+- Dashboards are read-only, but any dashboard can be duplicated into an editable
+  custom copy for customisation.
+- Exportable via PDF and CSV for sharing with Finance and stakeholders.
+
+Managed Dashboards do not replace CUR / Data Exports for detailed attribution
+and custom tooling - they are the quick-win visibility layer, not the granular
+data foundation.
+
+Source: https://aws.amazon.com/about-aws/whats-new/2026/08/aws-billing-and-cost-management-managed-dashboards/
+
 ### AWS Cost Anomaly Detection
 
 Set up before an incident occurs. AWS Cost Anomaly Detection uses ML to identify
@@ -490,6 +512,26 @@ Configure at minimum:
 **Recommended alert recipients:** Both the FinOps practitioner and the engineering team
 lead for the relevant account. FinOps-only alerts create a bottleneck; engineering-only
 alerts lack financial context.
+
+### Extended Support version audits (recurring action item)
+
+Several AWS services charge an Extended Support surcharge for domains, clusters, or
+instances left on end-of-standard-support versions. This is the "outdated resource
+incurring extended support charges" pattern - see `finops-aws-patterns.md` for the
+enumerated entries (EKS clusters, OpenSearch/Elasticsearch domains).
+
+Make version audits a recurring FinOps action item:
+- Audit Amazon OpenSearch Service domains for legacy Elasticsearch (1.5-7.8) and
+  OpenSearch (1.0-1.2, 2.3-2.9) versions still incurring Extended Support charges.
+- As of August 2026, AWS extended Extended Support patch coverage for these legacy
+  versions by 12 months to November 2027, but from November 2026 the Extended Support
+  surcharge rises to equal 100% of instance pricing (a 2x effective compute cost for
+  domains still on old versions). Newer versions (ES 6.8/7.9/7.10, OpenSearch 1.3,
+  2.11-2.19) have their own Standard/Extended Support windows ranging 1-3 years.
+- AWS revises these support windows periodically - always check the current support
+  dates before budgeting rather than relying on a cached table.
+
+Source: https://aws.amazon.com/about-aws/whats-new/2026/08/amazon-opensearch-service-additional-upgrade-runway-support-dates
 
 ---
 

--- a/skills/cloud-finops/references/finops-bedrock.md
+++ b/skills/cloud-finops/references/finops-bedrock.md
@@ -161,6 +161,9 @@ path by recording the caller's IAM principal ARN on every billed line item.
 
 When enabled, AWS records the calling IAM principal ARN for each Bedrock API call and
 propagates tags applied to that principal into the Cost and Usage Report and Cost Explorer.
+As of August 2026, this coverage extends to the **bedrock-mantle** endpoint in addition
+to the original **bedrock-runtime** support, closing a per-application/team attribution
+gap for inference costs routed through that endpoint.
 
 **How it shows up in CUR 2.0:**
 
@@ -177,6 +180,10 @@ propagates tags applied to that principal into the Cost and Usage Report and Cos
 2. Activate those tag keys in Billing > Cost Allocation Tags (up to 24h propagation)
 3. Enable "Include caller identity (IAM principal) allocation data" in CUR 2.0 Data Exports
 
+As of August 2026, this activation covers inference calls on both the **bedrock-runtime**
+and **bedrock-mantle** endpoints - no additional setup step is needed to pick up
+bedrock-mantle traffic once caller-identity allocation is enabled.
+
 **Structural consequences to plan for:**
 
 - **CUR size grows significantly.** Row count multiplies roughly by the number of distinct
@@ -190,9 +197,11 @@ propagates tags applied to that principal into the Cost and Usage Report and Cos
   chargeback still needs to be built on top of the CUR
 
 **Coverage caveat:** some Bedrock features do not execute under the calling IAM role.
-**Guardrails** usage, notably, may appear in CUR without the caller-identity value -
-only resource tags carry the attribution (unconfirmed in AWS documentation; validate
-in your own CUR before relying on it). IAM Principal Cost Allocation therefore does
+As of August 2026 the bedrock-runtime and bedrock-mantle inference endpoints are both
+covered, which narrows the list of Bedrock surfaces lacking a principal-based
+attribution path. **Guardrails** usage, notably, may still appear in CUR without the
+caller-identity value - only resource tags carry the attribution (unconfirmed in AWS
+documentation; validate in your own CUR before relying on it). IAM Principal Cost Allocation therefore does
 not eliminate the tagging requirement: teams still need tag discipline for guardrails
 and similar non-principal line items. Note that a CUR 2.0 export created **before**
 enabling IAM principal attribution must be **recreated** - existing exports do not
@@ -456,6 +465,27 @@ Candidates: document enrichment, bulk classification, evaluation pipelines, repo
 - [ ] Post-optimisation observability: after each change (model swap, routing,
       caching), verify impact in invocation logs and token metrics - optimisations
       regress silently
+
+---
+
+## AgentCore in GovCloud - regulated-workload cost governance
+
+As of August 2026, AWS Bedrock AgentCore capabilities - **memory** (short and long-term),
+**policy** (natural-language-to-Cedar tool-access controls), and a **managed harness**
+(declarative agent runtime with no orchestration code) - are available in **AWS GovCloud
+(US-West)**. This extends the "policy-generation over direct mutation" and "memory with
+cost controls" architectural pillars (see `finops-agentic.md`) to regulated and
+government cloud environments.
+
+FinOps implications for GovCloud planning:
+
+- The **managed harness** is a new cost surface: compute, environment, and observability
+  are bundled into API calls. Treat it with its own cost attribution approach, similar to
+  the Managed Agents session-runtime billing documented in `finops-anthropic.md`.
+- Apply the same memory cost controls and policy-generation governance patterns already
+  documented for commercial regions to GovCloud (US-West) workloads.
+- Verify GovCloud-specific pricing separately - GovCloud rates commonly differ from
+  commercial-region rates.
 
 ---
 

--- a/skills/cloud-finops/references/finops-for-ai.md
+++ b/skills/cloud-finops/references/finops-for-ai.md
@@ -266,7 +266,7 @@ version); log full request and response content only for sampled traffic or erro
 | Training job attribution | SageMaker tags -> CUR | AzureML resource group + tags -> Cost Management | Vertex AI project labels -> BigQuery |
 | Inference attribution | Tags on provisioned throughput + app instrumentation | Separate AOAI accounts + tags + app instrumentation | Project labels + API call labels + Cloud Monitoring |
 | Token-level unit economics | App instrumentation + CloudWatch | App instrumentation + Azure Monitor | App instrumentation + Cloud Monitoring |
-| AI cost visibility | Bedrock inference profiles (limited) | Cost Management AI views | AI Cost Summary Agent (preview) |
+| AI cost visibility | Bedrock inference profiles (limited) | Cost Management AI views | AI Cost Summary Agent (preview) + Cloud Billing "Originating products" filter/group-by and Gemini Enterprise preset report |
 
 As of July 2026, Anthropic ships native cost governance tooling directly (announced 2 July
 2026, independent of any model release): admin spend analytics by group and user, model

--- a/skills/cloud-finops/references/finops-gcp.md
+++ b/skills/cloud-finops/references/finops-gcp.md
@@ -52,6 +52,15 @@ face when managing AI workloads on GCP.
 - Native tooling for AI spend attribution without third-party tools
 - Integrated into the Cloud Billing console for unified cost management
 
+**Originating products filter and Gemini Enterprise preset report.** As of August 2026,
+Cloud Billing added an **"Originating products"** filter/group-by dimension in Billing
+Reports, plus a **Gemini Enterprise preset report**. Together these give more precise
+native attribution of AI-related consumption (including Gemini Enterprise usage)
+directly in Billing Reports, further reducing reliance on third-party tooling for AI
+spend attribution. Use the "Originating products" group-by to segment AI-related
+consumption across services, and the Gemini Enterprise preset as a ready-made starting
+point for Gemini Enterprise cost visibility.
+
 For detailed AI cost optimisation strategies, see `finops-vertexai.md` and
 `finops-for-ai.md`.
 
@@ -182,6 +191,12 @@ billing-account-level coverage looks healthy in aggregate while individual
 project-level utilisation is poor. Day-1 audit on any GCP commitment engagement:
 verify whether CUD Sharing is enabled. Source:
 https://cloud.google.com/billing/docs/how-to/cud-analysis
+
+**Flexible GPU commitments across services.** As of August 2026, flexible GPU
+commitments can now apply across services (not just within a single service),
+broadening Flex CUD coverage for GPU-accelerated workloads such as AI/ML training and
+inference. This lets teams commit to GPU spend once and have the discount apply across
+qualifying services, improving commitment durability for evolving AI architectures.
 
 Sources: https://cloud.google.com/compute/docs/instances/committed-use-discounts-overview, https://cloud.google.com/compute/docs/instances/signing-up-flexible-committed-use-discounts
 

--- a/skills/cloud-finops/references/finops-kubernetes.md
+++ b/skills/cloud-finops/references/finops-kubernetes.md
@@ -265,13 +265,33 @@ node failures.
 Karpenter's `consolidationPolicy: WhenUnderutilized` is powerful but chatty.
 Aggressive `consolidateAfter` settings cause pod churn that affects SLOs.
 
+Karpenter triggers node replacement through three disruption mechanisms:
+
+- **Consolidation** - replaces or removes underutilised nodes to pack pods
+  onto fewer or cheaper nodes (`consolidationPolicy: WhenUnderutilized`).
+- **Drift** - detects when a node's actual configuration no longer matches
+  its NodePool / NodeClass spec (e.g. an AMI, instance-type list, or label
+  change) and replaces the drifted node to bring it into alignment. Drift
+  is how spec edits roll out to existing nodes rather than only new ones.
+- **Expiration** - forces node replacement after `expireAfter` for patching
+  cadence.
+
 Recommended starting points:
 
 - `consolidateAfter: 30s` for dev / staging clusters
 - `consolidateAfter: 5m` for prod clusters
-- `disruptionBudget` configured to limit simultaneous node drains
+- `disruptionBudget` configured to limit simultaneous node drains across all
+  disruption mechanisms (consolidation, drift, and expiration)
 - `expireAfter: 720h` (30 days) to force a rolling refresh of nodes for
   patching cadence
+
+For workload-level control, use the `karpenter.sh/do-not-disrupt: "true"`
+annotation on pods that must not be involuntarily moved (e.g. long-running
+batch jobs or stateful workloads mid-operation). This overrides
+consolidation and drift for the node running that pod, at the cost of some
+consolidation savings - apply it narrowly, not cluster-wide. As of March
+2026, disruption budgets and do-not-disrupt are the two primary controls for
+governing how aggressively Karpenter replaces nodes.
 
 Tune up or down based on the observed pod-disruption rate vs the savings
 delivered.

--- a/skills/cloud-finops/references/finops-vertexai.md
+++ b/skills/cloud-finops/references/finops-vertexai.md
@@ -169,6 +169,14 @@ analysis across Gemini API and Vertex AI services through a Billing Overview wid
 an engagement). This native tool addresses the AI cost
 visibility gap, offering spend attribution and insights specifically for AI workloads.
 
+**Originating products attribution (Cloud Billing):** as of August 2026, Cloud Billing
+adds an "Originating products" filter/group-by dimension plus a Gemini Enterprise preset
+report, giving more precise native attribution of AI-related consumption directly in
+Billing Reports. For Vertex AI and Gemini spend, use this dimension to attribute
+AI-related consumption (including Gemini Enterprise usage) without relying solely on
+third-party tooling. Combine it with the BigQuery export approach above for detailed,
+SKU-level analysis. Source: https://cloud.google.com/billing/docs
+
 **Limitation:** native billing does not provide token-level granularity per request.
 For unit economics, combine billing data with application-level metrics from
 Cloud Monitoring or your own instrumentation.


### PR DESCRIPTION
## Content update - 16 Aug 2026

Closes https://github.com/OptimNow/cloud-finops-skills/issues/132

### Changes applied

- **Amazon OpenSearch Service announces additional upgrade runway for existing domains and support dates for additional versions** (PRICING_CHANGE)
  - Files: `finops-aws.md`, `finops-aws-patterns.md`
  - AWS is extending Extended Support patch coverage for legacy Elasticsearch (1.5-7.8) and OpenSearch (1.0-1.2, 2.3-2.9) versions by 12 months to November 2027, but from November 2026 the Extended Support surcharge rises to equal 100% of instance pricing (i.e., a 2x effective compute cost for domains still on old versions). AWS also announced new Standard/Extended Support timelines for additional versions (ES 6.8/7.9/7.10, OpenSearch 1.3, 2.11-2.19), with support windows ranging 1-3 years. This is a direct, quantifiable cost-forecasting item for any organisation running OpenSearch/Elasticsearch domains that have not upgraded, and represents a new "outdated resource incurring extended support charges" pattern analogous to the existing EKS Extended Support pattern already documented for AWS.</summary>
<parameter name="suggested_action">Add an OpenSearch/Elasticsearch Extended Support surcharge entry to finops-aws-patterns.md's compute/service patterns (parallel to the existing "Outdated Eks Cluster Incurring Extended Support Charges" pattern), noting the version ranges, the Nov 2026 surcharge-doubling to 100% of instance price, and the Nov 2027 cutoff for continued coverage. Optionally add a brief note in finops-aws.md's service cost-governance section flagging OpenSearch domain version audits as a recurring FinOps action item, with a reminder to check current support dates before budgeting, since AWS revises these support windows periodically.

- **Amazon Bedrock expands IAM principal cost allocation to the bedrock-mantle endpoint** (NEW_FEATURE)
  - Files: `finops-bedrock.md`
  - AWS extended IAM Principal Cost Allocation for Amazon Bedrock to cover the bedrock-mantle endpoint (in addition to the existing bedrock-runtime support), letting customers tag IAM users/roles and attribute bedrock-mantle inference costs by team, project, or cost centre via Cost Explorer or CUR 2.0. This closes a coverage gap in per-application/team attribution for Bedrock inference costs on this endpoint.</summary>
<parameter name="suggested_action">Update the "IAM Principal Cost Allocation" section in finops-bedrock.md to note that coverage now extends to the bedrock-mantle endpoint (previously bedrock-runtime only), and update the CUR 2.0 setup/activation steps to reflect this expanded scope. Also consider revising the "Coverage caveat" note about features that may not execute under the calling IAM role, since mantle-endpoint coverage narrows the list of Bedrock surfaces without this attribution path.

- **Amazon Bedrock AgentCore adds memory, policy, and harness in AWS GovCloud (US-West)** (NEW_FEATURE)
  - Files: `finops-agentic.md`, `finops-bedrock.md`
  - AWS Bedrock AgentCore now offers memory (short/long-term), policy (natural-language-to-Cedar tool-access controls), and a managed harness (declarative agent runtime with no orchestration code) in AWS GovCloud (US-West). This expands the "policy-generation over direct mutation" and "memory with cost controls" architectural pillars already discussed in finops-agentic.md to regulated/government cloud environments, and adds a new managed harness billing surface to track alongside AgentCore Payments.</summary>
<parameter name="suggested_action">Update finops-agentic.md's "three architectural pillars" section to note GovCloud (US-West) availability of memory, policy, and managed harness, and flag the managed harness as a new cost surface (compute/environment/observability bundled into API calls) requiring its own cost attribution treatment similar to the Managed Agents session-runtime billing documented in finops-anthropic.md. Also note in finops-bedrock.md that AgentCore capabilities now extend to GovCloud for regulated-workload cost governance planning.

- **AWS Billing and Cost Management introduces Managed Dashboards** (NEW_FEATURE)
  - Files: `finops-aws.md`
  - AWS Billing and Cost Management now offers five curated Managed Dashboards (Cost Overview & Trends, Compute, Database, Reservations and Savings Plans) that come pre-populated with account data at no additional cost, requiring no setup. Dashboards are read-only but can be duplicated into editable custom copies, and exported via PDF/CSV - useful as a fast-start visibility baseline for organisations beginning or standardizing their FinOps practice.

- **AI Provider Cost Updates 2026-08-13 | Token Economics News** (NEW_FEATURE)
  - Files: `finops-ai-dev-tools.md`, `finops-anthropic.md`
  - Anthropic's Claude Code now displays gateway spend limits proactively in usage warnings - including the spending cap, reset time, and operator message - rather than only failing silently or after the fact. This improves cost governance visibility for teams enforcing per-user or per-team budget caps on Claude Code usage, reducing surprise overage incidents.

- **GCP Updates 2026-08-12 | Cloud Provider News** (NEW_FEATURE)
  - Files: `finops-gcp.md`, `finops-vertexai.md`, `finops-for-ai.md`
  - GCP Cloud Billing now offers an "Originating products" filter/group-by dimension plus a Gemini Enterprise preset report, giving more precise native attribution of AI-related consumption (including Gemini Enterprise usage) directly in Billing Reports. Separately, flexible GPU commitments can now apply across services. This improves native AI cost visibility on GCP, reducing reliance on third-party tooling for AI spend attribution.

- **Karpenter Disruption and Drift: How to Consolidate Nodes Safely** (BEST_PRACTICE)
  - Files: `finops-kubernetes.md`
  - Cast AI blog post explains Karpenter's disruption mechanics - consolidation, drift, and expiration - and how disruption budgets and do-not-disrupt annotations govern node replacement aggressiveness. This is operational guidance for safely reducing cluster cost via node consolidation without destabilizing workloads.

---
_Generated by the FinOps content update pipeline._