### PR TITLE
Fix two SEP-1865 conformance defects in the playbook viewer, and record the MCP Apps allowlist finding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,6 +270,71 @@ The pipeline now sits in a sustainable operating shape. Future work is
 about *simplification* (reducing the manual review surface), not adding
 more automation.
 
+### MCP Apps rendering in Claude is allowlisted, not earned by conformance (2026-08-16)
+
+The `ui://cloud-finops/playbook-viewer` MCP App shipped in PR #133 had never
+been opened in a real host - only against a test harness that simulates the
+`postMessage` handshake. The 2026-08-16 session finally validated it, and the
+result reorders the whole "publish a remote MCP server" plan.
+
+**What the validation established.** Running MCPJam Inspector against the
+local stdio server (no hosting, no public endpoint, about an hour of work):
+
+- The viewer **works**. It renders in MCPJam's ChatGPT host emulation:
+  frontmatter parsed into badges, the six sections laid out with their
+  colour coding, the footer line present. The prototype is a validated
+  component, not a hypothesis.
+- Two conformance defects were found by auditing the HTML against
+  `modelcontextprotocol/ext-apps` `specification/2026-01-26/apps.mdx`
+  *before* the first live run, and fixed in PR #135: an incomplete
+  `ui/initialize` handshake (missing `protocolVersion` / `clientInfo` /
+  `capabilities`; the spec's reference call passes `protocolVersion:
+  "2026-01-26"`), and `target="_blank"` links, which the host sandbox
+  swallows because it grants `allow-scripts` and `allow-same-origin` but
+  not `allow-popups` - clicks now go through the host's `ui/open-link`.
+- MCPJam's accepted resource mime types, from its own error message:
+  `text/html;profile=mcp-app` (the spec value, which is what the server
+  declares), `text/html+skybridge`, `text/html`. A deliberate experiment
+  substituting the older `text/html+mcp` disproved the mime-type
+  hypothesis cleanly and is *not* retained.
+
+**The finding that changes the plan.** The same server renders as plain
+text in Claude - in MCPJam's Claude emulation, and in real Claude Desktop
+against the local stdio server. The cause is not conformance. Anthropic's
+[Use interactive connectors in Claude](https://support.claude.com/en/articles/13454812-use-interactive-connectors-in-claude)
+names the connectors that may render UI (Amplitude, Asana, Box, Canva,
+Clay, Figma, Hex, Slack) and states that a self-built interactive
+connector "must meet additional design, security, and testing
+requirements", pointing at the Connectors Directory submission and review
+process. `anthropics/claude-ai-mcp#471` reports exactly this failure for a
+spec-correct custom remote connector on Claude Web and was closed as *not
+planned* - consistent with intended behaviour rather than a bug.
+
+**So SEP-1865 conformance is an eligibility condition, not an entry
+ticket.** A custom connector, remote or local, gets the text fallback no
+matter how correct it is. The path to rendering in Claude is: conformant
+server, then publicly reachable remote deployment, then Connectors
+Directory submission, then Anthropic review - the last two outside the
+maintainer's control and on an unpublished timeline.
+
+**Consequences.**
+
+- A remote deployment (Alpic) is **necessary but nowhere near sufficient**
+  for interactive rendering. It must therefore be justified on
+  distribution grounds alone: letting a non-technical user paste a URL
+  into claude.ai instead of installing a PyPI package. That is the
+  decision taken on 2026-08-16, with the interactive viewer explicitly
+  *not* counted as a benefit.
+- Do not treat the "Interactive" badge in the Connectors Directory as
+  reachable by shipping correct code.
+- The transferable discipline: **validate a host-dependent feature in a
+  real host before planning the infrastructure that depends on it.** An
+  hour in MCPJam, costing nothing and requiring no deployment, produced a
+  finding that would otherwise have surfaced at the end of a multi-day
+  hosting project. The prototype had sat unvalidated since PR #133
+  precisely because the only test in place asserted the resource existed,
+  never that it rendered.
+
 ---
 
 ## Roadmap

--- a/mcp_server/src/cloud_finops_mcp/ui/playbook_viewer.html
+++ b/mcp_server/src/cloud_finops_mcp/ui/playbook_viewer.html
@@ -394,7 +394,38 @@
     }
   });
 
-  post({ jsonrpc: "2.0", id: 1, method: "ui/initialize", params: { appCapabilities: {} } });
+  // Links must not navigate the iframe itself: the host sandbox has
+  // allow-scripts/allow-same-origin but not allow-popups, so a plain
+  // target="_blank" is silently swallowed. Route clicks through the host's
+  // ui/open-link request instead. The href is kept as-is so a host that
+  // does not implement ui/open-link degrades to today's behaviour rather
+  // than to a dead element.
+  var linkRequestId = 100;
+  document.addEventListener("click", function (event) {
+    var anchor = event.target && event.target.closest && event.target.closest("a[href]");
+    if (!anchor) return;
+    var href = anchor.getAttribute("href");
+    if (!href || href === "#") return;
+    event.preventDefault();
+    post({
+      jsonrpc: "2.0",
+      id: ++linkRequestId,
+      method: "ui/open-link",
+      params: { url: href }
+    });
+  });
+
+  post({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "ui/initialize",
+    params: {
+      protocolVersion: "2026-01-26",
+      clientInfo: { name: "cloud-finops-playbook-viewer", version: "1" },
+      capabilities: {},
+      appCapabilities: {}
+    }
+  });
 })();
 </script>
 </body>

--- a/mcp_server/tests/test_e2e.py
+++ b/mcp_server/tests/test_e2e.py
@@ -150,6 +150,15 @@ async def test_e2e_playbook_viewer_ui_resource(
             assert "<!DOCTYPE html>" in html
             assert "ui/initialize" in html
             assert "ui/notifications/tool-result" in html
+            # The handshake must carry a protocolVersion: a host that
+            # validates McpUiInitializeRequest rejects a bare
+            # {"appCapabilities": {}} and the view never receives a result.
+            assert '"2026-01-26"' in html
+            assert "clientInfo" in html
+            # Links go through the host. The sandbox grants allow-scripts and
+            # allow-same-origin but not allow-popups, so target="_blank"
+            # navigation is silently swallowed.
+            assert "ui/open-link" in html
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

First validation of the `ui://cloud-finops/playbook-viewer` MCP App in a real host, the two conformance fixes it required, and the finding that came out of it.

The prototype landed in #133 had only ever been exercised by a test harness that simulates `postMessage`. The only tests in place asserted the resource *existed*, never that it *rendered*, which is why it sat unvalidated.

## Result: the viewer works

Validated 2026-08-16 with [MCPJam Inspector](https://github.com/MCPJam/inspector) against the local stdio server, no hosting and no public endpoint required. It renders in the ChatGPT host emulation: frontmatter parsed into badges, six sections with their colour coding, footer line present. The prototype is a validated component now, not a hypothesis.

## The two defects, found by audit before the first live run

Audited against [`modelcontextprotocol/ext-apps`, `specification/2026-01-26/apps.mdx`](https://github.com/modelcontextprotocol/ext-apps/blob/main/specification/2026-01-26/apps.mdx).

**1. Incomplete `ui/initialize` handshake.** The view sent only `{"appCapabilities": {}}`. The spec's request shape is `{protocolVersion, clientInfo, capabilities, appCapabilities}`, and the reference call passes `protocolVersion: "2026-01-26"`. A host that validates `McpUiInitializeRequest` rejects the bare form and the view never receives the tool result. The failure mode is a permanently empty panel with no error, the hardest kind to diagnose in a host you do not control.

**2. Links could not open.** Rendered links used `target="_blank"`. The host iframe is sandboxed with `allow-scripts` and `allow-same-origin` but not `allow-popups`, so that navigation is silently swallowed and every `See also` link was inert. Clicks now go through the host's `ui/open-link`. The `href` is deliberately left in place, so a host without `ui/open-link` degrades to the previous behaviour rather than to a dead element.

Not A/B tested against the unfixed build: the corrected, spec-conformant version renders, which is what the PR claims. It does not claim defect 1 was the sole cause of anything.

## The finding: Claude gates MCP Apps by allowlist, not by conformance

The same server renders as plain text in Claude, both in MCPJam's Claude emulation and in real Claude Desktop against the local stdio server.

The cause is not conformance. [Use interactive connectors in Claude](https://support.claude.com/en/articles/13454812-use-interactive-connectors-in-claude) names the connectors that may render UI (Amplitude, Asana, Box, Canva, Clay, Figma, Hex, Slack) and states that a self-built interactive connector "must meet additional design, security, and testing requirements", pointing at Connectors Directory submission and review. [`anthropics/claude-ai-mcp#471`](https://github.com/anthropics/claude-ai-mcp/issues/471) reports the identical failure for a spec-correct custom remote connector on Claude Web and was closed as *not planned*, consistent with intended behaviour rather than a bug.

SEP-1865 conformance is an eligibility condition, not an entry ticket. This is recorded in CLAUDE.md `Lessons learned` so it does not have to be rediscovered, along with the consequence for the remote-publication plan: a hosted deployment is necessary but nowhere near sufficient for interactive rendering, and has to be justified on distribution grounds alone.

## Also recorded

MCPJam's accepted resource mime types, from its own error message: `text/html;profile=mcp-app` (the spec value the server already declares), `text/html+skybridge`, `text/html`. A deliberate experiment substituting the older `text/html+mcp` disproved the mime-type hypothesis and is **not** retained in the diff.

## Tests

`test_e2e_playbook_viewer_ui_resource` pins the protocol version, `clientInfo`, and the `ui/open-link` route, so the handshake cannot silently regress to the pre-spec shape. 68 passed locally.

## Not in this PR

- No version bump. Content PR, per the release-train rule in CLAUDE.md.
- No change to the `mcp>=1.28,<2` pin.
- No transport change: the server still runs stdio only.