### PR TITLE
Release 1.28.1 and register at the MCP Registry

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Cloud Financial Management references and tooling by OptimNow.",
-    "version": "1.28.0"
+    "version": "1.28.1"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloud-finops",
-  "version": "1.28.0",
+  "version": "1.28.1",
   "description": "Expert FinOps guidance for cloud, AI, SaaS, and data-platform spend (multi-provider, model-agnostic).",
   "author": {
     "name": "OptimNow",

--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -1,5 +1,7 @@
 # cloud-finops-mcp
 
+<!-- mcp-name: io.github.OptimNow/cloud-finops -->
+
 MCP server exposing the [OptimNow Cloud FinOps skill](https://github.com/OptimNow/cloud-finops-skills)
 (reference library + named-pattern playbooks) as queryable tools for any
 MCP-aware client (Claude Code, Cursor, Codex CLI, Windsurf, Aider, Cline, etc.).

--- a/mcp_server/pyproject.toml
+++ b/mcp_server/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cloud-finops-mcp"
-version = "1.28.0"
+version = "1.28.1"
 description = "MCP server exposing the OptimNow Cloud FinOps skill (reference library + named-pattern playbooks) as queryable tools."
 readme = "README.md"
 license = { text = "CC-BY-SA-4.0" }

--- a/server.json
+++ b/server.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.OptimNow/cloud-finops",
+  "title": "Cloud FinOps",
+  "description": "Queryable Cloud FinOps reference library and named-pattern waste playbooks by OptimNow.",
+  "repository": {
+    "url": "https://github.com/OptimNow/cloud-finops-skills",
+    "source": "github"
+  },
+  "version": "1.28.1",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "identifier": "cloud-finops-mcp",
+      "version": "1.28.1",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## ⚠️ Merging this publishes to PyPI

Release PR per the release-train rule in CLAUDE.md. It bumps `plugin.json`, `marketplace.json` `metadata.version` and `mcp_server/pyproject.toml` together (1.28.0 → 1.28.1). Merging tags, cuts a GitHub Release, and publishes `cloud-finops-mcp` 1.28.1 to PyPI. **A PyPI version number cannot be reused**, so merge deliberately.

**Merge #135 first.** That PR fixes two SEP-1865 conformance defects in the playbook viewer with no version bump. If this release lands first, 1.28.1 ships the broken viewer and the fix has to wait for another version.

## Why a release is needed at all for a registry entry

The MCP Registry verifies that you own the package you are claiming. For PyPI, it does that by looking for the exact string `mcp-name: <server-name>` **in the package description, which is built from the package README**. So the marker has to physically reach PyPI before `mcp-publisher publish` will accept the `packages` entry. A plain doc change on `main` is not enough. This is the ordering constraint that makes an otherwise trivial metadata change into a release.

## What changed

- `mcp_server/README.md` gains `<!-- mcp-name: io.github.OptimNow/cloud-finops -->`, hidden in an HTML comment, which the registry docs explicitly allow.
- New `server.json` at the repo root, declaring the PyPI package only. Validated against the official [`2025-12-11` server schema](https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json).
- Version bumps in the three tracked files.

## Deliberately not included

**No `remotes` entry.** `packages` and `remotes` are documented to coexist in one registry entry, so the hosted endpoint can be added on a later version once it exists and has proven stable. Publishing a `remotes` URL is a public availability commitment; there is nothing to commit to yet.

**No transport change.** The server is still stdio only, and the `mcp>=1.28,<2` pin is untouched.

## Manual steps after merge

Merging does not publish to the registry. Once the PyPI release is live:

```bash
mcp-publisher login github     # device flow, grants the io.github.OptimNow/* namespace
mcp-publisher publish          # from the repo root, reads ./server.json
curl "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.OptimNow/cloud-finops"
```

If it reports `Registry validation failed for package`, the marker has not propagated to the PyPI description yet: check the rendered description on the PyPI project page before retrying.

## CI gates

`check-marketplace-version.sh`, `check-docs-drift.sh`, `check-llms-txt.sh` all pass locally. `check-skill-description.sh` warns at 987/1024 characters, which is pre-existing and untouched here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QRJz5wYSTjiCQ5ndmWrd5J)_