### PR TITLE
Add a streamable HTTP transport alongside stdio

### DIFF
--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -132,6 +132,33 @@ command = "cloud-finops-mcp"
 The server speaks MCP over stdio. Point any compatible client at `cloud-finops-mcp`
 (or `python -m cloud_finops_mcp`).
 
+## Streamable HTTP (hosted deployments)
+
+stdio is the default and is what every local client above spawns. For a hosted
+deployment, the same six tools are served over streamable HTTP:
+
+```bash
+cloud-finops-mcp --transport http
+```
+
+- Route is `/mcp` (the SDK default, and what hosting platforms probe).
+- Binds `0.0.0.0`; port comes from `$PORT`, falling back to `8000`. `--host` and
+  `--port` override both.
+- Runs **stateless**: a new transport and session per request, no server-side
+  session affinity. The server is a read-only retrieval surface with no
+  per-user state, so this costs nothing and is what allows horizontal or
+  serverless scaling.
+- No extra dependency. `uvicorn` and `starlette` already ship as hard
+  dependencies of `mcp`, so there is no `[http]` extra to install.
+
+Nothing about the tools changes between transports. `tests/test_e2e_http.py`
+mirrors the stdio suite over HTTP so the two cannot silently diverge.
+
+Note that a self-hosted MCP server added to Claude as a custom connector will
+**not** render the bundled MCP Apps viewer, however conformant it is: Claude
+gates interactive rendering to connectors accepted into its Connectors
+Directory. See the `Lessons learned` entry in the repo's CLAUDE.md.
+
 ## Example tool calls
 
 Agent prompt: *"Use the cloud-finops MCP to find references for the Optimize phase

--- a/mcp_server/src/cloud_finops_mcp/__main__.py
+++ b/mcp_server/src/cloud_finops_mcp/__main__.py
@@ -2,14 +2,69 @@
 
 from __future__ import annotations
 
+import argparse
 import asyncio
+import os
 
-from .server import run
+from .server import DEFAULT_HTTP_HOST, DEFAULT_HTTP_PORT, run, run_http
 
 
-def main() -> None:
+def _env_port() -> int:
+    """Read ``$PORT``, falling back to the default when unset or unparseable.
+
+    Hosting platforms assign the listening port through this variable. A
+    malformed value falls back rather than crashing on boot: a server that
+    starts on the wrong port fails its health check with a legible symptom,
+    whereas one that refuses to start looks like a build failure.
+    """
+    raw = os.environ.get("PORT")
+    if not raw:
+        return DEFAULT_HTTP_PORT
+    try:
+        return int(raw)
+    except ValueError:
+        return DEFAULT_HTTP_PORT
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="cloud-finops-mcp",
+        description=(
+            "MCP server exposing the OptimNow Cloud FinOps reference library "
+            "and named-pattern playbooks."
+        ),
+    )
+    parser.add_argument(
+        "--transport",
+        choices=["stdio", "http"],
+        default="stdio",
+        help=(
+            "stdio (default) is what a local MCP client spawns. http serves "
+            "streamable HTTP on /mcp for a hosted deployment."
+        ),
+    )
+    parser.add_argument(
+        "--host",
+        default=DEFAULT_HTTP_HOST,
+        help=f"Interface to bind in http mode (default: {DEFAULT_HTTP_HOST}).",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=None,
+        help="Port to bind in http mode. Defaults to $PORT, then 8000.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
     """Synchronous wrapper used by the console-script entry point."""
-    asyncio.run(run())
+    args = _parse_args(argv)
+    if args.transport == "http":
+        port = args.port if args.port is not None else _env_port()
+        asyncio.run(run_http(host=args.host, port=port))
+    else:
+        asyncio.run(run())
 
 
 if __name__ == "__main__":

--- a/mcp_server/src/cloud_finops_mcp/server.py
+++ b/mcp_server/src/cloud_finops_mcp/server.py
@@ -1,9 +1,10 @@
 """MCP server wiring.
 
-Registers the six tools with FastMCP and runs the stdio transport - three over
-references (list / get / find) and three over playbooks (list / get / find).
-The actual tool logic lives in :mod:`cloud_finops_mcp.tools` so it can be
-unit-tested without an MCP client.
+Registers the six tools with FastMCP - three over references (list / get /
+find) and three over playbooks (list / get / find) - and exposes two ways to
+serve them: stdio (the default, what every local MCP client spawns) and
+streamable HTTP (for a hosted deployment). The actual tool logic lives in
+:mod:`cloud_finops_mcp.tools` so it can be unit-tested without an MCP client.
 """
 
 from __future__ import annotations
@@ -16,6 +17,12 @@ from mcp.server.fastmcp import FastMCP
 from . import __version__
 from . import metadata as _metadata
 from . import tools as _tools
+
+# Streamable HTTP defaults. Bind all interfaces because the only reason to run
+# this transport is to be reachable from outside the process. The port is a
+# fallback: `__main__` prefers $PORT, which is how hosting platforms assign one.
+DEFAULT_HTTP_HOST = "0.0.0.0"  # noqa: S104 - see docstring on run_http
+DEFAULT_HTTP_PORT = 8000
 
 # MCP Apps (SEP-1865, extension id io.modelcontextprotocol/ui) resource: a
 # self-contained HTML view that renders get_playbook()'s markdown as
@@ -202,18 +209,65 @@ def find_playbooks(
     )
 
 
-async def run() -> None:
-    """Run the MCP server over the stdio transport."""
-    # Touch both indexes before serving. They are lru_cached and built lazily,
-    # so without this an empty content bundle stays silent until the first tool
-    # call - and then answers it with an empty list rather than an error. The
-    # index builders log at ERROR when they find nothing, which surfaces in the
-    # client's MCP server log at startup instead of never.
+def _warm_indexes() -> None:
+    """Build both content indexes before serving.
+
+    They are lru_cached and built lazily, so without this an empty content
+    bundle stays silent until the first tool call - and then answers it with an
+    empty list rather than an error. The index builders log at ERROR when they
+    find nothing, which surfaces in the client's MCP server log at startup
+    instead of never.
+    """
     _metadata.get_index()
     _metadata.get_playbook_index()
+
+
+async def run() -> None:
+    """Run the MCP server over the stdio transport."""
+    _warm_indexes()
     # FastMCP exposes both synchronous and asynchronous run helpers; we use
     # the async one so the entry point can be called from ``asyncio.run``.
     await mcp.run_stdio_async()
 
 
-__all__ = ["mcp", "run", "__version__"]
+async def run_http(host: str = DEFAULT_HTTP_HOST, port: int = DEFAULT_HTTP_PORT) -> None:
+    """Run the MCP server over the streamable HTTP transport.
+
+    Args:
+        host: interface to bind. Defaults to ``0.0.0.0`` because the only
+            reason to run this transport is to be reachable from outside the
+            process, typically from a platform's ingress.
+        port: TCP port to bind.
+
+    In the 1.x Python SDK, ``host``/``port``/``stateless_http`` are **constructor**
+    keywords on ``FastMCP`` and ``run_streamable_http_async()`` takes no
+    arguments - it reads ``self.settings``. The module-level ``mcp`` instance
+    has to be built at import time because every ``@mcp.tool()`` decorator
+    binds to it, so the settings are assigned here instead. The session manager
+    is constructed lazily on first use, after this function has run, so it
+    picks the values up.
+
+    ``stateless_http`` is deliberate: a new transport and session per request,
+    no server-side session affinity. This server is a pure read-only retrieval
+    surface with no per-user state, so it costs nothing and it is what lets the
+    deployment scale horizontally or run on a serverless platform.
+
+    The route is FastMCP's default ``/mcp``, which is also what hosting
+    platforms expect to find - do not move it without checking the target
+    platform's health check.
+    """
+    _warm_indexes()
+    mcp.settings.host = host
+    mcp.settings.port = port
+    mcp.settings.stateless_http = True
+    await mcp.run_streamable_http_async()
+
+
+__all__ = [
+    "mcp",
+    "run",
+    "run_http",
+    "DEFAULT_HTTP_HOST",
+    "DEFAULT_HTTP_PORT",
+    "__version__",
+]

--- a/mcp_server/tests/test_e2e_http.py
+++ b/mcp_server/tests/test_e2e_http.py
@@ -1,0 +1,201 @@
+"""End-to-end test over the streamable HTTP transport.
+
+Mirrors the stdio suite in ``test_e2e.py``. The two transports share all of the
+tool code, so this is not about re-testing the tools - it is about proving that
+``--transport http`` actually serves them, on the route a hosting platform
+expects, in stateless mode. A silent divergence between the two transports is
+exactly the kind of thing that only surfaces after deployment.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from mcp import ClientSession
+
+# `streamable_http_client`, not the older `streamablehttp_client`: the latter
+# is deprecated in 1.29 and emits a DeprecationWarning. Both names exist across
+# the whole `mcp>=1.28,<2` range (verified against 1.28.0 and 1.29.0), so
+# taking the current one costs no compatibility.
+from mcp.client.streamable_http import streamable_http_client
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SERVER_PKG = "cloud_finops_mcp"
+STARTUP_TIMEOUT_S = 30.0
+
+
+def _free_port() -> int:
+    """Ask the OS for an unused port, then release it.
+
+    Racy in principle, fine in practice for a test fixture and far better than
+    a hardcoded port that collides with whatever else the CI runner is doing.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _wait_until_listening(port: int, proc: subprocess.Popen[bytes]) -> None:
+    deadline = time.monotonic() + STARTUP_TIMEOUT_S
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            raise RuntimeError(
+                f"server exited during startup with code {proc.returncode}"
+            )
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.5):
+                return
+        except OSError:
+            time.sleep(0.1)
+    raise TimeoutError(f"server did not listen on port {port} within {STARTUP_TIMEOUT_S}s")
+
+
+@pytest.fixture(scope="module")
+def http_server_url() -> Iterator[str]:
+    """Serve this checkout over streamable HTTP for the duration of the module."""
+    port = _free_port()
+    src_dir = REPO_ROOT / "mcp_server" / "src"
+    env = os.environ.copy()
+    existing = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = f"{src_dir}{os.pathsep}{existing}" if existing else str(src_dir)
+    # Set PORT to something else on purpose: an explicit --port must win over
+    # the environment, otherwise a platform-injected PORT would silently
+    # override a deliberate command line.
+    env["PORT"] = str(port + 1)
+
+    proc = subprocess.Popen(
+        [sys.executable, "-m", SERVER_PKG, "--transport", "http",
+         "--host", "127.0.0.1", "--port", str(port)],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        _wait_until_listening(port, proc)
+        yield f"http://127.0.0.1:{port}/mcp"
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=10)
+
+
+@pytest.mark.asyncio
+async def test_http_lists_tools(http_server_url: str) -> None:
+    async with streamable_http_client(http_server_url) as (read, write, _):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            result = await session.list_tools()
+            tool_names = {t.name for t in result.tools}
+            assert {
+                "list_references",
+                "get_reference",
+                "find_references",
+                "list_playbooks",
+                "get_playbook",
+                "find_playbooks",
+            }.issubset(tool_names)
+
+
+@pytest.mark.asyncio
+async def test_http_list_references(
+    http_server_url: str, expected_references: int
+) -> None:
+    async with streamable_http_client(http_server_url) as (read, write, _):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            result = await session.call_tool("list_references", {})
+            assert _payload(result)["total"] == expected_references
+
+
+@pytest.mark.asyncio
+async def test_http_list_playbooks(
+    http_server_url: str, expected_playbooks: int
+) -> None:
+    async with streamable_http_client(http_server_url) as (read, write, _):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            result = await session.call_tool("list_playbooks", {})
+            assert _payload(result)["total"] == expected_playbooks
+
+
+@pytest.mark.asyncio
+async def test_http_get_playbook(http_server_url: str) -> None:
+    async with streamable_http_client(http_server_url) as (read, write, _):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            result = await session.call_tool(
+                "get_playbook", {"name": "aws-zombie-nat-gateway"}
+            )
+            payload = _payload(result)
+            assert payload["name"] == "aws-zombie-nat-gateway"
+            assert "## Detection" in payload["content"]
+
+
+@pytest.mark.asyncio
+async def test_http_serves_the_ui_resource(http_server_url: str) -> None:
+    """The MCP Apps resource must survive the transport change.
+
+    It is read from disk at import time and served as a resource, so there is
+    no reason for it to differ - which is precisely why an untested assumption
+    would go unnoticed until a host asked for it over HTTP.
+    """
+    async with streamable_http_client(http_server_url) as (read, write, _):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            resources = await session.list_resources()
+            viewer = next(
+                r
+                for r in resources.resources
+                if str(r.uri) == "ui://cloud-finops/playbook-viewer"
+            )
+            assert viewer.mimeType == "text/html;profile=mcp-app"
+
+            read_result = await session.read_resource(viewer.uri)
+            html = next(c.text for c in read_result.contents if hasattr(c, "text"))
+            assert "<!DOCTYPE html>" in html
+            assert "ui/initialize" in html
+
+            tools = await session.list_tools()
+            get_playbook_tool = next(t for t in tools.tools if t.name == "get_playbook")
+            assert (
+                get_playbook_tool.meta["ui"]["resourceUri"]
+                == "ui://cloud-finops/playbook-viewer"
+            )
+
+
+@pytest.mark.asyncio
+async def test_http_is_stateless_across_sessions(http_server_url: str) -> None:
+    """Two independent connections both work against the same process.
+
+    ``run_http`` sets ``stateless_http=True``. If that ever regresses, a second
+    connection to a server that has torn down the first one's session is where
+    it shows up first - and it is the failure mode a load-balanced or
+    serverless deployment would hit immediately.
+    """
+    for _ in range(2):
+        async with streamable_http_client(http_server_url) as (read, write, _):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                result = await session.call_tool(
+                    "find_playbooks", {"scope": "aws", "waste_category": "idle"}
+                )
+                assert _payload(result)["total"] >= 1
+
+
+def _payload(result) -> dict:
+    """Extract and JSON-decode the structured tool result."""
+    if getattr(result, "structuredContent", None):
+        return result.structuredContent
+    text = next(c.text for c in result.content if hasattr(c, "text"))
+    return json.loads(text)


### PR DESCRIPTION
## What

`--transport http` serves the same six tools over streamable HTTP on `/mcp`, for a hosted deployment. **stdio stays the default and is untouched** — every local client keeps spawning the console script and getting identical behaviour.

```bash
cloud-finops-mcp                    # stdio, unchanged
cloud-finops-mcp --transport http   # streamable HTTP on /mcp
```

Binds `0.0.0.0`, port from `$PORT` falling back to `8000`; `--host` / `--port` override both.

## Three SDK details that drove the shape

Verified by running against `mcp` 1.29.0, not from memory.

- **`host`, `port` and `stateless_http` are FastMCP *constructor* keywords**, and `run_streamable_http_async()` takes no arguments — it reads `self.settings`. The module-level `mcp` instance has to exist at import time because every `@mcp.tool()` binds to it, so `run_http` assigns the settings before serving. The session manager is built lazily afterwards and picks them up. The alternative, converting to a factory, would have touched every decorator for no gain.
- **`uvicorn` and `starlette` are already hard dependencies of `mcp`**, so there is no `[http]` extra here. Adding one would imply they aren't, and create a doc obligation for nothing.
- **`/mcp` is the SDK's default route** and also what hosting platforms probe for a health check, so it is left alone.

## Stateless is deliberate

The server is a read-only retrieval surface with no per-user state, so per-request sessions cost nothing and are what allow horizontal or serverless scaling. `test_http_is_stateless_across_sessions` opens two independent connections against the same process — the failure mode a load-balanced deployment would hit first.

## Tests

New `tests/test_e2e_http.py` mirrors the stdio end-to-end suite over HTTP: tool listing, references, playbooks, `get_playbook`, and the MCP Apps resource with its `_meta.ui.resourceUri`. The point is not to re-test the tools — both transports share all the tool code — it is that a silent divergence between transports only surfaces after deployment.

The fixture sets `$PORT` to a *different* value than `--port` on purpose, so a platform-injected `PORT` silently overriding an explicit command line would fail the test.

74 passed locally.

## Dependency pin

Untouched. The test client imports `streamable_http_client` rather than the deprecated `streamablehttp_client`; both names exist across the whole `mcp>=1.28,<2` range (checked against 1.28.0 and 1.29.0), so taking the current name costs no compatibility.

## Deliberately not included

**No `alpic.json`.** Alpic's docs say most projects deploy without extra configuration and that it auto-detects Python projects, so a hand-written config could break detection that would otherwise work. The first real deploy will say what, if anything, is needed. Same discipline as #135: do not build infrastructure ahead of the evidence.

**No version bump.** Content PR, per the release-train rule.

## Context

Serving over HTTP is a prerequisite for a hosted deployment, which was decided on distribution grounds — letting a non-technical user paste a URL into claude.ai instead of installing a PyPI package. It is explicitly **not** a step toward the interactive playbook viewer: per the `Lessons learned` entry added in #135, Claude gates MCP Apps rendering to connectors accepted into its Connectors Directory, and no amount of hosting changes that. `mcp_server/README.md` says so at the point where a reader would otherwise assume the opposite.

Note that Alpic also accepts a stdio server and converts the transport in its gateway, so this PR is not strictly required to deploy there. It is here so the deployment does not depend on one vendor's gateway.

## Pre-existing, not touched

`ruff check` reports one import-sort error in `tests/test_conformance.py` that is present on `main` and unrelated to this change. `ruff` is not currently wired into the `CI` workflow. Left alone to keep this diff scoped; worth a separate cleanup.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QRJz5wYSTjiCQ5ndmWrd5J)_