### PR TITLE
Bump gh-action-pypi-publish to v1.14.2 so PyPI accepts metadata 2.5

### DIFF
--- a/.github/workflows/auto-tag-on-plugin-bump.yml
+++ b/.github/workflows/auto-tag-on-plugin-bump.yml
@@ -215,7 +215,16 @@ jobs:
           name: pypi-dist
           path: dist/
 
+      # Pinned at v1.14.2, not v1.14.0. hatchling (pinned `>=1.18,<2`, so it
+      # floats within the major) now emits `Metadata-Version: 2.5`, and the
+      # twine bundled in v1.14.0 rejects it outright:
+      #   InvalidDistribution: '2.5' is not a valid metadata version
+      # That broke the 1.28.1 publish on 2026-08-16 after the tag, the GitHub
+      # Release and the wheel build had all succeeded. v1.14.2 ships twine 7,
+      # which accepts metadata 2.5. Both this workflow and its counterpart must
+      # move together - they are duplicated on purpose (see the comment above
+      # the build job) and a fix applied to only one leaves the other broken.
       - name: Publish via trusted publishing
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
         with:
           packages-dir: dist/

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -120,7 +120,16 @@ jobs:
           name: pypi-dist
           path: dist/
 
+      # Pinned at v1.14.2, not v1.14.0. hatchling (pinned `>=1.18,<2`, so it
+      # floats within the major) now emits `Metadata-Version: 2.5`, and the
+      # twine bundled in v1.14.0 rejects it outright:
+      #   InvalidDistribution: '2.5' is not a valid metadata version
+      # That broke the 1.28.1 publish on 2026-08-16 after the tag, the GitHub
+      # Release and the wheel build had all succeeded. v1.14.2 ships twine 7,
+      # which accepts metadata 2.5. Both this workflow and its counterpart must
+      # move together - they are duplicated on purpose (see the comment above
+      # the build job) and a fix applied to only one leaves the other broken.
       - name: Publish via trusted publishing
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
         with:
           packages-dir: dist/


### PR DESCRIPTION
## The failure

The 1.28.1 release tagged, cut its GitHub Release and built its wheel, then died on upload ([run 31969305291](https://github.com/OptimNow/cloud-finops-skills/actions/runs/31969305291/job/95219157447)):

```
Checking dist/cloud_finops_mcp-1.28.1-py3-none-any.whl:
ERROR InvalidDistribution: Invalid distribution metadata:
'2.5' is not a valid metadata version
```

So `v1.28.1` and its GitHub Release exist, but PyPI is still on 1.28.0.

## Root cause: one side floats, the other is frozen

`hatchling` is pinned `>=1.18,<2`, so it floats within the major and now resolves to **1.32.0**, which emits `Metadata-Version: 2.5`. The publish action was pinned to **v1.14.0**, whose bundled twine predates that metadata revision and rejects the wheel before it is ever uploaded.

Nothing in the 1.28.1 content caused this. It was latent and would have broken **any** release from the first hatchling that emitted 2.5 onwards. It surfaced now only because this is the first release since.

## Verified, not assumed

- Built the wheel locally with the same pins and read `Metadata-Version: 2.5` straight out of its `METADATA` (hatchling 1.32.0).
- Upstream release notes: **v1.14.2** is the release that bumps twine to v7 specifically so "sdists and wheels containing core packaging metadata v2.5" can be uploaded. v1.14.1 and v1.14.0 do not.
- Resolved the tag to its dereferenced commit SHA with `git ls-remote`, keeping the existing pin-by-SHA convention (`dc37677…` = `v1.14.2^{}`, exactly as `cef2210…` was `v1.14.0^{}`).

## Both workflows, on purpose

`auto-tag-on-plugin-bump.yml` and `publish-mcp.yml` duplicate these steps deliberately — PyPI trusted publishing does not support reusable workflows, as the comment above the build job explains. Fixing only one would leave the **manual recovery path broken**, which is precisely the path needed to finish publishing 1.28.1.

A comment above each pin records why it is at v1.14.2 and that the two must move together, so a future "tidy the pins" pass does not silently reintroduce this.

## How to finish the 1.28.1 publish after merging

The tag already exists, so a re-run of the auto-tag workflow would skip. Use the documented recovery path instead — dispatch `publish-mcp.yml` **from `main`** (so it picks up this fixed workflow definition) with:

```
tag: v1.28.1
```

It checks out `inputs.tag` for the source, so the wheel is still built from the 1.28.1 commit; only the workflow definition comes from `main`.

Then confirm the marker landed, which is what the MCP Registry entry depends on:

```bash
curl -s https://pypi.org/pypi/cloud-finops-mcp/json \
  | python -c "import json,sys; d=json.load(sys.stdin); print(d['info']['version']); print('mcp-name: io.github.OptimNow/cloud-finops' in (d['info']['description'] or ''))"
```

## Worth considering separately

This class of break recurs whenever a floating build backend meets a frozen publisher. Options, not taken here to keep the diff to the fix: upper-bound `hatchling` and bump it deliberately, or add a `twine check` step against the freshly built wheel in the build job so the failure surfaces before the tag and Release are created rather than after.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QRJz5wYSTjiCQ5ndmWrd5J)_