### PR TITLE
Make the release workflows fail before the irreversible step

### DIFF
--- a/.github/workflows/auto-tag-on-plugin-bump.yml
+++ b/.github/workflows/auto-tag-on-plugin-bump.yml
@@ -28,7 +28,73 @@ permissions:
   contents: write   # required to push the new tag and create the release
 
 jobs:
+  # Runs BEFORE anything is created. On 2026-08-16 the 1.28.1 release pushed a
+  # tag, cut a GitHub Release and built a wheel, and only then discovered that
+  # twine refused the wheel's metadata version. The tag and Release were left
+  # pointing at something that had never been publishable, and the only way
+  # forward was a manual recovery dispatch.
+  #
+  # Building and running `twine check --strict` here costs about thirty
+  # seconds and moves that class of failure to before the first irreversible
+  # side effect. The build is deliberately duplicated rather than shared with
+  # build-mcp: sharing it would mean tagging first to have a ref to check out,
+  # which is exactly the ordering this job exists to avoid.
+  verify-package:
+    name: Verify the wheel is publishable
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout pushed commit
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: '3.12'
+
+      - name: Pin pyproject version to plugin.json
+        working-directory: mcp_server
+        run: |
+          set -euo pipefail
+          version=$(jq -r '.version' ../.claude-plugin/plugin.json)
+          VERSION="$version" python - <<'PY'
+          import os, pathlib, re
+          version = os.environ["VERSION"]
+          path = pathlib.Path("pyproject.toml")
+          text = path.read_text(encoding="utf-8")
+          new = re.sub(r'^version = ".*"', f'version = "{version}"', text, count=1, flags=re.M)
+          path.write_text(new, encoding="utf-8")
+          print(f"pyproject.toml version pinned to {version}")
+          PY
+
+      - name: Sync references into bundled data/
+        working-directory: mcp_server
+        run: python scripts/sync_references.py
+
+      - name: Install build tooling
+        run: python -m pip install --upgrade pip build twine
+
+      - name: Build sdist + wheel
+        working-directory: mcp_server
+        run: python -m build
+
+      - name: Check the artefacts the way PyPI will
+        working-directory: mcp_server
+        run: |
+          set -euo pipefail
+          python -m twine check --strict dist/*
+          echo "--- metadata version actually emitted ---"
+          python - <<'PY'
+          import glob, zipfile
+          wheel = glob.glob("dist/*.whl")[0]
+          with zipfile.ZipFile(wheel) as z:
+              name = next(n for n in z.namelist() if n.endswith("METADATA"))
+              print(z.read(name).decode().splitlines()[0])
+          PY
+
   tag-and-release:
+    needs: verify-package
     runs-on: ubuntu-latest
     outputs:
       # Surfaced so the downstream build-mcp / publish-mcp jobs know which tag

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -34,8 +34,57 @@ permissions:
   id-token: write  # required for PyPI trusted publishing (OIDC)
 
 jobs:
+  # Normalise and validate the dispatch input before anything tries to use it.
+  #
+  # Git refs are case sensitive. A dispatch with `V1.28.1` instead of
+  # `v1.28.1` used to reach actions/checkout unchanged, which then spent three
+  # minutes retrying a fetch for a ref that does not exist and gave up with
+  # "The process '/usr/bin/git' failed with exit code 1" - a message that names
+  # neither the tag nor the reason. It also broke the version derivation below,
+  # since `${TAG#v}` does not strip a capital V, so a run that survived
+  # checkout would have pinned the package to version "V1.28.1".
+  #
+  # Failing here instead costs seconds and says which tag was not found.
+  resolve-tag:
+    name: Resolve and validate the tag
+    runs-on: ubuntu-latest
+    outputs:
+      ref: ${{ steps.resolve.outputs.ref }}
+    steps:
+      - name: Resolve tag
+        id: resolve
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+          FALLBACK_REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${INPUT_TAG}" ]]; then
+            # push:tags path - github.ref is already refs/tags/<tag>.
+            echo "ref=${FALLBACK_REF}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          tag="${INPUT_TAG}"
+          tag="${tag#V}"          # tolerate a capitalised prefix
+          tag="${tag#v}"
+          tag="v${tag}"           # and a missing one
+          if [[ "$tag" != "${INPUT_TAG}" ]]; then
+            echo "::notice::normalised tag input '${INPUT_TAG}' to '${tag}'"
+          fi
+
+          # Public repo, so an unauthenticated ls-remote is enough and avoids
+          # a full checkout just to answer "does this tag exist".
+          if ! git ls-remote --exit-code --tags \
+               "https://github.com/${GITHUB_REPOSITORY}" "refs/tags/${tag}" >/dev/null 2>&1; then
+            echo "::error::tag ${tag} does not exist in ${GITHUB_REPOSITORY}. Check the Releases page for the exact tag name; refs are case sensitive."
+            exit 1
+          fi
+          echo "Resolved to ${tag}"
+          echo "ref=${tag}" >> "$GITHUB_OUTPUT"
+
   build:
     name: Build wheel + sdist
+    needs: resolve-tag
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
@@ -43,10 +92,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
-          # push:tags -> github.ref is refs/tags/<tag>; default checkout grabs
-          # the tagged commit. workflow_dispatch -> use the explicit tag input
-          # so manual recovery can target any historical tag.
-          ref: ${{ inputs.tag || github.ref }}
+          # Always the resolved ref from the job above: refs/tags/<tag> on a
+          # push, the normalised and existence-checked tag on a dispatch.
+          ref: ${{ needs.resolve-tag.outputs.ref }}
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
@@ -56,11 +104,12 @@ jobs:
       - name: Resolve version from tag
         id: version
         env:
-          INPUT_TAG: ${{ inputs.tag }}
+          RESOLVED_REF: ${{ needs.resolve-tag.outputs.ref }}
         run: |
-          # workflow_dispatch -> use the explicit tag input.
-          # push:tags -> GITHUB_REF_NAME is the tag.
-          TAG="${INPUT_TAG:-${GITHUB_REF_NAME}}"
+          # One source of truth for both triggers. Strips a refs/tags/ prefix
+          # on the push path and is a bare tag already on the dispatch path,
+          # so the capitalisation bug cannot reappear here either.
+          TAG="${RESOLVED_REF##*/}"
           VERSION="${TAG#v}"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Building cloud-finops-mcp ${VERSION} from tag ${TAG}"


### PR DESCRIPTION
## Why

Two failures on 2026-08-16, same shape twice: what was wrong got discovered long after the point where it could still be handled cleanly, and the error message did not name it.

## 1. `verify-package` — new first job in `auto-tag-on-plugin-bump.yml`

The 1.28.1 release pushed a tag, cut a GitHub Release and built a wheel, and **only then** found that twine refused the wheel's metadata version. Tag and Release were left pointing at something that had never been publishable, and the only way forward was a manual recovery dispatch.

The new job builds and runs `twine check --strict` **before `tag-and-release` runs at all**, moving that class of failure ahead of the first irreversible side effect. It also prints the metadata version the build actually emitted — the single line that would have made the original diagnosis immediate instead of a research exercise.

The build is duplicated rather than shared with `build-mcp` deliberately: sharing it would require a tag to check out, which is exactly the ordering this job exists to avoid. Cost is about thirty seconds, on a workflow that only fires when `plugin.json` changes.

## 2. `resolve-tag` — new first job in `publish-mcp.yml`

Git refs are case sensitive. A dispatch with `V1.28.1` reached `actions/checkout` unchanged, which retried a fetch for a nonexistent ref for three minutes and gave up with:

```
The process '/usr/bin/git' failed with exit code 1
```

naming neither the tag nor the reason. The same input would also have poisoned the version derivation further down, since `${TAG#v}` does not strip a capital `V` — a run that somehow survived checkout would have pinned the package to version `V1.28.1`.

The job normalises the prefix, checks the tag exists with `git ls-remote`, and fails in seconds with a message that names the tag. Both the checkout ref and the version now derive from its single output, so they cannot drift apart.

## Verified, not assumed

Ran the resolve script against the real repository:

| Input | Result |
|---|---|
| `V1.28.1` | → `v1.28.1` |
| `v1.28.1` | → `v1.28.1` |
| `1.28.1` | → `v1.28.1` |
| `v9.9.9` | fails: `tag v9.9.9 does not exist in OptimNow/cloud-finops-skills…` |
| *(empty, push path)* | passes `refs/tags/v1.28.1` through unchanged |

And ran `twine check --strict` against a locally built wheel using twine 7.0.0 — the same version `gh-action-pypi-publish` v1.14.2 bundles — which **PASSED** on metadata 2.5. So the new guard does not false-positive on the current pins.

## Merge order

This should land **before** the 1.29.0 release PR, so that release is the first real exercise of both guards. If `verify-package` fails on it, that is the guard doing its job and no tag will have been created.

## Not in this PR

No version bump, per the release-train rule. The `hatchling` upper-bound question raised in #138 is still open and deliberately left alone: with `twine check` now running before the tag, a future metadata bump fails loudly and early rather than silently, which was the actual problem.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QRJz5wYSTjiCQ5ndmWrd5J)_