### PR TITLE
Release 1.29.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Cloud Financial Management references and tooling by OptimNow.",
-    "version": "1.28.1"
+    "version": "1.29.0"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloud-finops",
-  "version": "1.28.1",
+  "version": "1.29.0",
   "description": "Expert FinOps guidance for cloud, AI, SaaS, and data-platform spend (multi-provider, model-agnostic).",
   "author": {
     "name": "OptimNow",

--- a/mcp_server/pyproject.toml
+++ b/mcp_server/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cloud-finops-mcp"
-version = "1.28.1"
+version = "1.29.0"
 description = "MCP server exposing the OptimNow Cloud FinOps skill (reference library + named-pattern playbooks) as queryable tools."
 readme = "README.md"
 license = { text = "CC-BY-SA-4.0" }

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/OptimNow/cloud-finops-skills",
     "source": "github"
   },
-  "version": "1.28.1",
+  "version": "1.29.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "cloud-finops-mcp",
-      "version": "1.28.1",
+      "version": "1.29.0",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## ⚠️ Merging this publishes to PyPI

Bumps all four version fields together: `plugin.json`, `marketplace.json` `metadata.version`, `mcp_server/pyproject.toml`, and both version fields in `server.json`. Merging tags `v1.29.0`, cuts a GitHub Release, and publishes `cloud-finops-mcp` 1.29.0 to PyPI. A PyPI version number cannot be reused.

**Merge #139 first.** It adds the two guards that make this release safe to run, and this release is their first real exercise.

## Why minor, not patch

1.28.1 was a metadata-only release. Enough user-visible work has accumulated since 1.28.0 to warrant a real one:

- **Streamable HTTP transport alongside stdio** (#137). stdio stays the default; `--transport http` serves the same six tools on `/mcp` for a hosted deployment. This is the feature that makes it a minor.
- **Two SEP-1865 conformance fixes in the playbook viewer** (#135), found by auditing against the spec and confirmed by the first validation of the viewer in a real MCP Apps host. The `ui/initialize` handshake now carries `protocolVersion` and `clientInfo`, and links route through the host's `ui/open-link` instead of a `target="_blank"` the sandbox silently swallows.
- **MCP Registry entry**: the `mcp-name` ownership marker in the package README and a root `server.json` declaring the PyPI package (#136).
- **Publish chain repaired and hardened** (#138, #139).

## What happens to 1.28.1

It tagged and cut a GitHub Release but never reached PyPI — the publish failed on metadata 2.5. Rather than recover a version whose only content was the registry marker, that content ships here instead. `v1.28.1` stays as a GitHub-only tag; nothing depends on it, and no PyPI release ever claimed that number.

If you would rather not leave a tag without a PyPI counterpart, deleting the tag and its Release is a separate decision — say so and I will do it, but it is not required and I would leave it.

## server.json

Both version fields move to 1.29.0 — the entry version and the declared package version — so the registry claim matches what will actually be on PyPI. Re-validated against the official [`2025-12-11` server schema](https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json).

## After merge: finish the registry entry

Once PyPI shows 1.29.0, from the repo root:

```bash
mcp-publisher login github
mcp-publisher publish
curl -s https://pypi.org/pypi/cloud-finops-mcp/json \
  | python -c "import json,sys; d=json.load(sys.stdin); print(d['info']['version']); print('mcp-name: io.github.OptimNow/cloud-finops' in (d['info']['description'] or ''))"
```

The second command must print `1.29.0` then `True` before `publish` can succeed.

## Checks

`check-marketplace-version.sh`, `check-docs-drift.sh`, `check-llms-txt.sh` pass. `check-skill-description.sh` warns at 987/1024, pre-existing and untouched. 74 tests pass.

No content or reference changes, so the marketplace description and the FCP coverage matrix are deliberately untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QRJz5wYSTjiCQ5ndmWrd5J)_