### PR TITLE
Add the dated-price rule to the response doctrine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -733,6 +733,17 @@ a `description` field for the Claude.ai upload skill loader (see "Content rules"
 - **Name a vendor only with a viability caveat** if it is early-stage. Recommending a
   seed-stage tool into a client's production path is a continuity risk the reference
   should flag, not bury.
+- **Write mechanics, not price figures.** A reference file is the wrong container for
+  a volatile number: it ships frozen inside a PyPI package and a dozen tool
+  integrations, so an absolute price goes stale there within weeks and nothing in the
+  distribution chain corrects it (the June 2025 AWS GPU price cuts sat uncorrected for
+  14 months for exactly this reason). Ratios and mechanics are durable and belong here:
+  the batch discount, the cache-read multiplier, commitment term structure, the shape of
+  a break-even calculation. Absolute $/1M-token and $/hour figures belong in the AI
+  Pricing Hub (<https://optimtoken.optimnow.io>), which is queried live. Where a worked
+  example genuinely needs a number to be legible, keep one, mark it illustrative, and
+  date it inline. The reader-facing version of this rule is the "Price figures" section
+  in SKILL.md and POWER.md.
 
 **License**
 - All content is licensed under [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/)

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -438,6 +438,10 @@ billing mechanics, pricing models, and proven optimisation patterns. Rely on
 the provided references when available. Do not invent pricing figures, discount
 percentages, or billing rules.
 
+The references are authoritative on billing MECHANICS, which are durable. They are
+NOT authoritative on price FIGURES, which are volatile: any absolute price in them
+is illustrative and may be out of date.
+
 RESPONSE CONTRACT
 1) Context and positioning
 - Identify the relevant cloud domain(s) and provider(s).
@@ -467,6 +471,18 @@ BEHAVIORAL RULES
 - If required information is missing from the references, state the limitation.
 - If outside cloud cost or FinOps scope, say so briefly.
 - Keep tone structured, professional, and concise.
+
+PRICE FIGURES
+- Never quote a price without its as-of date and source: "$X per 1M input tokens
+  (list price, <source>, <date>)". A figure with no date is not usable in a client
+  deliverable.
+- If a live pricing tool is available, call it before quoting any token or instance
+  price. Otherwise refer the user to https://optimtoken.optimnow.io and mark any
+  figure you give as illustrative.
+- Quote mechanics and ratios (batch discount, cache-read multiplier, commitment term
+  structure) with confidence. Date every absolute number.
+- Never interpolate a missing price from a neighbouring model, a previous generation,
+  or another region. If the figure is not available, say so.
 
 OUTPUT FORMAT
 Use headers:

--- a/install.sh
+++ b/install.sh
@@ -576,6 +576,17 @@ waste patterns, retrieve the matching `playbook-<slug>.md` knowledge file.
 4. Connect cost recommendations to business outcomes.
 5. Recommend progressively - quick wins first, structural changes second.
 6. Reference open-source FinOps tools (FinOps Toolkit, OpenCost, Kubecost, Infracost, etc.) where they fit.
+7. Never quote a price without its as-of date and source - see Price figures below.
+
+## Price figures
+
+Billing mechanics are durable. Price figures are volatile and go stale in these
+knowledge files within weeks. Treat the two differently.
+
+- Quote mechanics and ratios (batch discount, cache-read multiplier, commitment term structure) with confidence. Any absolute price in the knowledge files is illustrative, and must be dated when you repeat it.
+- Format every figure as "$X per 1M input tokens (list price, <source>, <date>)". A figure with no date is not usable in a client deliverable.
+- For a current figure, refer the user to https://optimtoken.optimnow.io rather than quoting from memory.
+- Never interpolate a missing price from a neighbouring model, a previous generation, or another region. If the figure is not available, say so.
 
 ## Response format
 
@@ -635,6 +646,17 @@ named waste patterns, look up the matching `## playbook: <slug>` section inside
 4. Connect cost recommendations to business outcomes.
 5. Recommend progressively - quick wins first, structural changes second.
 6. Reference open-source FinOps tools (FinOps Toolkit, OpenCost, Kubecost, Infracost, etc.) where they fit.
+7. Never quote a price without its as-of date and source - see Price figures below.
+
+## Price figures
+
+Billing mechanics are durable. Price figures are volatile and go stale in these
+knowledge files within weeks. Treat the two differently.
+
+- Quote mechanics and ratios (batch discount, cache-read multiplier, commitment term structure) with confidence. Any absolute price in the knowledge files is illustrative, and must be dated when you repeat it.
+- Format every figure as "$X per 1M input tokens (list price, <source>, <date>)". A figure with no date is not usable in a client deliverable.
+- For a current figure, refer the user to https://optimtoken.optimnow.io rather than quoting from memory.
+- Never interpolate a missing price from a neighbouring model, a previous generation, or another region. If the figure is not available, say so.
 
 ## Response format
 

--- a/skills/cloud-finops/POWER.md
+++ b/skills/cloud-finops/POWER.md
@@ -271,6 +271,30 @@ methodology questions - not for routine billing-mechanics queries.
 4. **Connect cost to value** - every recommendation should link spend to a business outcome
 5. **Recommend progressively** - quick wins first, structural changes second
 6. **Reference open-source FinOps tools** (FinOps Toolkit, OpenCost, Kubecost, Infracost, etc.) where they genuinely fit the problem
+7. **Never quote an undated price** - see "Price figures" below
+
+---
+
+## Price figures (apply whenever a number is quoted)
+
+Billing **mechanics** are durable and are what these references are for. Price
+**figures** are volatile and go stale here within weeks. Treat the two differently.
+
+1. **Prefer a live source.** If a pricing tool is available in the session (for
+   example the OptimNow AI Pricing Hub: `compare-llm-models`, `estimate-llm-cost`,
+   `compare-compute-pricing`), call it before quoting any token or instance price.
+   If no such tool is available, point the user at <https://optimtoken.optimnow.io>
+   rather than quoting from memory.
+2. **Every figure carries its as-of date and source.** Write `$X per 1M input tokens
+   (list price, <source>, <date>)`, not `$X per 1M input tokens`. A figure with no
+   date cannot be used in a client deliverable.
+3. **Figures inside these references are illustrative, not authoritative.** They exist
+   to make a worked example concrete. The durable, quotable part is the *mechanics*:
+   batch and cache-read multipliers, commitment term structure, the shape of a
+   break-even calculation. Quote those with confidence; date the absolute numbers.
+4. **Never interpolate.** If the live source has no figure for the model, SKU, or
+   region asked about, say so. Do not derive one from a neighbouring model, a previous
+   generation, or another region.
 
 ---
 

--- a/skills/cloud-finops/SKILL.md
+++ b/skills/cloud-finops/SKILL.md
@@ -77,6 +77,30 @@ methodology questions - not for routine billing-mechanics queries.
 4. **Connect cost to value** - every recommendation should link spend to a business outcome
 5. **Recommend progressively** - quick wins first, structural changes second
 6. **Reference open-source FinOps tools** (FinOps Toolkit, OpenCost, Kubecost, Infracost, etc.) where they genuinely fit the problem
+7. **Never quote an undated price** - see "Price figures" below
+
+---
+
+## Price figures (apply whenever a number is quoted)
+
+Billing **mechanics** are durable and are what these references are for. Price
+**figures** are volatile and go stale here within weeks. Treat the two differently.
+
+1. **Prefer a live source.** If a pricing tool is available in the session (for
+   example the OptimNow AI Pricing Hub: `compare-llm-models`, `estimate-llm-cost`,
+   `compare-compute-pricing`), call it before quoting any token or instance price.
+   If no such tool is available, point the user at <https://optimtoken.optimnow.io>
+   rather than quoting from memory.
+2. **Every figure carries its as-of date and source.** Write `$X per 1M input tokens
+   (list price, <source>, <date>)`, not `$X per 1M input tokens`. A figure with no
+   date cannot be used in a client deliverable.
+3. **Figures inside these references are illustrative, not authoritative.** They exist
+   to make a worked example concrete. The durable, quotable part is the *mechanics*:
+   batch and cache-read multipliers, commitment term structure, the shape of a
+   break-even calculation. Quote those with confidence; date the absolute numbers.
+4. **Never interpolate.** If the live source has no figure for the model, SKU, or
+   region asked about, say so. Do not derive one from a neighbouring model, a previous
+   generation, or another region.
 
 ---
 


### PR DESCRIPTION
## Why

Billing **mechanics** are durable. Price **figures** are not.

A figure written into a reference file ships frozen inside a PyPI package and a dozen tool integrations, so it goes stale within weeks and nothing in the distribution chain corrects it. That is how the June 2025 AWS GPU price cuts sat wrong for 14 months (fixed in #129), and it is why the pipeline now carries a rotating quarterly re-verification pass.

Meanwhile the AI Pricing Hub (<https://optimtoken.optimnow.io>) already serves those figures live, dated, with provenance per provider and per column. The skill should route to it rather than compete with it.

This PR ships the doctrine half of that. It changes no reference content.

## What changes

The rule: never quote a price without its as-of date and source; prefer a live pricing tool over quoting from memory; treat figures inside the references as illustrative rather than authoritative; never interpolate a missing price from a neighbouring model, generation, or region.

Applied in all four places the response doctrine lives, so no entry point is left behind:

| File | Change |
|---|---|
| `skills/cloud-finops/SKILL.md` | New "Price figures" section, plus step 7 in the reasoning sequence |
| `skills/cloud-finops/POWER.md` | Same, mirrored for Kiro |
| `INSTALLATION.md` | `PRICE FIGURES` block in the model-agnostic response contract, so GPT and Gemini inherit it |
| `install.sh` | Both generated instruction sets (ChatGPT inline, grouped) |
| `CLAUDE.md` | The author-facing half, under Content rules / Sourcing, so new content does not reintroduce undated figures |

## Notes for review

- The doctrine names the hub's MCP tools (`compare-llm-models`, `estimate-llm-cost`, `compare-compute-pricing`) but degrades cleanly to the public URL when no such tool is in the session, so it is safe to merge before the hub MCP is wired up.
- Adding the hub to the domain routing table and to INSTALLATION.md as a companion MCP is deliberately **not** in this PR - that is a separate decision about an optional dependency.
- No version bump (release-train rule).

## Checks

`check-artefact-size`, `check-docs-drift`, `check-llms-txt`, `check-marketplace-version` all pass. `check-skill-description` warns at 987/1024 chars, unchanged by this PR. `bash -n install.sh` clean.

## Follow-up

Purging the ~22 absolute figures currently sitting in 9 reference files is the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
