### PR TITLE
Purge volatile price figures from the references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,17 @@ which is how the June 2025 AWS GPU price cuts went uncorrected for 14 months
 (fixed in PR #129). Procedure and rotation table in
 `pipeline/MONTHLY_WORKFLOW.md`.
 
+**Scope reduction (2026-08-17).** The re-verification pass exists because absolute
+figures sat in the reference files with nothing to correct them. The dated-price
+rule (PR #141) and the figure purge (PR #142) remove most of that surface: LLM
+token rates are now expressed as ratios and multipliers routed to the AI Pricing
+Hub, and the figures that remain (SaaS seat prices, storage and egress rates,
+which the hub does not serve) carry an inline as-of date. The rotation still
+matters for those, but the pass is now a check on a short dated list rather than
+a hunt across every reference. When updating the rotation table, verify the
+*dates* on the remaining banners rather than re-pricing tables that no longer
+carry absolute rates.
+
 The pipeline is human-in-the-loop: nothing is changed automatically. Every
 proposed update goes through preview, approve/reject, and a guard-railed
 execute pass before touching any reference file.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,9 +30,15 @@ differ.
 cloud-finops-skills/
 ├── CLAUDE.md              <- You are here
 ├── README.md              <- Public-facing documentation
+├── AGENTS.md              <- Agent-facing repo brief (truncated tree, defers to CLAUDE.md)
 ├── INSTALLATION.md        <- Setup instructions (12 tool integrations) + response contract
 ├── LICENSE.md             <- CC BY-SA 4.0
+├── llms.txt               <- Machine-readable "Key files" list (CI-gated)
 ├── install.sh             <- One-liner installer script
+├── server.json            <- MCP Registry manifest
+├── .claude-plugin/        <- plugin.json + marketplace.json (versions bump together)
+├── .github/workflows/     <- ci, marketplace-version-check, auto-tag-on-plugin-bump,
+│                             publish-mcp, mcp-install-smoke, release
 ├── assets/                <- Screenshots for installation guide
 ├── skills/cloud-finops/          <- The skill (this is what gets installed)
 │   ├── SKILL.md           <- Entry point + domain router
@@ -79,21 +85,32 @@ cloud-finops-skills/
 │                                README.md index. RAG-friendly chunks routed from
 │                                SKILL.md / POWER.md "named waste pattern" rows
 ├── mcp_server/            <- `cloud-finops-mcp` PyPI package (six MCP tools,
-│                             faceted retrieval over references + playbooks)
+│                             faceted retrieval over references + playbooks;
+│                             stdio + streamable-HTTP transports; MCP Apps
+│                             `ui://cloud-finops/playbook-viewer` resource)
 ├── scripts/               <- `fcp-coverage.sh` (parses FCP frontmatter, emits
-│                             `fcp-coverage.md` matrix)
+│                             `fcp-coverage.md` matrix) plus five CI guards run by
+│                             the `CI` workflow: check-artefact-size,
+│                             check-docs-drift, check-llms-txt,
+│                             check-marketplace-version, check-skill-description
 ├── fcp-coverage.md        <- Generated FCP capability coverage matrix (22 caps)
 ├── .gitattributes         <- Force LF on *.sh for Windows checkouts
 └── pipeline/              <- Content update pipeline (gitignored, private)
-    ├── run_scan.py        <- Weekly scan entry point
-    ├── run_apply.py       <- Review and apply entry point
+    ├── run_scan.py        <- Fortnightly scan entry point
+    ├── run_apply.py.FROZEN <- Review and apply entry point, frozen since the
+    │                          May 2026 truncation incident (see Roadmap P1)
+    ├── run_report.py      <- Per-run report rendering
+    ├── smoke_test.py      <- Real-API smoke test, run before any batch
     ├── config.yaml        <- Pipeline configuration
-    ├── sources.yaml       <- 29 content sources (RSS, pricing pages, blogs)
+    ├── sources.yaml       <- ~30 content sources (RSS, pricing pages, blogs)
+    ├── MONTHLY_WORKFLOW.md <- Operating doctrine for a batch (maintainer-local)
+    ├── pipeline-audit-2026-05.md / pipeline-harden-plan.md  <- Phase-1 forensics
     ├── scanner/           <- Fetcher + Sonnet-based classifier
     ├── proposer/          <- CHANGES.md report generator
     ├── applier/           <- Opus-based diff generator and file editor
     ├── alerter/           <- Gmail draft builder
-    └── state/             <- Runtime state (scan results, history)
+    ├── tests/             <- Unit tests over the guard rails
+    └── state/             <- Runtime state (scan results, history, runs/)
 ```
 
 ---
@@ -251,7 +268,9 @@ achievable for files >1500 lines without manual intervention.
 
 What the session established:
 - **Cadence dropped to monthly** (was twice-monthly). Each run takes 2-4
-  hours of focused review; twice-monthly was unsustainable.
+  hours of focused review; twice-monthly was unsustainable. *Superseded on
+  2026-08-10 - the cadence went back to twice-monthly. See the Content update
+  pipeline section above for the current schedule.*
 - **Architecture: FIND/REPLACE plain-text edits**, not whole-file rewrites
   and not JSON tool-use hunks. Whole-file rewrites hit Opus's 32K output
   token ceiling on big files and silently truncated. Tool-use hunks failed
@@ -271,11 +290,14 @@ What the session established:
   - Preview-mode guard rails - `_validate_content` runs against the
     proposed content before showing it as a diff, so unsafe proposals
     print "REJECTED by guard rail" instead of a 1000-line broken diff.
-- **Big files are at the edge of the auto-edit envelope.** `finops-aws.md`
-  (2657 lines) and `finops-azure.md` (~3000 lines) routinely produce
-  guard-rail rejections or anchor failures for non-additive changes.
-  Structural changes to these files need manual integration. Additive
-  edits (new subsection, new note) work fine.
+- **Big files are at the edge of the auto-edit envelope.** At the time this
+  meant `finops-aws.md` (2,657 lines) and `finops-azure.md` (~3,000 lines),
+  which routinely produced guard-rail rejections or anchor failures for
+  non-additive changes. The August 2026 split (see Closed gaps) removed both
+  from that band; the largest files are now `finops-azure.md` (~1,800 lines)
+  and `finops-aws-patterns.md` (~1,470). Treat roughly 1,500 lines as the
+  threshold above which structural changes need manual integration. Additive
+  edits (new subsection, new note) work fine at any size.
 
 The pipeline now sits in a sustainable operating shape. Future work is
 about *simplification* (reducing the manual review surface), not adding
@@ -390,10 +412,12 @@ GitHub issues, which track in-flight work.
      validates fetch results (HTTP status, content-type, minimum payload
      length) so a 200-with-empty-body cannot become a "this source has no
      news" classification; `proposer/` validates that proposed CHANGES.md is
-     well-formed before write; the `Anthropic` API calls in
-     `applier/file_updater.py` switch to the structured output (tool-use)
-     pattern so the model returns a JSON object with explicit fields rather
-     than free-form markdown that the Python code parses with regex. Every
+     well-formed before write. **The third target originally listed here -
+     switching `applier/file_updater.py` to the structured-output (tool-use)
+     pattern - is withdrawn.** It was attempted and rolled back on 2026-05-15
+     when Opus regressed to legacy XML format under `tool_choice`; the shipped
+     architecture is plain-text FIND/REPLACE blocks with a regex parser (see
+     the 2026-05-15 lessons above). Do not resurrect it. Every
      module produces a per-run structured report (one JSON file per run,
      archived under `pipeline/state/runs/<timestamp>/`) so post-hoc audit
      does not depend on stdout scrolling. Add ratchets: secrets handling
@@ -438,7 +462,7 @@ GitHub issues, which track in-flight work.
 - **WasteLine extension to Azure and GCP.** `finops-waste-detection-playbooks.md` covers the
   eight-category waste taxonomy and references the WasteLine appliance for AWS automation;
   Azure and GCP coverage currently routes to the in-cloud pattern catalogues
-  (`finops-azure.md` 48-pattern, `finops-gcp.md` 26-pattern). When WasteLine ships Azure and
+  (`finops-azure-patterns.md`, `finops-gcp.md`). When WasteLine ships Azure and
   GCP providers, update the operational tooling section to reflect the broader coverage and
   remove the "for Azure and GCP, see in-cloud catalogues" caveat.
 
@@ -611,7 +635,7 @@ These files shipped during the white-space analysis follow-up (PRs #48, #50, #51
   as it is pipeline damage.
 
 - YAML FCP frontmatter pass across all 22 pre-existing references (PR #53)
-- `skills/cloud-finops/playbooks/` directory (PRs #64, #66, #67, #83) - 23 RAG-friendly
+- `skills/cloud-finops/playbooks/` directory (PRs #64, #66, #67, #83) - RAG-friendly
   named-pattern playbooks (`<scope>-<pattern>.md`, ~2-3KB each,
   Problem/Symptoms/Detection/Fix/Anti-pattern/See also format) covering AWS (incl. SageMaker + GPU), Azure, GCP, and cross-cloud waste patterns.
   Routed from SKILL.md and POWER.md "named waste pattern" rows
@@ -629,7 +653,8 @@ is how well they follow the structure and avoid hallucinating billing rules.
 - **Claude** (Code, .ai, API) - reads SKILL.md natively, no extra configuration needed
 - **Kiro IDE** - reads POWER.md natively
 - **GPT, Gemini, other models** - inject the reference files as context and add the
-  response contract from INSTALLATION.md (Option 6) to the system prompt
+  response contract from INSTALLATION.md ("API integration (system-prompt injection)" ->
+  "Recommended response contract") to the system prompt
 
 The response contract ensures consistent output structure (Context, Recommendation,
 Metrics, Business impact) and prevents models from inventing pricing figures or
@@ -813,7 +838,8 @@ Good test patterns:
       (must match; CI-gated by `scripts/check-marketplace-version.sh` via the
       `marketplace version in sync` workflow), `mcp_server/pyproject.toml`.
 - [ ] Marketplace description in `.claude-plugin/marketplace.json` reflects the new
-      reference file count and topic list (can ride the release PR)
+      topic list (can ride the release PR). It carries no reference count by design -
+      see the no-hardcoded-counts rule above.
 - [ ] SKILL.md description stays under 1024 characters (CI-gated by
       `scripts/check-skill-description.sh`, which also warns above 950 so the
       ceiling is visible before it is hit)

--- a/skills/cloud-finops/references/finops-ai-dev-tools.md
+++ b/skills/cloud-finops/references/finops-ai-dev-tools.md
@@ -85,6 +85,9 @@ in detail provides a template for evaluating any seat + usage tool.
 
 Cursor has two cost layers: a fixed subscription and variable usage-based token charges.
 
+*Seat prices below are list price as of August 2026. This category reprices its tiers
+several times a year - check the vendor's pricing page before quoting a figure.*
+
 | Plan | Seat cost | Included usage | Overage billing |
 |---|---|---|---|
 | Hobby (free) | $0 | Limited requests and completions | Not available |
@@ -109,7 +112,8 @@ variable. The range is wide:
   the routing mix rather than a fixed figure
 - **First-party models** (Composer, Grok variants): included in the plan's "Cursor
   Models" pool with no separately published per-token rate
-- **Premium models** (e.g. the Claude Opus family): $5.00/MTok input, $25.00/MTok output
+- **Premium models** (e.g. the Claude Opus family): billed through at the provider's
+  published per-token rate, so the cost follows the model's own rate card
 
 A 10-50x gap exists between the cheapest and most expensive models available in Cursor.
 Even small shifts in model distribution across a team show up on the invoice fast.
@@ -156,6 +160,8 @@ Claude Code is a terminal-based coding agent built by Anthropic. It has two acce
 each with a different billing model.
 
 ### Subscription access
+
+*List price as of August 2026 - verify on the vendor's pricing page before quoting.*
 
 | Plan | Cost | What you get |
 |---|---|---|
@@ -264,6 +270,8 @@ billing.
 
 ### GitHub Copilot
 
+*List price as of August 2026 - verify on the vendor's pricing page before quoting.*
+
 | Plan | Seat cost | Notes |
 |---|---|---|
 | Free | $0 | Limited completions |
@@ -273,7 +281,8 @@ billing.
 | Business | $19/seat/month | Admin controls, audit logs, IP indemnity |
 | Enterprise | $39/seat/month | Requires GH Enterprise Cloud ($21/seat/month extra); ~3,900 credits/user |
 
-Overage charges apply at $0.04 per premium request beyond the monthly allocation.
+Overage beyond the monthly allocation used to be charged at a flat $0.04 per premium
+request. That rate is retired - see the transition note below before quoting it.
 
 **GitHub AI Credits - transition date passed 1 June 2026.** GitHub moved Copilot
 overage from the fixed `$0.04 per premium request` rate to usage-based billing in
@@ -307,6 +316,8 @@ Windsurf overhauled its pricing in March 2026, retiring the credit system in fav
 daily/weekly usage quotas, and rebranded to **Devin Desktop** in June 2026 (windsurf.com
 now redirects to devin.ai - expect the vendor name change to surface in invoices and
 SaaS-management inventories).
+
+*List price as of August 2026 - verify on the vendor's pricing page before quoting.*
 
 | Plan | Cost | Usage model | Notes |
 |---|---|---|---|
@@ -397,9 +408,10 @@ less per request.
 
 ### For BYOK tools (Claude Code, Codex)
 
-**Model selection** - Sonnet 4.6 at $3/$15 per MTok vs Opus 4.6 at $5/$25 for Claude Code.
-codex-mini at $1.50/$6 vs GPT-5 at $1.25/$10 for Codex. Choose the model that matches the
-task complexity. Default to the more efficient model and escalate only when needed.
+**Model selection** - the mid tier runs at roughly 0.6x the large tier on the Claude side,
+and the gap between a mini and a frontier model on the OpenAI side is wider still. Choose
+the model that matches the task complexity, default to the more efficient one, and escalate
+only when needed. Pull the current rates before quantifying the saving.
 
 **Prompt caching** (Anthropic) - cache reads cost 0.1x the base input price. Cache writes
 cost 1.25x (5-minute TTL) or 2x (1-hour TTL). For repetitive workflows with stable system
@@ -511,12 +523,18 @@ becomes a cost problem when:
 
 ---
 
-## Pricing comparison (verified August 2026)
+## Pricing comparison
+
+> *Seat prices are list price as of August 2026. They are the most frequently repriced
+> figures in this file - treat the table as a shape comparison (who charges for what),
+> not as a quotable rate card, and verify against each vendor's pricing page. For the
+> per-token rates behind the BYOK rows, use a live source such as
+> <https://optimtoken.optimnow.io>.*
 
 | Tool | Type | Seat cost | Token / usage model | Enterprise option | Proxy-compatible |
 |---|---|---|---|---|---|
 | **Cursor** | Seat + usage | $20 (Pro) / $40 (Teams Standard) / $120 (Teams Premium) | Usage pool per plan + per-token overage at model rates | Yes (custom) | No (vendor-mediated) |
-| **Claude Code** | BYOK or subscription | $20 (Pro) / $100 (Max 5x) / $200 (Max 20x) | API key: $1-$25/MTok depending on model | Via Anthropic Enterprise | Yes (API key mode) |
+| **Claude Code** | BYOK or subscription | $20 (Pro) / $100 (Max 5x) / $200 (Max 20x) | API key: per-token at current Claude-model rates (see `finops-anthropic.md` for the rate structure) | Via Anthropic Enterprise | Yes (API key mode) |
 | **OpenAI Codex** | BYOK or subscription | $20 (ChatGPT Plus) and up | API key: per-token at current Codex-model rates (see OpenAI pricing page) | Via OpenAI Enterprise | Yes (API key mode) |
 | **GitHub Copilot** | Seat + usage | $10 (Pro) / $100 (Max) / $19 (Business) / $39 (Enterprise) | AI-credit overage priced on underlying model cost (legacy $0.04/request retired June 2026) | Yes ($60/seat total with GH Enterprise Cloud) | No (vendor-mediated) |
 | **Windsurf (Devin Desktop)** | Seat + usage | $20 (Pro) / $200 (Max) / $40 (Teams) | Daily/weekly quota + API-priced overage (credits retired March 2026) | Yes (custom) | No (vendor-mediated) |

--- a/skills/cloud-finops/references/finops-ai-self-hosted-vs-managed.md
+++ b/skills/cloud-finops/references/finops-ai-self-hosted-vs-managed.md
@@ -38,9 +38,12 @@ or cost arbitrage reasons that managed APIs cannot meet.
 
 Three drivers make this conversation more common in 2026:
 
-1. **Frontier model pricing has stabilised** (Sonnet 4 around $3/M input, $15/M output;
-   GPT-5 in similar territory). Clients with predictable workloads can now build credible
-   TCO models comparing managed APIs to renting their own GPUs.
+1. **Frontier model pricing has stabilised.** Mid-tier rates have held roughly flat across
+   several model generations on both the Claude and GPT sides, so a rate assumed today is
+   unlikely to be invalidated mid-project. Clients with predictable workloads can now build
+   credible TCO models comparing managed APIs to renting their own GPUs. Pull the current
+   rates from a live source (<https://optimtoken.optimnow.io>) when you build the model -
+   stability is not the same as permanence.
 2. **Open-weight models have closed the quality gap** for many use cases. Qwen3.6, Llama 4,
    GLM-5.1, Gemma 4 deliver production-grade quality across reasoning, coding, multimodal.
    Self-hosting a capable model is a real option, not a research experiment.
@@ -245,9 +248,11 @@ billed to the same FinOps budget as remediation.
 
 These are the failure modes seen repeatedly in 2024-2026:
 
-- **TCO calculator without operational tax.** Comparing $0.50/M tokens self-hosted to $3/M
-  managed, omitting the FTE cost, oncall burden, migration overhead, retuning cycles. The
-  TCO model is wrong by a factor of 2-5x.
+- **TCO calculator without operational tax.** Putting the self-hosted per-token rate next
+  to the managed per-token rate and stopping there, omitting the FTE cost, oncall burden,
+  migration overhead, retuning cycles. The headline gap is usually several-fold in favour
+  of self-hosting, which is exactly why it survives scrutiny for so long. The TCO model is
+  wrong by a factor of 2-5x.
 - **"We will figure it out" sizing.** Provisioning A100s without 90 days of usage data,
   ending up at 15-25% utilisation. The per-token math collapses immediately.
 - **No fallback plan.** Single-pod self-hosted in one region, no redundancy. First

--- a/skills/cloud-finops/references/finops-anthropic.md
+++ b/skills/cloud-finops/references/finops-anthropic.md
@@ -38,7 +38,7 @@ Total cost is now shaped by a combination of variables that FinOps must track ex
 
 | Variable | What it does |
 |---|---|
-| Model choice | Base token rate anchor (Opus 5: $5/$25 per MTok input/output) |
+| Model choice | Base token rate anchor (see "Rate structure: Claude models" below) |
 | Performance tier | Standard vs Fast mode - 2x price multiplier, and only on the models that offer it |
 | Context length | **Per-model**: the current generation prices flat across a 1M-token window with no long-context premium. Older models applied premium rates above 200K input tokens. Verify per model rather than assuming either behaviour. |
 | Data residency | US-only inference adds a 1.1× multiplier |
@@ -50,9 +50,14 @@ Total cost is now shaped by a combination of variables that FinOps must track ex
 
 ---
 
-## Pricing reference: Claude models
+## Rate structure: Claude models
 
-### Base token pricing (verified against Anthropic model documentation, June 2026)
+> *Illustrative rates, list price, as of June 2026 (Anthropic model documentation).
+> Prices move and this file does not. For a current figure, call a live pricing tool or
+> check <https://optimtoken.optimnow.io>. What is durable below is the tier structure and
+> the multipliers, not the absolute numbers.*
+
+### Base token pricing
 
 | Model | Input ($/MTok) | Output ($/MTok) | Context | Notes |
 |---|---|---|---|---|

--- a/skills/cloud-finops/references/finops-aws.md
+++ b/skills/cloud-finops/references/finops-aws.md
@@ -256,10 +256,14 @@ their own operational discipline.
 SageMaker real-time endpoints and notebook instances are billed at the
 underlying instance hourly rate **as long as they are provisioned**,
 whether traffic flows through them or not. This differs from
-consumption-based services like Lambda or Bedrock on-demand. A small
-endpoint at `ml.m5.xlarge` costs ~$170/month if left running; a GPU
-endpoint at `ml.g4dn.xlarge` is ~$540/month; a `p4d.24xlarge` endpoint
-is ~$27,500/month. Forgotten POC endpoints, never-decommissioned A/B
+consumption-based services like Lambda or Bedrock on-demand. What makes this
+expensive is the spread: idling a small `ml.m5.xlarge` endpoint costs low
+hundreds of dollars a month, a `ml.g4dn.xlarge` GPU endpoint a few times that,
+and a `p4d.24xlarge` endpoint is in the tens of thousands - roughly two orders
+of magnitude between the cheapest and the most expensive thing you can forget
+to switch off (indicative, August 2026; pull current rates from the AWS
+pricing API or <https://optimtoken.optimnow.io> before quoting a number).
+Forgotten POC endpoints, never-decommissioned A/B
 variants, and notebook instances left `InService` over a weekend are the
 two highest-density waste patterns in any account running SageMaker.
 
@@ -635,6 +639,11 @@ bundle CDN, WAF, Route 53, CloudWatch Logs ingest, ACM, CloudFront Functions and
 S3 storage credits into a single monthly price, removing the bill variance that
 made CloudFront costs hard to forecast.
 
+> *Plan prices and allowances below are list values as of August 2026. The durable content
+> in this section is the shape of the trade-off - what each tier locks behind it, where the
+> request ceiling bites before the bandwidth one, what the plan does not include - not the
+> specific dollar amounts. Verify against the CloudFront pricing page before quoting.*
+
 ### Tier summary
 
 | Plan | Monthly cost | Data transfer out | Requests | S3 credit | WAF rules | Cache behaviours |
@@ -830,7 +839,8 @@ original S3 bucket as durable backing store.
 
 ### Pricing mechanics
 
-Two cost dimensions on top of the underlying S3 bucket:
+Two cost dimensions on top of the underlying S3 bucket (us-east-1 list rates as of
+August 2026 - verify against the AWS pricing page before using them in a model):
 
 | Dimension | Rate |
 |---|---|

--- a/skills/cloud-finops/references/finops-azure-openai.md
+++ b/skills/cloud-finops/references/finops-azure-openai.md
@@ -43,8 +43,9 @@ are handled through Azure.
 | Image / audio | Billed in units (images per resolution, audio per second) - separate from tokens |
 
 **Key cost driver:** output tokens are billed at 4-8x the input rate on current
-Azure OpenAI models (GPT-4.1 $2/$8 per MTok = 4x; GPT-5 $1.25/$10 = 8x). High
-output-ratio workloads carry disproportionately higher costs.
+Azure OpenAI models (GPT-4.1 at 4x, GPT-5 at 8x, as of August 2026). High
+output-ratio workloads carry disproportionately higher costs, and the multiplier
+matters more than the headline input rate when you size a workload.
 
 ### Deployment Locality
 
@@ -87,12 +88,16 @@ Standard pricing is per-million tokens, billed per API call. No upfront commitme
 | o3-mini | Mid | Reasoning model, cost-optimised |
 | o3 | High | Full reasoning model |
 
-Representative pricing (verify against current Azure pricing documentation):
+The rate *structure* is what to plan against - the multipliers below have been stable
+while the absolute rates have not (structure as of August 2026):
 
-| Model | Standard input | Cached input | Standard output |
-|---|---|---|---|
-| GPT-5 | $1.25/MTok | $0.125/MTok | $10.00/MTok |
-| GPT-4.1 | $2.00/MTok | $0.50/MTok | $8.00/MTok |
+| Model | Cached input vs standard input | Output vs standard input |
+|---|---|---|
+| GPT-5 | 0.1x (90% discount) | 8x |
+| GPT-4.1 | 0.25x (75% discount) | 4x |
+
+For the current absolute rates, use the Azure pricing documentation or a live pricing
+tool (<https://optimtoken.optimnow.io>) rather than a figure remembered from this file.
 
 ### Provisioned vs standard pricing - hourly PTU vs reservation-discounted PTU
 
@@ -330,7 +335,7 @@ highest ROI for the effort.
 ### Prompt caching
 
 Azure OpenAI supports prompt caching. The cached-input discount is **model-dependent**,
-not a flat rate: roughly 90% on GPT-5 ($0.125 cached vs $1.25 standard input), 75% on
+not a flat rate: roughly 90% on GPT-5, 75% on
 GPT-4.1, ~50% on GPT-4o, and up to 100% on Provisioned deployments. Newer model
 generations may also charge for cache **writes** - check the per-model pricing page
 rather than assuming reads-only billing. Effective for:

--- a/skills/cloud-finops/references/finops-azure.md
+++ b/skills/cloud-finops/references/finops-azure.md
@@ -1235,6 +1235,12 @@ Networking is the most commonly underestimated cost line on multi-region or
 hub-spoke architectures. The egress and peering charges are small per GB but
 compound to material amounts on busy workloads.
 
+> *Every rate in this section is an approximate list rate for a common region, as of
+> August 2026, and varies by region. They are here to show the relative weight of each
+> charge - the per-GB peering charge landing on both sides, the NAT Gateway hourly floor -
+> which is the part that stays true. Pull current rates from the Azure Retail Prices API
+> before putting a number in a client model.*
+
 ### Egress pricing tiers
 
 Outbound to internet, per-GB pricing decreases by volume:

--- a/skills/cloud-finops/references/finops-bedrock.md
+++ b/skills/cloud-finops/references/finops-bedrock.md
@@ -39,9 +39,9 @@ through a unified API.
 | Batch inference | Asynchronous processing at discounted rates |
 
 **Key cost driver:** output tokens are billed at roughly 4-5x the input rate on
-current Bedrock models (4x on Amazon Nova, 5x on Claude - e.g. Claude Sonnet $3/$15
-per MTok). Workloads with high output ratios (agentic tasks, long-form generation)
-carry disproportionately higher costs.
+current Bedrock models (4x on Amazon Nova, 5x on Claude, as of August 2026).
+Workloads with high output ratios (agentic tasks, long-form generation) carry
+disproportionately higher costs. Size against the multiplier, not the input rate.
 
 ---
 

--- a/skills/cloud-finops/references/finops-for-ai.md
+++ b/skills/cloud-finops/references/finops-for-ai.md
@@ -404,29 +404,28 @@ whether failure is environment-changing, per use case, before funding.
 Treat model selection like instance rightsizing. Defaulting to the largest or latest model
 for every feature is the AI equivalent of running all workloads on ml.p4d.24xlarge.
 
-Anthropic's rate card (verified August 2026) shows the tier spread on the Claude side:
+What drives the routing decision is the **spread between tiers**, not the absolute rate.
+The spread is the durable, transferable number; the rate card behind it changes every
+few months. Tier structure as observed August 2026:
 
-| Model tier | Use case | Cost ratio | Anthropic example (per 1M tokens) |
-|---|---|---|---|
-| Small / fast (Claude Haiku 4.5) | Classification, routing, simple Q&A | 1x | $1 input / $5 output |
-| Mid-tier (Claude Sonnet) | Complex reasoning, code generation | 3x | $3 input / $15 output |
-| Large (Claude Opus 5) | Research, nuanced judgment | 5x | $5 input / $25 output |
-| Frontier (Claude Fable 5) | Hardest reasoning, high-stakes work | 10x | $10 input / $50 output |
-
-OpenAI's pricing structure (rates verified August 2026, models one generation back)
-shows a much wider spread:
-
-| Model tier | Use case | Cost ratio example | OpenAI example (per 1M tokens) |
-|---|---|---|---|
-| Small / fast (e.g. GPT-4o mini) | Classification, routing, simple Q&A | 1x | $0.15 input / $0.60 output |
-| Mid-tier (e.g. GPT-4o) | Complex reasoning, code generation | 17x | $2.50 input / $10.00 output |
-| Large (e.g. o1) | Research, nuanced judgment | 100x | $15.00 input / $60.00 output |
+| Model tier | Use case | Cost ratio vs small tier (Claude) |
+|---|---|---|
+| Small / fast (Haiku class) | Classification, routing, simple Q&A | 1x |
+| Mid-tier (Sonnet class) | Complex reasoning, code generation | 3x |
+| Large (Opus class) | Research, nuanced judgment | 5x |
+| Frontier (Fable class) | Hardest reasoning, high-stakes work | 10x |
 
 The spread is vendor-specific and compresses across generations: the Claude 3-era
 small-to-large ratio was roughly 60x, the current one is 5-10x, while OpenAI's
-mini-to-reasoning spread remains near 100x. Check the live rate card before building
-routing economics on a remembered ratio - the payoff from tiered routing depends
-directly on it.
+mini-to-reasoning spread remains near 100x. A vendor whose spread is 100x rewards
+tiered routing far more than one at 5x, and that alone can decide whether the routing
+harness is worth building.
+
+**Pull the live rate card before building routing economics on a remembered ratio.**
+Call a pricing tool if one is available, or check <https://optimtoken.optimnow.io>. The
+payoff from tiered routing depends directly on the current spread. For the Claude
+per-model rate structure, see `finops-anthropic.md` - and treat the figures there as
+illustrative, not as a quotable rate card.
 
 Implement tiered routing: classify query complexity first (cheap), then route to the
 appropriate model. Simple queries to small models, complex queries to large models.

--- a/skills/cloud-finops/references/finops-genai-capacity.md
+++ b/skills/cloud-finops/references/finops-genai-capacity.md
@@ -143,12 +143,12 @@ per million tokens at 100% utilization.
 **The result may be higher than pay-as-you-go**, even at full utilization. In that case,
 provisioned capacity is a performance and SLA purchase, not a cost-saving one.
 
-| Model | Standard input | Provisioned input (derived) | Delta at 100% utilization |
-|---|---|---|---|
-| GPT-5 | $1.25/MTok | ~$2.08/MTok | +67% |
-| GPT-4.1 | $2.00/MTok | ~$2.55/MTok | +27% |
+| Model | Provisioned vs standard input, at 100% utilization |
+|---|---|
+| GPT-5 | +67% |
+| GPT-4.1 | +27% |
 
-*Sourcing note:* the provisioned $/MTok figures are **derived estimates** from a
+*Sourcing note:* these deltas are **derived estimates** (observed August 2026) from a
 FinOps Foundation working-group analysis, not Microsoft-published rates - Microsoft
 prices PTUs only in $/PTU/hour, and the conversion depends on throughput assumptions
 and on which price point (hourly vs 1-month vs 1-year reservation) is used. Treat

--- a/skills/cloud-finops/references/finops-vertexai.md
+++ b/skills/cloud-finops/references/finops-vertexai.md
@@ -40,9 +40,10 @@ provides access to Google's own models (Gemini family) and selected third-party 
 | Region | Some models are available only in specific regions |
 
 **Key cost driver:** output tokens are billed at 4-8x the input rate on current
-Gemini SKUs (Gemini 2.0 Flash $0.15/$0.60 per MTok = 4x; Gemini 2.5 Pro $1.25/$10 =
-8x). High output-ratio workloads (agentic tasks, long-form generation) carry
-disproportionately higher costs.
+Gemini SKUs (Flash at 4x, Pro at 8x, as of August 2026). High output-ratio workloads
+(agentic tasks, long-form generation) carry disproportionately higher costs, and the
+multiplier is the number to size against - it has been more stable than the rates
+themselves.
 
 ---
 
@@ -64,8 +65,8 @@ No minimum spend, no upfront commitment.
 | Model family | Relative cost tier | Notes |
 |---|---|---|
 | Gemini Flash-Lite | Low | Cheapest tier, high-volume simple tasks |
-| Gemini Flash | Low-Mid | High throughput, cost-optimised (e.g. 2.0 Flash $0.15/$0.60 per MTok) |
-| Gemini Pro | High | Complex reasoning, multimodal (e.g. 2.5 Pro $1.25/$10 per MTok) |
+| Gemini Flash | Low-Mid | High throughput, cost-optimised |
+| Gemini Pro | High | Complex reasoning, multimodal; roughly an order of magnitude above Flash on input |
 | Anthropic Claude Haiku | Low | Available via Vertex Model Garden |
 | Anthropic Claude Sonnet | Mid | Available via Vertex Model Garden |
 | Anthropic Claude Opus | High | Available via Vertex Model Garden |
@@ -250,9 +251,10 @@ the pricing shape differs (verified August 2026):
 - Cache write: charged at **standard input-token rates** - unlike Anthropic and
   Bedrock, there is no write premium.
 - Cache **storage**: explicit caches additionally bill per hour the cache is held,
-  roughly $1.00-$4.50 per 1M cached tokens per hour depending on model. This is
-  the cost component to watch - a large cache held for hours can outweigh the read
-  savings if traffic is thin.
+  at a per-1M-cached-tokens-per-hour rate that varies several-fold across models
+  (roughly $1.00-$4.50 as of August 2026 - verify current rates before modelling).
+  This is the cost component to watch, and the one most often missed: a large cache
+  held for hours can outweigh the read savings if traffic is thin.
 - Cache hit (read): 90% off the standard input rate on 2.5-generation and later
   models (75% on 2.0-era models).
 - TTL: configurable cache lifetime.


### PR DESCRIPTION
Follow-up to #141, which established the dated-price rule. That PR changed no content; this one makes the reference files consistent with it.

Merge #141 first - this PR assumes the doctrine it introduced.

## The boundary applied

| Figure type | Treatment | Why |
|---|---|---|
| LLM per-token rates (hub-servable) | Removed, replaced by the ratio or multiplier they illustrated, plus a pointer to the live source | The hub serves these live and dated; the reference cannot |
| SaaS seat prices, storage / egress rates, CloudFront plan prices | Kept, with an inline as-of date and a pointer to the vendor's pricing page | The hub does not serve these, so deleting would leave a hole with no live replacement |
| Worked-example and scenario amounts | Untouched | Arithmetic, not a rate card. `$1,600/month can cost $8,800` does not go stale |

The consistent principle: **ratios survive, absolutes get dated or routed.** Output-vs-input multipliers, cached-input discounts, tier spreads and break-even shapes are what a practitioner actually reasons with, and they have been far more stable than the rates underneath them.

After this PR, `grep -E '\$[0-9.]+\s*(/|per )\s*(1M|MTok)'` over `references/` returns nothing. The remaining per-token table (Claude base rates in `finops-anthropic.md`) is deliberately kept - it carries the "Opus tier held constant across five generations" observation, which is a mechanics claim - and now sits behind an explicit illustrative-and-dated banner.

## Content changes worth reviewing, beyond mechanical dating

- **`finops-for-ai.md`** - the two tier tables restated rates `finops-anthropic.md` already carried, and the OpenAI one was pinned to a generation-old model set (GPT-4o / o1 in August 2026). Collapsed to one ratio table plus the cross-vendor spread argument, which is what actually drives the routing decision: a vendor at 100x spread rewards tiered routing far more than one at 5x.
- **`finops-azure-openai.md`, `finops-genai-capacity.md`** - rate tables converted to multiplier tables. The 90% / 75% cached-input discounts and the +67% / +27% provisioned deltas survive; the absolute $/MTok inputs behind them do not.
- **`finops-aws.md`** - the SageMaker idle-endpoint passage now expresses the two-orders-of-magnitude spread between a small endpoint and a `p4d.24xlarge`, which is the actual point, instead of three monthly totals that drift independently.
- **`finops-ai-dev-tools.md`** - the Copilot overage paragraph asserted the retired `$0.04/request` rate in the present tense, and only the note below it explained the June 2026 retirement. Reordered so a RAG chunk that catches the first sentence alone is not actively wrong.

## Knock-on

`CLAUDE.md` records the effect on the pipeline: the rotating AI-pricing re-verification pass now checks dates on a short list of banners rather than hunting absolute rates across every reference. That was 2-4 hours of the monthly batch.

## Checks

All five `scripts/check-*.sh` pass. Every edited reference still ends with the OptimNow / CC BY-SA footer (verified, no truncation). No em dashes. No version bump.

## Not in this PR

Routing the hub from the domain-routing table, and listing it in INSTALLATION.md as a companion MCP. That is a separate decision about taking on an optional dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
