### PR TITLE
Fix cross-references left stale by the August 2026 file split

### DIFF
--- a/skills/cloud-finops/playbooks/README.md
+++ b/skills/cloud-finops/playbooks/README.md
@@ -20,7 +20,7 @@ by an analyst building a mental model of a domain.
 Playbooks are the opposite: each one is scoped to **one named pattern**, and
 exists so an LLM doing retrieval over knowledge chunks can answer a specific
 question ("what is a zombie NAT gateway and how do I detect one?") without
-loading the entire 2,600-line `finops-aws.md`.
+loading a full provider reference such as `finops-aws.md`.
 
 The two layers cover the same patterns from different angles:
 - **Reference file** = narrative context, cross-pattern reasoning, billing
@@ -130,5 +130,7 @@ the canonical taxonomy and confidence rubric; playbooks instantiate it.
 ## Status
 
 This directory is seeded with a curated subset of high-frequency patterns.
-Full extraction of the 48 AWS / 48 Azure / 26 GCP patterns from the
-reference files is tracked in the Roadmap section of `CLAUDE.md`.
+The full per-provider catalogues live in `references/finops-aws-patterns.md`,
+`references/finops-azure-patterns.md`, and `references/finops-gcp.md`;
+extracting more of them into playbooks is tracked in the Roadmap section of
+`CLAUDE.md`.

--- a/skills/cloud-finops/playbooks/aws-outdated-gpu-generation.md
+++ b/skills/cloud-finops/playbooks/aws-outdated-gpu-generation.md
@@ -84,7 +84,7 @@ to enumerate live instances and tag-check ownership.
    instance is covered by a Compute Savings Plan or an EC2 Instance
    Savings Plan, migrating to a different family can strand the
    commitment. Plan the move alongside commitment refresh (see
-   `references/finops-aws.md` commitment portfolio section).
+   `references/finops-aws-commitments.md` commitment portfolio section).
 5. **Cut over** during a maintenance window, with a snapshot of the
    previous workload's performance benchmarks for rollback comparison.
 
@@ -113,8 +113,9 @@ to enumerate live instances and tag-check ownership.
   generation
 - `playbooks/aws-mig-candidate.md` - if the workload needs A100/H100
   features but only a slice
-- `references/finops-aws.md` - AWS commitment portfolio (impact of
-  RI/SP on modernisation timing), AWS GPU family map
+- `references/finops-aws-commitments.md` - AWS commitment portfolio (impact
+  of RI/SP on modernisation timing)
+- `references/finops-aws.md` - AWS GPU instance families and rightsizing
 - `references/finops-waste-detection-playbooks.md` - Category 7 (AI/ML
   inefficiency) and the "modernization" waste category
 

--- a/skills/cloud-finops/playbooks/aws-oversized-rds.md
+++ b/skills/cloud-finops/playbooks/aws-oversized-rds.md
@@ -87,8 +87,11 @@ aws cloudwatch get-metric-statistics \
 
 ## See also
 
-- `references/finops-aws.md` - RDS commitment strategy, Database Savings
-  Plans, Aurora vs RDS economics
+- `references/finops-aws-commitments.md` - Database Savings Plans and the
+  commitment decision tree
+- `references/finops-aws-patterns.md` - RDS commitment strategy and the
+  enumerated RDS inefficiency patterns
+- `references/finops-aws.md` - Aurora vs RDS economics
 - `playbooks/aws-snapshot-sprawl.md` - related RDS snapshot sprawl
 
 ---

--- a/skills/cloud-finops/playbooks/aws-sagemaker-mme-consolidation.md
+++ b/skills/cloud-finops/playbooks/aws-sagemaker-mme-consolidation.md
@@ -100,8 +100,9 @@ The right shape depends on whether the models share a container.
 
 ## See also
 
-- `references/finops-aws.md` - SageMaker AI Savings Plan, deployment
-  pattern selection, MME vs Inference Components decision
+- `references/finops-aws.md` - SageMaker deployment pattern selection,
+  MME vs Inference Components decision
+- `references/finops-aws-commitments.md` - SageMaker AI Savings Plan
 - `playbooks/aws-sagemaker-idle-endpoint.md` - the deletion-first option
   when an endpoint receives literally zero traffic
 - `references/finops-waste-detection-playbooks.md` - Category 7 (AI/ML

--- a/skills/cloud-finops/playbooks/cross-cloud-schedule-blindness.md
+++ b/skills/cloud-finops/playbooks/cross-cloud-schedule-blindness.md
@@ -107,7 +107,7 @@ ORDER BY cost_30d DESC;
 
 ## See also
 
-- `references/finops-aws.md` - EC2 patterns including non-prod
+- `references/finops-aws-patterns.md` - EC2 patterns including non-prod
   scheduling
 - `references/finops-azure.md` - Azure VM rightsizing and scheduling
 - `references/finops-gcp.md` - Compute Engine scheduling patterns

--- a/skills/cloud-finops/references/finops-aws.md
+++ b/skills/cloud-finops/references/finops-aws.md
@@ -11,10 +11,13 @@ fcp_maturity_entry: "Walk"
 
 # FinOps on AWS
 
-> AWS-specific guidance covering cost management tools, commitment discounts, compute
-> rightsizing, cost allocation, and governance. Covers CUR, Cost Explorer, Compute
-> Optimizer, Trusted Advisor, Savings Plans, Reserved Instances, Enterprise Discount
-> Program (EDP) negotiation, RDS cost management strategy, and AWS-native FinOps patterns.
+> AWS-specific guidance covering cost management tools, compute rightsizing, SageMaker
+> operational FinOps, cost allocation, and governance. Covers CUR and Data Exports,
+> Cost Explorer, Compute Optimizer, Trusted Advisor, EC2 and GPU rightsizing,
+> CloudFront flat-rate plans, S3 Files, and multi-org billing.
+>
+> Commitments (Savings Plans, RIs, Spot, EDP) and the enumerated per-service pattern
+> catalogue live in their own files - see the routing table below.
 
 ---
 

--- a/skills/cloud-finops/references/finops-azure.md
+++ b/skills/cloud-finops/references/finops-azure.md
@@ -11,13 +11,16 @@ fcp_maturity_entry: "Walk"
 
 # FinOps on Azure
 
-> Azure-specific guidance covering cost management tools, commitment discounts, compute
-> rightsizing, database and storage optimisation, cost allocation, and governance.
-> Covers Cost Management exports, FOCUS exports, Azure Advisor, Reservations, Savings
-> Plans, Azure Hybrid Benefit, Azure Policy and tagging governance, AKS optimisation,
-> database optimisation (Azure SQL, Postgres/MySQL Flexible, Cosmos DB), Log Analytics
-> cost control, backup and snapshot management, storage tiering and lifecycle, and
-> networking cost.
+> Azure-specific guidance covering cost management tools, compute rightsizing, database
+> and storage optimisation, cost allocation, and governance. Covers Cost Management
+> exports, FOCUS exports, the Retail Prices API, Azure Advisor calibration, Azure Policy
+> and tagging governance, AKS optimisation, database optimisation (Azure SQL,
+> Postgres/MySQL Flexible, Cosmos DB), Log Analytics cost control, backup and snapshot
+> management, storage tiering and lifecycle, networking cost, and the EA-to-MCA
+> transition.
+>
+> Commitments (Reservations, Savings Plans, AHB, Spot, MACC) and the enumerated
+> per-service pattern catalogue live in their own files - see the routing table below.
 >
 > Distilled from OptimNow Azure FinOps engagement experience and primary Microsoft
 > sources (Azure Pricing pages, Cost Management documentation, FinOps Toolkit).

--- a/skills/cloud-finops/references/finops-fabric.md
+++ b/skills/cloud-finops/references/finops-fabric.md
@@ -132,8 +132,8 @@ did not audit the active-dataset list first.
   Microsoft Fabric reserved capacity page before quoting.
 - Scope and exchange rules: similar to Azure VM Reservations but capacity-
   specific. Exchanges allowed within the F-SKU family with the standard Azure
-  reservation mechanics (see `finops-azure.md` for exchange / refund / cap
-  details, which apply identically here).
+  reservation mechanics (see `finops-azure-commitments.md` for exchange /
+  refund / cap details, which apply identically here).
 - **No 3-year option as of April 2026.** Fabric Reserved Capacity is 1-year only.
 - **Sequencing:** only commit after cleanup and capacity sizing have stabilised.
   Reserving before cleanup locks the wrong F-SKU into a 1-year contract - the

--- a/skills/cloud-finops/references/finops-itam.md
+++ b/skills/cloud-finops/references/finops-itam.md
@@ -168,7 +168,8 @@ twice. When managed poorly, it creates compliance exposure and hidden costs.
 **Azure Hybrid Benefit (AHB):** Windows Server and SQL Server licences with active Software
 Assurance can be applied to Azure VMs, reducing compute costs by up to 40-80%. Requires
 ITAM to confirm SA coverage and FinOps to track which VMs have AHB applied vs which are
-paying full price. See `finops-azure.md` for AHB-specific optimisation patterns.
+paying full price. See `finops-azure-commitments.md` for AHB-specific optimisation
+patterns.
 
 **AWS Licence Manager:** Tracks licence usage across EC2 instances. Requires ITAM to define
 licence rules and FinOps to monitor consumption against those rules.

--- a/skills/cloud-finops/references/finops-kubernetes.md
+++ b/skills/cloud-finops/references/finops-kubernetes.md
@@ -20,9 +20,10 @@ fcp_maturity_entry: "Walk"
 > This file is the cross-cluster discipline (EKS, GKE, AKS). Provider-specific
 > node mechanics live in the per-cloud files: AKS in
 > `finops-azure.md` (Node Auto Provisioning, Azure Linux 2 retirement, MIG /
-> MPS / DRA for GPU partitioning), EKS in `finops-aws.md` (commitment options
-> for node groups including Karpenter integration), GKE in `finops-gcp.md`
-> (Spot VMs, Autopilot vs Standard).
+> MPS / DRA for GPU partitioning), EKS in `finops-aws.md` (node mechanics and
+> the Auto Mode vs Karpenter comparison) and `finops-aws-commitments.md`
+> (commitment options for node groups), GKE in `finops-gcp.md` (Spot VMs,
+> Autopilot vs Standard).
 
 ---
 
@@ -456,8 +457,8 @@ own. It belongs to the Platform team's budget, not the application teams'.
 - `finops-allocation-showback.md` - the upstream allocation methodology;
   K8s allocation is one source feeding the broader allocation pipeline
 - `finops-tagging.md` - tag (label) hygiene is the prerequisite
-- `finops-aws.md` - EKS-specific commitment options; Karpenter integration
-  with EC2 Savings Plans and Compute Savings Plans
+- `finops-aws-commitments.md` - EKS-specific commitment options; Karpenter
+  integration with EC2 Savings Plans and Compute Savings Plans
 - `finops-azure.md` - AKS-specific deep cuts (Node Auto Provisioning,
   Azure Linux 2 retirement, MIG / MPS / DRA for GPU partitioning)
 - `finops-gcp.md` - GKE-specific options (Spot VMs, Autopilot vs Standard,

--- a/skills/cloud-finops/references/finops-oci.md
+++ b/skills/cloud-finops/references/finops-oci.md
@@ -107,8 +107,9 @@ eligible OCI consumption draws down against that commitment.
   consumption stability before committing for three years.
 
 The Universal Credits / FinOps interaction mirrors the MACC framing in
-`finops-azure.md` - read that section for the full optimisation-paradox and
-operational-cadence guidance, then apply OCI-specific coverage rules.
+`finops-azure-commitments.md` - read that section for the full
+optimisation-paradox and operational-cadence guidance, then apply
+OCI-specific coverage rules.
 
 ---
 

--- a/skills/cloud-finops/references/finops-onboarding-workloads.md
+++ b/skills/cloud-finops/references/finops-onboarding-workloads.md
@@ -197,8 +197,8 @@ Specific patterns to watch for:
 
 - **Cross-zone chatter.** Microservices designed for on-premises latency
   often span availability zones in cloud, generating cross-AZ data transfer
-  charges that did not exist on-premises (see `finops-aws.md` 48-pattern
-  catalogue, `finops-azure.md` patterns)
+  charges that did not exist on-premises (see the pattern catalogues in
+  `finops-aws-patterns.md` and `finops-azure-patterns.md`)
 - **Database replication.** Synchronous replication across zones for HA
   was free on-premises (private network); in cloud it is per-GB
 - **Storage egress.** A team's S3 reads from a service in another region
@@ -405,10 +405,11 @@ it post-migration costs a quarter of engineering time.
   configured; the intake gate enforces this
 - `finops-tagging.md` - the prerequisite for the tag-related intake gate
   items
-- `finops-aws.md` - AWS-specific commitment timing for post-migration
-  workloads (the 60-90 day rule applies)
-- `finops-azure.md` - Azure-specific commitment timing; the EA-to-MCA
-  transition is a related onboarding scenario
+- `finops-aws-commitments.md` - AWS-specific commitment timing for
+  post-migration workloads (the 60-90 day rule applies)
+- `finops-azure-commitments.md` - Azure-specific commitment timing
+- `finops-azure.md` - the EA-to-MCA transition, a related onboarding
+  scenario
 - `finops-gcp.md` - GCP-specific commitment timing
 - `finops-fabric.md` - the Pro/PPU-to-Fabric migration governance trap is
   a precedent migration scenario where forecasting before commitment

--- a/skills/cloud-finops/references/finops-waste-detection-playbooks.md
+++ b/skills/cloud-finops/references/finops-waste-detection-playbooks.md
@@ -23,9 +23,8 @@ fcp_maturity_entry: "Crawl"
 > resource-state categories below. WasteLine automates the
 > detection-and-classification
 > work; this file is the doctrine the appliance encodes. For Azure and GCP,
-> use the in-cloud catalogues (`finops-azure.md` 48-pattern catalogue,
-> `finops-gcp.md` 26-pattern catalogue) until WasteLine extends to those
-> providers.
+> use the in-cloud catalogues (`finops-azure-patterns.md`, `finops-gcp.md`)
+> until WasteLine extends to those providers.
 
 ---
 
@@ -664,9 +663,9 @@ What WasteLine adds beyond a manual hunt:
   IDs, and tags are stripped at the MCP boundary
 
 For Azure and GCP waste detection, the cloud-specific catalogues in
-`finops-azure.md` (48-pattern catalogue) and `finops-gcp.md` (26-pattern
-catalogue) cover the same waste taxonomy applied to those providers.
-WasteLine extension to Azure and GCP is on the roadmap.
+`finops-azure-patterns.md` and `finops-gcp.md` cover the same waste taxonomy
+applied to those providers. WasteLine extension to Azure and GCP is on the
+roadmap.
 
 ---
 
@@ -731,11 +730,13 @@ WasteLine extension to Azure and GCP is on the roadmap.
 
 ## Cross-references
 
-- `finops-aws.md` - AWS-specific commitment, EC2, RDS, EDP guidance
-  (the Category 4 details)
-- `finops-azure.md` - Azure 48-pattern catalogue (Azure-side equivalents
-  to the categories above)
-- `finops-gcp.md` - GCP 26-pattern catalogue (GCP-side equivalents)
+- `finops-aws-commitments.md` - AWS commitment and EDP guidance (the
+  Category 4 details)
+- `finops-aws.md` - AWS EC2 and RDS cost mechanics
+- `finops-aws-patterns.md` - the enumerated AWS pattern catalogue
+- `finops-azure-patterns.md` - Azure pattern catalogue (Azure-side
+  equivalents to the categories above)
+- `finops-gcp.md` - GCP pattern catalogue (GCP-side equivalents)
 - `finops-tagging.md` - tag enforcement is the prerequisite for
   owner-driven decommission workflows
 - `finops-allocation-showback.md` - waste hunting reads from the same


### PR DESCRIPTION
Independent of #141 / #142 - merges in any order.

## Why

The August 2026 split moved commitments and pattern catalogues out of `finops-aws.md` and `finops-azure.md` into their own files, but the files pointing at that content were not updated. Fifteen cross-references still send a reader to the core file for material that lives elsewhere.

This is worse than a broken link in prose. A retrieval-driven agent follows the pointer, loads the wrong file, finds nothing on the topic, and either says so or improvises - which is exactly the failure the split was meant to prevent.

## Root cause, fixed here too

The description blockquotes on both core files still advertised the moved content: `finops-aws.md` claimed "Savings Plans, Reserved Instances, Enterprise Discount Program (EDP) negotiation", `finops-azure.md` claimed "Reservations, Savings Plans, Azure Hybrid Benefit".

That blockquote is line 3 and the highest-salience text a retriever sees. It kept pulling readers to the wrong file, and it is why new pointers kept being written against the core file after the split. Both blockquotes now describe what the file actually holds and defer to the routing table immediately below them.

## What moved where

| Pointer topic | Was | Now |
|---|---|---|
| Azure / AWS pattern catalogues | `finops-azure.md`, `finops-aws.md` | `finops-azure-patterns.md`, `finops-aws-patterns.md` |
| AHB, MACC, reservation exchange / refund / cap | `finops-azure.md` | `finops-azure-commitments.md` |
| EKS commitment options, Database SPs, SageMaker AI SP, commitment portfolio | `finops-aws.md` | `finops-aws-commitments.md` |

Touched: `finops-waste-detection-playbooks.md` (3), `finops-onboarding-workloads.md` (2), `finops-kubernetes.md` (2), `finops-oci.md`, `finops-fabric.md`, `finops-itam.md`, and four playbooks.

Every destination was verified by grepping for the topic before repointing, so this does not trade one broken pointer for another. Pointers that were already correct - `finops-azure.md` for Node Auto Provisioning and "Agentic FinOps on Azure", `finops-aws.md` for Cost Anomaly Detection and SageMaker deployment patterns - were left alone.

## Also cleaned up

- Removed the hardcoded "48-pattern" / "26-pattern" counts. They no longer match the catalogues, and the repo's own PR checklist forbids hardcoded counts.
- `playbooks/README.md` said retrieval avoids "the entire 2,600-line `finops-aws.md`" - that file is now ~1,000 lines. Its Status section also pointed at pattern counts in files that no longer hold them.
- One dangling pointer dropped rather than repointed: `aws-outdated-gpu-generation.md` cited an "AWS GPU family map" that exists in no reference file.

## Checks

All five `scripts/check-*.sh` pass. No em dashes. No version bump.

Note: `CLAUDE.md` carried the same stale `finops-azure.md` 48-pattern pointer in its WasteLine roadmap item. That one is fixed in #142's CLAUDE.md audit commit, not duplicated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
