### PR TITLE
Document the AI Pricing Hub as a companion connector

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -363,6 +363,62 @@ Source: https://github.com/OptimNow/cloud-finops-skills/tree/main/mcp_server
 
 ---
 
+### Companion connector: OptimNow AI Pricing Hub (optional)
+
+This skill deliberately does not carry current price figures. Billing mechanics are
+durable and belong in the reference files; absolute prices are volatile and go stale
+inside a packaged skill within weeks. See "Price figures" in `SKILL.md` for the rule.
+
+The AI Pricing Hub is where those figures live: <https://optimtoken.optimnow.io>. The
+website is usable on its own and needs no setup. Adding its MCP connector lets the model
+fetch a figure mid-answer instead of telling the user to go and look it up.
+
+**It is a remote server, so there is nothing to install.** Point your client at the
+endpoint:
+
+```
+https://ai-pricing-hub-mcp-9604f763.alpic.live/
+```
+
+Claude Desktop / Claude Code (`claude_desktop_config.json` or `.mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "ai-pricing-hub": {
+      "command": "npx",
+      "args": ["mcp-remote", "https://ai-pricing-hub-mcp-9604f763.alpic.live/"]
+    }
+  }
+}
+```
+
+On Windows, wrap the command: `"command": "cmd"`, `"args": ["/c", "npx", "mcp-remote", "<url>"]`.
+
+**Three tools (all read-only):**
+
+- `compare-llm-models(provider?, category?, openness?, capability?, maxInputPrice?, maxOutputPrice?, minElo?, useCasePreset?, volumePreset?, limit?)` - model comparison by price, quality (ELO), and efficiency, with list and cache/batch-optimised cost
+- `estimate-llm-cost(modelName?, useCasePreset?, monthlyVolume?, customInputTokens?, customOutputTokens?)` - per-request and monthly cost for a model against a use-case token profile
+- `compare-compute-pricing(provider?, category?, processor?, useCase?, minVCPUs?, maxVCPUs?, minMemory?, maxMemory?, sortBy?, limit?)` - instance pricing across AWS, Azure, GCP, DigitalOcean, OCI, OVH, and Alibaba, including spot, Savings Plan, and reserved rates
+
+**Read the provenance block before quoting anything it returns.** Every response carries
+one, and it is the thing that makes the dated-price rule workable:
+
+| Field | Why it matters |
+|---|---|
+| `provenance.tier` | `1` = fetched live from optimtoken.optimnow.io. `2` = served from a committed static snapshot because the upstream was unreachable |
+| `provenance.dataAsOf` / `upstreamTimestamp` | The as-of date to put next to the figure |
+| `provenance.notice` | Present on tier 2, and states plainly that the pricing is stale, how old the snapshot is, and which filters were *not* applied |
+
+A tier-2 response is still usable - it is a dated snapshot, not a guess - but it must be
+quoted as one. Do not present a tier-2 figure as a current price, and note that on tier 2
+the compute catalogue is a subset of the live one and carries no region dimension, so a
+region filter silently does not apply and a narrow query can come back empty.
+
+Source: https://github.com/OptimNow/ai-pricing-hub-mcp
+
+---
+
 ## Updating
 
 ```bash
@@ -483,6 +539,10 @@ PRICE FIGURES
   structure) with confidence. Date every absolute number.
 - Never interpolate a missing price from a neighbouring model, a previous generation,
   or another region. If the figure is not available, say so.
+- If the pricing tool returns a "provenance" block, read it first. tier 1 = fetched
+  live; tier 2 = a dated static snapshot served because the upstream was unreachable.
+  Quote a tier-2 figure as a dated snapshot, never as a current price, and treat an
+  empty tier-2 result as possibly degraded data rather than as "no match".
 
 OUTPUT FORMAT
 Use headers:

--- a/skills/cloud-finops/POWER.md
+++ b/skills/cloud-finops/POWER.md
@@ -302,6 +302,14 @@ Billing **mechanics** are durable and are what these references are for. Price
 4. **Never interpolate.** If the live source has no figure for the model, SKU, or
    region asked about, say so. Do not derive one from a neighbouring model, a previous
    generation, or another region.
+5. **When the tool returns provenance, read it before quoting.** The AI Pricing Hub
+   tools return a `provenance` block. `tier: 1` means the figure was fetched live;
+   `tier: 2` means it came from a dated static snapshot because the upstream was
+   unreachable, and `provenance.notice` says so explicitly. `dataAsOf` /
+   `upstreamTimestamp` is the date to put next to the number. A tier-2 figure is usable
+   as a dated snapshot, never as a current price. On tier 2 the compute catalogue is
+   also a subset with no region dimension, so a region filter silently does not apply
+   and an empty result can mean degraded data rather than no match - say which.
 
 ---
 

--- a/skills/cloud-finops/SKILL.md
+++ b/skills/cloud-finops/SKILL.md
@@ -102,6 +102,14 @@ Billing **mechanics** are durable and are what these references are for. Price
 4. **Never interpolate.** If the live source has no figure for the model, SKU, or
    region asked about, say so. Do not derive one from a neighbouring model, a previous
    generation, or another region.
+5. **When the tool returns provenance, read it before quoting.** The AI Pricing Hub
+   tools return a `provenance` block. `tier: 1` means the figure was fetched live;
+   `tier: 2` means it came from a dated static snapshot because the upstream was
+   unreachable, and `provenance.notice` says so explicitly. `dataAsOf` /
+   `upstreamTimestamp` is the date to put next to the number. A tier-2 figure is usable
+   as a dated snapshot, never as a current price. On tier 2 the compute catalogue is
+   also a subset with no region dimension, so a region filter silently does not apply
+   and an empty result can mean degraded data rather than no match - say which.
 
 ---
 


### PR DESCRIPTION
Step 3b - the half held back in #144 pending the hub server's schema fix. Completes the pricing-hub integration.

## Verified before writing

I called all three tools against the live remote server. They execute now - the draft-07 `outputSchema` defect that blocked this is gone.

Two things the verification turned up, both of which shaped what got written:

**The provenance work landed, and it is why this is worth documenting rather than just linking.** Every response now carries `provenance.tier` (1 = fetched live from optimtoken.optimnow.io, 2 = dated static snapshot because upstream was unreachable), `dataAsOf` / `upstreamTimestamp`, and on tier 2 an explicit stale-pricing notice. That is precisely the input #141's dated-price rule needs: it turns "quote the as-of date" from something the model has to guess into a field it can read.

**`compare-compute-pricing` is currently serving tier 2.** Consistently, across repeated calls, while the two LLM tools reached tier 1 in the same seconds. Details are with Jean. It does not block this PR - the tool is honest about the degradation, which is exactly what the doctrine asks for - but the hub side is worth a look.

## What changes

- `INSTALLATION.md` - a companion-connector section beside the MCP server block: remote endpoint, config for Claude Desktop / Claude Code (including the `cmd /c` wrapper Windows needs), the three tool signatures, and the provenance contract as a table.
- `SKILL.md`, `POWER.md`, and the model-agnostic response contract - a fifth Price figures rule: read the provenance block before quoting.

## The two tier-2 traps, called out explicitly

Both fail quietly, which is why they are in the doctrine and not only in the docs:

1. The snapshot compute catalogue is a subset of the live one (137 instances against ~5,800 upstream).
2. It has **no region dimension**, so a region filter silently does not apply.

Together these mean a narrow query - "cheapest AWS GPU instances" - can come back as an empty list that reads as "nothing found" rather than "my data source is degraded". The rule now says to distinguish the two in the answer.

## Checks

Rebased onto main after #141-#144 merged; no conflicts. All five `scripts/check-*.sh` pass. No em dashes. No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
