### PR TITLE
Release 1.30.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Cloud FinOps Skill & MCP by OptimNow: reference library, named-pattern playbooks, and a queryable MCP server.",
-    "version": "1.29.0"
+    "version": "1.30.0"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloud-finops",
-  "version": "1.29.0",
+  "version": "1.30.0",
   "description": "Expert FinOps guidance for cloud, AI, SaaS, and data-platform spend (multi-provider, model-agnostic).",
   "author": {
     "name": "OptimNow",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -768,10 +768,14 @@ Follow these five steps whenever you add a new domain:
      and version-number collisions between parallel branches (the
      1.27/1.28/1.29/1.30 collision resolved by combined release PR #110).
    - Releasing is a separate, deliberate act: a small dedicated release PR
-     bumps all three together - `plugin.json` version (minor for user-visible
+     bumps all four together - `plugin.json` version (minor for user-visible
      features), `marketplace.json` `metadata.version` (must match plugin.json;
-     CI-gated by `scripts/check-marketplace-version.sh`), and
-     `mcp_server/pyproject.toml` version. Update the marketplace plugin
+     CI-gated by `scripts/check-marketplace-version.sh`),
+     `mcp_server/pyproject.toml` version, and **`server.json`, which carries the
+     version twice** - the top-level `version` and `packages[0].version`, the
+     PyPI package version the MCP Registry advertises. Nothing gates that fourth
+     file, so it is the one that drifts; it was missing from this checklist until
+     the 1.30.0 release. Update the marketplace plugin
      description topic list in the same release PR if new domains shipped.
      The version number is decided at release time, never pre-assigned on
      content branches. Natural release moment: after the monthly content
@@ -954,10 +958,12 @@ Two standing rules that follow from the map:
       `mcp_server/pyproject.toml` are untouched (release-train rule - see step 5
       of "How to add a new reference file"). A `plugin.json` bump reaching main
       publishes to PyPI, so bumps live only in dedicated release PRs.
-- [ ] **Release PR only: bump all three versions together** - `plugin.json`
+- [ ] **Release PR only: bump all four versions together** - `plugin.json`
       (minor for user-visible features), `marketplace.json` `metadata.version`
       (must match; CI-gated by `scripts/check-marketplace-version.sh` via the
-      `marketplace version in sync` workflow), `mcp_server/pyproject.toml`.
+      `marketplace version in sync` workflow), `mcp_server/pyproject.toml`, and
+      `server.json` (two fields: top-level `version` and `packages[0].version`).
+      Only the marketplace one is CI-gated, so check the other three by hand.
 - [ ] Marketplace description in `.claude-plugin/marketplace.json` reflects the new
       topic list (can ride the release PR). It carries no reference count by design -
       see the no-hardcoded-counts rule above.

--- a/mcp_server/pyproject.toml
+++ b/mcp_server/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cloud-finops-mcp"
-version = "1.29.0"
+version = "1.30.0"
 description = "MCP server exposing the OptimNow Cloud FinOps skill (reference library + named-pattern playbooks) as queryable tools."
 readme = "README.md"
 license = { text = "CC-BY-SA-4.0" }

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/OptimNow/cloud-finops-skills",
     "source": "github"
   },
-  "version": "1.29.0",
+  "version": "1.30.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "cloud-finops-mcp",
-      "version": "1.29.0",
+      "version": "1.30.0",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
Twelve PRs since 1.29.0, all user-visible, so a minor bump.

## What shipped

**Prices left the repo.** The dated-price rule (#141) and the figure purge (#142) mean the references no longer carry volatile price figures. What remains is ratios, multipliers and mechanics, with absolute numbers dated inline where a worked example needs one. Current figures are routed to OptimToken (#144).

**Two companion connectors documented.** The AI Pricing Hub (#145) and the AI ROI Calculator (#147). The second came with a new section on quantifying the value side of an AI business case - the four value methods, the trap each one carries, and sensitivity as a reporting discipline.

**The MCP server is reachable by URL** (#148, #150). `alpic.json` carries the build contract, the endpoint is published in README, INSTALLATION.md and the `server.json` remotes block, and it was verified serving all 33 references before being announced.

**A cross-repo dependency map** (#149) and a PR gate for it (#150), because most breakage across this family is documentation drift that no CI check catches.

Plus stale cross-references from the August split repaired (#143), a proper MCP presentation in the README (#151), and the rename to Cloud FinOps Skill & MCP with a refreshed social preview (#152).

## Version bumps

| File | Field |
|---|---|
| `.claude-plugin/plugin.json` | `version` |
| `.claude-plugin/marketplace.json` | `metadata.version` (CI-gated to match) |
| `mcp_server/pyproject.toml` | `version` |
| `server.json` | `version` **and** `packages[0].version` |

## One thing found while doing it

**`server.json` was missing from the release checklist in `CLAUDE.md`,** even though past release PRs did bump it (1.28.1 and 1.29.0 both did). It carries the version twice, and only the marketplace one is CI-gated - so it is precisely the file that drifts silently, and had this release been done from the checklist alone, the MCP Registry would have kept advertising 1.29.0 after PyPI moved to 1.30.0.

Both the release-train section and the PR checklist now name it and say which fields need a manual check.

## Verified before opening

- All five `scripts/check-*.sh` pass; the version gate agrees at 1.30.0
- `uv build --wheel` produces `cloud_finops_mcp-1.30.0-py3-none-any.whl` carrying 58 bundled markdown files

## What merging this does

Merging fires `auto-tag-on-plugin-bump`, which tags `v1.30.0` and triggers the skill-zip release and the PyPI publish. The `pypi` environment approval gate is the manual control point - the publish waits there until approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
