### PR TITLE
Release 1.31.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Cloud FinOps Skill & MCP by OptimNow: reference library, named-pattern playbooks, and a queryable MCP server.",
-    "version": "1.30.0"
+    "version": "1.31.0"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloud-finops",
-  "version": "1.30.0",
+  "version": "1.31.0",
   "description": "Expert FinOps guidance for cloud, AI, SaaS, and data-platform spend (multi-provider, model-agnostic).",
   "author": {
     "name": "OptimNow",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ cloud-finops-skills/
 ├── AGENTS.md              <- Agent-facing repo brief (truncated tree, defers to CLAUDE.md)
 ├── INSTALLATION.md        <- Setup instructions (12 tool integrations) + response contract
 ├── LICENSE.md             <- CC BY-SA 4.0
-├── llms.txt               <- Machine-readable "Key files" list (CI-gated)
+├── llms.txt               <- llmstxt.org-format index (linked sections; CI-gated)
 ├── DEPENDENCIES.md        <- Cross-repo dependency map for the five OptimNow repos,
 │                             plus the "if I change X, what else needs review" table
 ├── install.sh             <- One-liner installer script
@@ -97,11 +97,13 @@ cloud-finops-skills/
 │                             stdio + streamable-HTTP transports; MCP Apps
 │                             `ui://cloud-finops/playbook-viewer` resource)
 ├── scripts/               <- `fcp-coverage.sh` (parses FCP frontmatter, emits
-│                             `fcp-coverage.md` matrix) plus five CI guards run by
-│                             the `CI` workflow: check-artefact-size,
-│                             check-docs-drift, check-llms-txt,
-│                             check-marketplace-version, check-skill-description
-├── fcp-coverage.md        <- Generated FCP capability coverage matrix (22 caps)
+│                             `fcp-coverage.md`; its --check mode diffs the
+│                             committed matrix in CI) plus the guards:
+│                             check-artefact-size, check-docs-drift,
+│                             check-llms-txt, check-skill-description (run by
+│                             the `CI` workflow) and check-marketplace-version
+│                             (its own `marketplace-version-check` workflow)
+├── fcp-coverage.md        <- Generated FCP coverage matrix (22 caps; CI-gated)
 ├── .gitattributes         <- Force LF on *.sh for Windows checkouts
 └── pipeline/              <- Content update pipeline (gitignored, private)
     ├── run_scan.py        <- Fortnightly scan entry point
@@ -164,7 +166,7 @@ execute pass before touching any reference file.
 
 **Operational reference:** `pipeline/MONTHLY_WORKFLOW.md` (gitignored,
 private; only present in the maintainer's local repo) is the step-by-step
-doctrine for running a monthly batch - pre-flight checks, per-item review,
+doctrine for running a batch - pre-flight checks, per-item review,
 execute, PR management, failure-mode handling, cost guidance. The
 `pipeline/README.md` alongside it covers the same workflow at a lower
 technical level. Both are intentionally kept out of public Git history -
@@ -655,10 +657,11 @@ Two standing rules that follow from the map:
 - [ ] README directory listing and "What this skill covers" section updated
 - [ ] CLAUDE.md "Repository structure" directory listing updated (CI-gated by
       `scripts/check-docs-drift.sh` - a reference missing from the tree, or a
-      tree entry with no file behind it, fails the `CI` workflow)
+      tree entry with no file behind it, fails the `CI` workflow. The same
+      script also gates the playbook catalogue in `playbooks/README.md`)
 - [ ] AGENTS.md and llms.txt updated to reflect the new reference (the llms.txt
-      "Key files" list is CI-gated by `scripts/check-llms-txt.sh` - a missing or
-      stale entry fails the `CI` workflow, so this can't drift silently).
+      References section is CI-gated by `scripts/check-llms-txt.sh` - a missing
+      or stale entry fails the `CI` workflow, so this can't drift silently).
       AGENTS.md deliberately does not enumerate references - it shows a
       truncated tree and defers to CLAUDE.md - so there is nothing to update
       there unless the new file changes what AGENTS.md says about the repo.
@@ -671,7 +674,8 @@ Two standing rules that follow from the map:
 - [ ] If adding a new playbook, follow the format in
       `skills/cloud-finops/playbooks/README.md` (frontmatter schema, Problem /
       Symptoms / Detection / Fix / Anti-pattern / See also sections, OptimNow
-      CC BY-SA footer), and update the named-
+      CC BY-SA footer), add it to that README's catalogue table (CI-gated by
+      `scripts/check-docs-drift.sh`), and update the named-
       pattern parenthetical in the ChatGPT / grouped routing tables in
       install.sh. SKILL.md and POWER.md carry representative examples only
       (since the 2026-08 token-efficiency pass) and defer to

--- a/mcp_server/pyproject.toml
+++ b/mcp_server/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cloud-finops-mcp"
-version = "1.30.0"
+version = "1.31.0"
 description = "MCP server exposing the OptimNow Cloud FinOps skill (reference library + named-pattern playbooks) as queryable tools."
 readme = "README.md"
 license = { text = "CC-BY-SA-4.0" }

--- a/server.json
+++ b/server.json
@@ -2,17 +2,17 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.OptimNow/cloud-finops",
   "title": "Cloud FinOps Skill & MCP",
-  "description": "Queryable Cloud FinOps knowledge for AI agents: cloud cost optimisation across AWS, Azure, GCP and OCI, AI inference economics, Kubernetes, Databricks/Fabric/Snowflake, allocation and chargeback, anomaly management, plus named-pattern waste detection playbooks. By OptimNow.",
+  "description": "Queryable Cloud FinOps knowledge for AI agents: AWS/Azure/GCP cost optimisation, waste playbooks.",
   "repository": {
     "url": "https://github.com/OptimNow/cloud-finops-skills",
     "source": "github"
   },
-  "version": "1.30.0",
+  "version": "1.31.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "cloud-finops-mcp",
-      "version": "1.30.0",
+      "version": "1.31.0",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
Release PR per the release-train rule: the four version fields move together to **1.31.0** - `plugin.json`, `marketplace.json` `metadata.version`, `mcp_server/pyproject.toml`, and `server.json` (both fields).

## Why now

Two triggers:

1. **The first `publish-registry` run failed** ([run 32242037079](https://github.com/OptimNow/cloud-finops-skills/actions/runs/32242037079)): the MCP Registry schema caps `description` at **100 characters**, and the 273-character description shipped in #156 was written against no known limit. This PR shortens it to 97 keyword-dense characters. The registry itself told us the constraint - the original short description was never lazy, it was compliant.
2. **PyPI needs a refresh**: everything merged in #156 (SKILL.md trigger description, playbook catalogue, finops-aws.md cleanup, maintainer email moved to the business domain) only reaches the published wheel and the PyPI page through a new version - PyPI forbids re-uploading 1.30.0.

Also carries the CLAUDE.md staleness-audit commit that was stranded on the auto-recreated post-merge branch (now deleted).

## What merging does

The full auto chain fires on the `plugin.json` bump: `verify-package` (now also gating `server.json` versions) -> tag `v1.31.0` -> GitHub Release zip -> **PyPI publish, which waits for your approval on the `pypi` environment** -> `publish-registry`, which waits for PyPI visibility and then publishes the fixed description to the MCP Registry. No manual registry step needed - this release exercises the new automation end to end.

## Verified locally

- All four version fields agree at 1.31.0 (verify-package logic run locally: PASS)
- `check-marketplace-version.sh` PASS
- Wheel builds at 1.31.0 and passes `twine check --strict`
- `server.json` description = 97 chars (limit 100)

🤖 Generated with [Claude Code](https://claude.com/claude-code)