### PR TITLE
Add Big-T notation token complexity classes to the agentic FinOps reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -570,6 +570,10 @@ This skill incorporates content derived from the following sources:
   descriptions, and maturity model structure are based on the FinOps Framework.
 - **[Point Five](https://www.pointfive.co)** - cloud optimisation recommendations
   informed several provider-specific best practices and quick-win patterns.
+- **[Tokenomics Foundation](https://www.tokeneconomics.com/)** - the token complexity
+  classes in the agentic FinOps reference are adapted from *Big-T Notation* by
+  Dan Neff (Adobe), published by the Tokenomics Foundation under
+  [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/).
 
 All referenced content has been adapted with additional context from OptimNow's
 consulting delivery experience. Any errors or opinionated interpretations are our own.

--- a/skills/cloud-finops/references/finops-agentic.md
+++ b/skills/cloud-finops/references/finops-agentic.md
@@ -45,6 +45,56 @@ as "agents":
   by later steps. Output-only quality gates therefore under-detect failure, which
   understates the true cost per successful task.
 
+## Token complexity classes - Big-T notation
+
+Big-T notation (Dan Neff, Adobe; published by the
+[Tokenomics Foundation](https://www.tokeneconomics.com/projects/big-t-notation/)
+under CC BY 4.0) applies the logic of Big-O runtime analysis to token spend: before
+committing to an architecture, ask how the bill scales as usage grows, not what one
+call costs. Token cost scales as **T(n · k · a)**:
+
+- **n** - request volume and input size (the factor everyone forecasts)
+- **k** - model calls per request: reasoning steps, multi-turn chains, tool calls
+  that replay context. Usually invisible in the request as written ("hidden k")
+- **a** - agent depth: sub-agents spawning sub-agents, multiplying k again
+
+| Class | Scaling behaviour | Example |
+|---|---|---|
+| T(1) | Constant - no model call per request | Cache hit, embedding lookup |
+| T(log n) | Sublinear - deterministic code shrinks input before the model sees it | Pre-filter, then summarise the survivors |
+| T(n) | Linear - one call per request, cost proportional to input | Single-shot classification |
+| T(n·k) | Multiplicative - k calls per request, k usually invisible | Multi-turn chat replaying full history every turn |
+| T(n·k·a) | Agent-multiplicative | Orchestrator spawns sub-agents that spawn tool calls |
+| T(∞) | Unbounded - loop with no termination condition | Retry loop without a cap |
+
+This grades the "unbounded per task" verdict in the table above: workflows and
+pipelines sit at T(n) or T(n·k) with a known k; true agents are T(n·k·a) with k and
+a decided at run time; an uncapped retry loop is T(∞) and belongs in incident
+response, not in a budget.
+
+**FinOps implications:**
+
+- **Change the class before optimising the coefficient.** Restructuring a workload
+  from T(n·k) to T(n) - isolated contexts instead of full-history replay, bounded
+  output templates - is worth more than any amount of prompt-shortening inside the
+  wrong class. The framework's own worked example (illustrative, as of August 2026)
+  cut a ten-document summarisation job ~34x by moving it from chat-replay T(n·k) to
+  engineered T(n).
+- **Forecast by class.** A workload's class names the variable that dominates its
+  growth: linear workloads scale with volume, agentic ones with depth and retries.
+  A cost estimate that assumed T(n) for a system built as T(n·k·a) is the usual
+  anatomy of a "30x over estimate" agent pilot.
+- **Hidden k is the audit target.** Reasoning tokens, retries, and context replay
+  rarely appear in request logs. Per-task tracing across providers (see the cost
+  anatomy section below) is what makes k and a observable at all.
+- **Jevons caveat.** Class improvements get reinvested: cheaper per-task cost
+  typically raises run frequency, so total spend falls less than unit cost does.
+  Budget for the rebound, not just the efficiency gain.
+
+The notation itself is durable mechanics; the framework is early-stage (published
+2026) and most of its companion tooling was still unreleased as of August 2026 -
+cite the classification, not the ecosystem.
+
 ## Agentic cost anatomy - where the tokens actually go
 
 - **Refinement is the sink.** ~60% of an agentic task's cost sits in checking,
@@ -175,6 +225,6 @@ making progress treat agent development as iterative learning, not project deliv
 
 ---
 
-> Sources: OptimNow methodology; x402 / MPP provider documentation (linked inline).
+> Sources: OptimNow methodology; Big-T Notation by Dan Neff, Tokenomics Foundation (CC BY 4.0, linked inline); x402 / MPP provider documentation (linked inline).
 
 > *Cloud FinOps Skill by [OptimNow](https://optimnow.io) - licensed under [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/).*


### PR DESCRIPTION
## What changed

- **`skills/cloud-finops/references/finops-agentic.md`** - new section "Token complexity classes - Big-T notation", placed after the workflow/pipeline/agent table. It introduces the T(n · k · a) scaling formula, the six-class ladder (T(1) constant through T(∞) unbounded), and four FinOps implications: change the architectural class before optimising the coefficient, forecast by class, audit hidden k (reasoning tokens, retries, context replay), and budget for the Jevons rebound. The source footer now credits the framework.
- **`README.md`** - Tokenomics Foundation added to the Acknowledgements section, attributing *Big-T Notation* to Dan Neff (Adobe), CC BY 4.0.

## Why

The agentic reference already states that true-agent cost is "unbounded per task" (~30x variance) but had no vocabulary for grading that unboundedness. Big-T notation supplies exactly that: a compact, durable classification for how a token bill scales, which answers the recurring client question "why did the agent pilot cost 30x the estimate?" (answer: the estimate assumed T(n), the system was built as T(n·k·a)).

## Reviewer notes

- **Licensing:** CC BY 4.0 material folds one-way into this repo's CC BY-SA 4.0 with attribution; attribution is present in three places (section intro, source footer, README acknowledgements).
- **Content rules respected:** no absolute price figures (the 34x saving is a ratio, marked illustrative and dated August 2026 inline), no em dashes, British spelling, OptimNow footer intact.
- **Early-stage caveat included:** the section tells readers to cite the classification, not the framework's companion tooling, which was still unreleased as of August 2026. The Tokenomics Foundation's Linux Foundation affiliation is its own claim; the attribution leans on the individual author for that reason.
- **Deliberately excluded:** the same foundation's "Five-Layer Tokenomics Stack" was evaluated in the same session and not adopted - its substance already exists across the AI references.
- Content-only PR: no new file, so no routing-table / llms.txt / install.sh changes, and no version bump (release-train rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)