### PR TITLE
Content update: AI token economics reference, detection and commitment guidance

### DIFF
--- a/skills/cloud-finops/playbooks/cross-cloud-schedule-blindness.md
+++ b/skills/cloud-finops/playbooks/cross-cloud-schedule-blindness.md
@@ -30,11 +30,18 @@ asleep.
   Cloud Monitoring
 - Tagged `env=dev` / `env=test` / `env=qa` instances have the same
   utilisation profile as production
+- Sunday and Tuesday hourly usage curves overlap (the flat-Sunday
+  signature)
 - The non-prod / prod cost ratio is > 1:3 (mature orgs are typically
   1:5 to 1:10 because non-prod is auto-stopped)
 - No team-owned automation visible in the IaC repo for stop / start
 
 ## Detection
+
+Confirm with the flat-Sunday signature before scheduling anything: a
+genuinely weekday-only workload shows a visible weekend trough, while a
+curve that is flat across Sunday and Tuesday does not. Then quantify the
+spend at stake:
 
 **AWS** - CUR over 30 days, instance-hours by environment tag:
 

--- a/skills/cloud-finops/references/finops-ai-self-hosted-vs-managed.md
+++ b/skills/cloud-finops/references/finops-ai-self-hosted-vs-managed.md
@@ -93,7 +93,10 @@ To this you add:
 ## The hidden cost surface of self-hosting
 
 This is the part TCO calculators omit. It is also where most self-hosting projects bleed
-their savings.
+their savings. In five-layer terms (the Tokenomics Foundation stack referenced in
+`finops-for-ai.md`), self-hosting means taking ownership of L2, L3 and L4 - capacity,
+inference stack, model and quantisation - while a managed API leaves you only L5,
+routing and governance. Everything below is the operational bill for those three layers.
 
 ### Operational costs
 

--- a/skills/cloud-finops/references/finops-aws-commitments.md
+++ b/skills/cloud-finops/references/finops-aws-commitments.md
@@ -337,6 +337,13 @@ with no recourse. Organisations that build a diversified portfolio with staggere
 expiry dates always have a portion of their commitment approaching renewal, creating
 a natural rebalancing rhythm.
 
+**Size the first tranche at the keel commitment** - the usage level that has never
+left the water across the trailing 12 months. Below the keel, committing needs no
+forecast: that spend is already sunk. Every point of coverage above it is a bet on a
+forecast, and belongs in the phased blocks below. Re-measure the keel quarterly; it
+moves when workloads are decommissioned or migrated, not when traffic fluctuates,
+and a falling keel is an early liquidity warning.
+
 ### Phased purchasing
 
 Never buy the full commitment in a single transaction. Purchase in blocks to create
@@ -385,7 +392,7 @@ smaller decisions.
 **Phased purchasing framework (quarterly example for steady consumption):**
 
 ```
-Quarter 1: Buy 20-25% of target commitment (the floor you are certain about)
+Quarter 1: Buy 20-25% of target commitment (the keel commitment - the floor you are certain about)
   → Monitor utilisation for 30 days
   → If utilisation >80%: proceed to next block
   → If utilisation <80%: investigate before buying more

--- a/skills/cloud-finops/references/finops-azure-commitments.md
+++ b/skills/cloud-finops/references/finops-azure-commitments.md
@@ -836,6 +836,14 @@ window where possible.
 
 Source: https://learn.microsoft.com/en-us/azure/cost-management-billing/reservations/exchange-and-refund-azure-reservations
 
+**Size the first tranche at the keel commitment** - the usage level that has never
+left the water across the trailing 12 months. Below the keel, committing needs no
+forecast: that spend is already sunk. Every point of coverage above it is a bet on a
+forecast, and belongs in the phased blocks below. Re-measure the keel quarterly; it
+moves when workloads are decommissioned or migrated, not when traffic fluctuates,
+and a falling keel is an early liquidity warning - on Azure doubly so after
+1 February 2027, when the refund cap becomes the main reshaping lever.
+
 ### Phased purchasing
 
 Never buy the full commitment in a single transaction. Purchase in blocks to create
@@ -893,7 +901,7 @@ Reservation management.
 **Phased purchasing framework (quarterly example for steady consumption):**
 
 ```
-Quarter 1: Buy 20-25% of target commitment (the floor you are certain about)
+Quarter 1: Buy 20-25% of target commitment (the keel commitment - the floor you are certain about)
   -> Monitor utilisation for 30 days via Azure Advisor and Cost Management
   -> If utilisation >80%: proceed to next block
   -> If utilisation <80%: investigate before buying more

--- a/skills/cloud-finops/references/finops-for-ai.md
+++ b/skills/cloud-finops/references/finops-for-ai.md
@@ -57,6 +57,21 @@ Cost allocation must happen *before* the cost is created, not after the bill arr
 Organisations that wait for monthly invoices to understand AI spend are already operating
 with a structural disadvantage that compounds with every new model deployment.
 
+**Where token cost is actually determined.** Token cost is not one number but the
+output of decisions stacked across the serving path. The Tokenomics Foundation - a
+Linux Foundation project launched in 2026 to standardise AI cost management, with
+token cost telemetry in the FOCUS specification on its roadmap - decomposes it as a
+five-layer stack in *The Five-Layer Tokenomics Stack*
+(<https://www.tokeneconomics.com/projects/the-five-layer-tokenomics-stack/the-five-layer-tokenomics-stack-paper/>,
+stack concept credited to Ambud Sharma, Pinterest): L1 silicon (chip generation),
+L2 capacity (hardware selection, placement, utilisation), L3 inference stack
+(serving engine, caching, batching), L4 model and quantisation, L5 routing and
+governance (budgets, agent caps). The framing is diagnostic: a unit-cost problem
+blamed on the model (L4) often lives in utilisation (L2) or batching (L3), and the
+only layer most API consumers control is L5 - which is where this file's routing
+and governance guidance operates. The foundation is young; treat its specifications
+as roadmap until published.
+
 ---
 
 ## The four-phase AI FinOps implementation

--- a/skills/cloud-finops/references/finops-waste-detection-playbooks.md
+++ b/skills/cloud-finops/references/finops-waste-detection-playbooks.md
@@ -401,6 +401,11 @@ work during business hours. Dev, test, and staging environments are the
 classic case. Some production workloads (batch processing, weekly
 reporting jobs) also fit.
 
+The quickest confirmation is the flat-Sunday signature: pull the
+resource's hourly usage curve for a Sunday and a Tuesday, and if the two
+are indistinguishable, nobody is switching this workload off - schedules,
+not sizing, are the fix.
+
 ### Common patterns
 
 | Pattern | Signal | Detection approach |


### PR DESCRIPTION
## What changed

Three small content improvements, no new reference file, no version bump (release-train rule):

**AI token economics reference.** `finops-for-ai.md` now cites the Tokenomics Foundation - the Linux Foundation project launched in 2026 to standardise AI cost management, with token cost telemetry in the FOCUS specification on its roadmap - and its *Five-Layer Tokenomics Stack* paper (stack concept credited to Ambud Sharma, Pinterest) as a diagnostic decomposition of where token cost is actually determined (L1 silicon through L5 routing + governance). Carries the young-organisation caveat per the sourcing rules. `finops-ai-self-hosted-vs-managed.md` maps its build-vs-buy split onto the same layers: self-hosting owns L2-L4, a managed API leaves only L5.

**Schedule-blindness detection.** The waste taxonomy and the `cross-cloud-schedule-blindness` playbook now name the quick confirmation check (compare a resource's Sunday and Tuesday hourly curves before scheduling anything) in Pattern shape, Symptoms, and Detection.

**Commitment sizing.** Both commitments files (AWS + Azure, deliberately mirrored) name the liquidity floor the first tranche should be sized at, tie it into the existing quarterly phased-purchasing framework, and add a quarterly re-measurement discipline; the Azure variant notes the post-February-2027 refund-cap angle.

## Checklist

- No version bump; footers intact; no em dashes; British spelling; no absolute price figures.
- Guards green locally: docs-drift, llms-txt, skill-description.
- Mechanics claims: the foundation's existence and roadmap are sourced from Linux Foundation announcements; the paper is cited by title with link and credited author, framework only (no figures).