### PR TITLE
Release 1.32.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Cloud FinOps Skill & MCP by OptimNow: reference library, named-pattern playbooks, and a queryable MCP server.",
-    "version": "1.31.0"
+    "version": "1.32.0"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloud-finops",
-  "version": "1.31.0",
+  "version": "1.32.0",
   "description": "Expert FinOps guidance for cloud, AI, SaaS, and data-platform spend (multi-provider, model-agnostic).",
   "author": {
     "name": "OptimNow",

--- a/mcp_server/pyproject.toml
+++ b/mcp_server/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cloud-finops-mcp"
-version = "1.31.0"
+version = "1.32.0"
 description = "MCP server exposing the OptimNow Cloud FinOps skill (reference library + named-pattern playbooks) as queryable tools."
 readme = "README.md"
 license = { text = "CC-BY-SA-4.0" }

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/OptimNow/cloud-finops-skills",
     "source": "github"
   },
-  "version": "1.31.0",
+  "version": "1.32.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "cloud-finops-mcp",
-      "version": "1.31.0",
+      "version": "1.32.0",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
Release-train bump: `plugin.json`, `marketplace.json` `metadata.version`, `mcp_server/pyproject.toml`, and `server.json` (both fields) move to **1.32.0** together (minor bump - user-visible features shipped).

**Merge order matters: merge PR #161 first**, then this one - the tag snapshots main at this merge, and the release should include the content update.

What ships since 1.31.0:
- MCP/skill alignment: the price-figures contract now reaches MCP-only consumers; `content_version.txt` bundle stamp logged at startup (a stale deployment is now self-identifying)
- Connectors Directory conformance: tool titles + read-only annotations, connection docs (Settings -> Connectors path, no `claude_desktop_config.json`)
- MCP Apps widget suite: playbook explorer + coverage matrix, playbook viewer v2 (copy buttons, fix checklist, see-also navigation), reference browser - with the 10 adversarial-review fixes and harness validation; full test suite now passes on Windows
- Content: Tokenomics Foundation / five-layer stack reference, sharpened schedule-blindness detection, commitment first-tranche sizing guidance

Post-merge chain (automated): auto-tag creates v1.32.0 -> release zip + PyPI publish (gated by the `pypi` environment approval - your manual control point) -> MCP Registry publish after PyPI visibility. Manual follow-ups: redeploy Alpic, then verify the hosted endpoint's startup stamp says 1.32.0.