### PR TITLE
Fix the copyright holder line in LICENSE.md

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)
 
-Copyright 2025–2026 OptimNow (James Barney)
+Copyright 2025–2026 OptimNow (Jean Latière)
 
 This work is licensed under the Creative Commons Attribution-ShareAlike 4.0
 International License.


### PR DESCRIPTION
The LICENSE.md copyright line has named the wrong person since the repo's first commit (authoring error at creation, never reviewed). Corrected to Jean Latiere (OptimNow). Found because a third-party redistribution faithfully copied the wrong attribution into its own footer. If you prefer plain "Copyright 2025-2026 OptimNow" with no personal name, amend before merging.