### PR TITLE
Release 1.32.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Cloud FinOps Skill & MCP by OptimNow: reference library, named-pattern playbooks, and a queryable MCP server.",
-    "version": "1.32.0"
+    "version": "1.32.1"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloud-finops",
-  "version": "1.32.0",
+  "version": "1.32.1",
   "description": "Expert FinOps guidance for cloud, AI, SaaS, and data-platform spend (multi-provider, model-agnostic).",
   "author": {
     "name": "OptimNow",

--- a/mcp_server/pyproject.toml
+++ b/mcp_server/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cloud-finops-mcp"
-version = "1.32.0"
+version = "1.32.1"
 description = "MCP server exposing the OptimNow Cloud FinOps skill (reference library + named-pattern playbooks) as queryable tools."
 readme = "README.md"
 license = { text = "CC-BY-SA-4.0" }

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/OptimNow/cloud-finops-skills",
     "source": "github"
   },
-  "version": "1.32.0",
+  "version": "1.32.1",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "cloud-finops-mcp",
-      "version": "1.32.0",
+      "version": "1.32.1",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
Patch release-train bump (all four version holders together). Sole payload: the LICENSE.md copyright-holder correction from #163, so the corrected attribution ships in the PyPI package, the release zip, and the hosted deployment. Post-merge: auto-tag v1.32.1 -> PyPI publish (gated by the pypi environment approval) -> registry publish. Manual follow-up: redeploy Alpic.