### PR TITLE
Declare the MCP Apps sandbox domain (ui.domain) on the widget resources

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -392,14 +392,19 @@ connector "gets the text fallback no matter how correct it is" is no
 longer the whole story - but whether a correct `ui.domain` is *sufficient*
 for rendering is still unproven for this repo's connector: the render test
 needs the connector added to the account and the Alpic deployment current.
-Per the test-first rule, `_meta.ui.domain` is NOT set on the resources;
-the precomputed value for the canonical URL
-`https://cloud-finops-skills-590a051d.alpic.live/mcp` is
-`1a3b12085dbe8a536c1a9f86d2e7e1a1.claudemcpcontent.com` - apply it only if
-a real render attempt fails with that log signature. When computing it,
-hash the public connector URL exactly as users are told to enter it, never
-an internal path - the wrong-input variant of this is exactly what broke
-ai-pricing-hub-mcp (fixed 2026-08-19).
+The real render attempt happened on 2026-08-19 (four prompts through the
+connector on claude.ai): tools executed, the host reserved the widget
+iframe, the frame stayed blank - the predicted failure. `ui.domain` was
+therefore applied on 2026-08-20: the three widget resources declare
+`meta={"ui": {"domain": ...}}` where the value is DERIVED in server.py
+from `CANONICAL_CONNECTOR_URL` (sha256 of the URL exactly as users enter
+it, no trailing slash, first 32 hex chars + `.claudemcpcontent.com`) and
+pinned by tests. When touching this, never hash an internal path instead
+of the public URL - that wrong-input variant is exactly what broke
+ai-pricing-hub-mcp. Correction to an earlier note in this entry:
+ai-pricing-hub was NOT fixed on 2026-08-19 - no such fix exists in that
+repo and its failures were still logging at 17:30 that day; it needs the
+same change as this one.
 
 ### A packaged artefact cannot own volatile data (2026-08-17)
 

--- a/mcp_server/src/cloud_finops_mcp/server.py
+++ b/mcp_server/src/cloud_finops_mcp/server.py
@@ -9,6 +9,7 @@ streamable HTTP (for a hosted deployment). The actual tool logic lives in
 
 from __future__ import annotations
 
+import hashlib
 import logging
 from pathlib import Path
 from typing import Any
@@ -50,6 +51,38 @@ DEFAULT_HTTP_PORT = 8000
 PLAYBOOK_VIEWER_URI = "ui://cloud-finops/playbook-viewer"
 PLAYBOOK_EXPLORER_URI = "ui://cloud-finops/playbook-explorer"
 REFERENCE_BROWSER_URI = "ui://cloud-finops/reference-browser"
+
+# The claude.ai / Claude Desktop MCP Apps host only mounts a widget iframe
+# when the ui:// resource declares the sandbox domain it will be served from:
+# sha256(<connector URL exactly as the user entered it in Settings, no
+# trailing slash>)[:32] + ".claudemcpcontent.com". A wrong or missing value
+# logs "ui.domain validation failed for connector <url>" in the host log
+# (mcp-ext-apps-host) and leaves a dead blank frame - observed live on
+# 2026-08-19 for both this server and ai-pricing-hub. The hash is DERIVED
+# from the canonical URL rather than pasted, so the URL constant is the only
+# thing that has to stay true; hashing an internal path instead of the
+# public URL is exactly the mistake that broke ai-pricing-hub.
+CANONICAL_CONNECTOR_URL = "https://cloud-finops-skills-590a051d.alpic.live/mcp"
+UI_DOMAIN = (
+    hashlib.sha256(CANONICAL_CONNECTOR_URL.encode("utf-8")).hexdigest()[:32]
+    + ".claudemcpcontent.com"
+)
+_UI_RESOURCE_META = {"ui": {"domain": UI_DOMAIN}}
+
+
+def _ui_tool_meta(resource_uri: str) -> dict[str, Any]:
+    """Tool-side widget link, declared under every key shape hosts read.
+
+    The working reference (ai-pricing-hub's tool listing as captured in the
+    Desktop logs) declares all three: the SEP-1865 nested form, the flat
+    slash form, and the OpenAI Apps SDK form. Redundant on any one host,
+    but each host reads a different one and the duplication is three lines.
+    """
+    return {
+        "ui": {"resourceUri": resource_uri},
+        "ui/resourceUri": resource_uri,
+        "openai/outputTemplate": resource_uri,
+    }
 
 _UI_DIR = Path(__file__).resolve().parent / "ui"
 _UI_MARKERS = (
@@ -102,7 +135,7 @@ mcp = FastMCP(
 @mcp.tool(
     title="List FinOps references",
     annotations=_READ_ONLY,
-    meta={"ui": {"resourceUri": REFERENCE_BROWSER_URI}},
+    meta=_ui_tool_meta(REFERENCE_BROWSER_URI),
 )
 def list_references() -> dict[str, Any]:
     """List every bundled FinOps reference with its FCP metadata.
@@ -142,7 +175,7 @@ def get_reference(name: str) -> dict[str, Any]:
 @mcp.tool(
     title="Find FinOps references by facet",
     annotations=_READ_ONLY,
-    meta={"ui": {"resourceUri": REFERENCE_BROWSER_URI}},
+    meta=_ui_tool_meta(REFERENCE_BROWSER_URI),
 )
 def find_references(
     domain: str | None = None,
@@ -191,7 +224,7 @@ def find_references(
 @mcp.tool(
     title="List waste playbooks",
     annotations=_READ_ONLY,
-    meta={"ui": {"resourceUri": PLAYBOOK_EXPLORER_URI}},
+    meta=_ui_tool_meta(PLAYBOOK_EXPLORER_URI),
 )
 def list_playbooks() -> dict[str, Any]:
     """List every bundled named-pattern playbook.
@@ -213,7 +246,7 @@ def list_playbooks() -> dict[str, Any]:
 @mcp.tool(
     title="Get a waste playbook",
     annotations=_READ_ONLY,
-    meta={"ui": {"resourceUri": PLAYBOOK_VIEWER_URI}},
+    meta=_ui_tool_meta(PLAYBOOK_VIEWER_URI),
 )
 def get_playbook(name: str) -> dict[str, Any]:
     """Fetch the full markdown content of one playbook by slug.
@@ -240,6 +273,7 @@ def get_playbook(name: str) -> dict[str, Any]:
 
 @mcp.resource(
     PLAYBOOK_VIEWER_URI,
+    meta=_UI_RESOURCE_META,
     name="Playbook viewer",
     mime_type="text/html;profile=mcp-app",
 )
@@ -258,6 +292,7 @@ def playbook_viewer_ui() -> str:
 
 @mcp.resource(
     PLAYBOOK_EXPLORER_URI,
+    meta=_UI_RESOURCE_META,
     name="Playbook explorer",
     mime_type="text/html;profile=mcp-app",
 )
@@ -276,6 +311,7 @@ def playbook_explorer_ui() -> str:
 
 @mcp.resource(
     REFERENCE_BROWSER_URI,
+    meta=_UI_RESOURCE_META,
     name="Reference browser",
     mime_type="text/html;profile=mcp-app",
 )
@@ -293,7 +329,7 @@ def reference_browser_ui() -> str:
 @mcp.tool(
     title="Find waste playbooks by facet",
     annotations=_READ_ONLY,
-    meta={"ui": {"resourceUri": PLAYBOOK_EXPLORER_URI}},
+    meta=_ui_tool_meta(PLAYBOOK_EXPLORER_URI),
 )
 def find_playbooks(
     scope: str | None = None,

--- a/mcp_server/tests/test_ui.py
+++ b/mcp_server/tests/test_ui.py
@@ -131,9 +131,47 @@ async def test_tools_link_their_widgets() -> None:
     by_name = {t.name: t for t in tools}
     for tool_name, uri in EXPECTED_TOOL_WIRING.items():
         meta = by_name[tool_name].meta or {}
+        # Declared under every key shape hosts read (SEP-1865 nested, flat
+        # slash form, OpenAI Apps SDK form) - see server._ui_tool_meta.
         assert meta.get("ui", {}).get("resourceUri") == uri, (
             f"{tool_name} does not declare {uri}"
         )
+        assert meta.get("ui/resourceUri") == uri
+        assert meta.get("openai/outputTemplate") == uri
     # get_reference deliberately has no widget: its content is read inside
     # the reference browser via an app-initiated call.
     assert not (by_name["get_reference"].meta or {}).get("ui")
+
+
+def test_ui_domain_is_derived_from_the_canonical_connector_url() -> None:
+    """The sandbox-domain hash must follow the URL constant, never drift.
+
+    The claude host validates sha256(<connector URL as entered, no trailing
+    slash>)[:32] + ".claudemcpcontent.com" against the resource meta; a
+    pasted hash that stops matching the URL is the ai-pricing-hub failure
+    mode.
+    """
+    import hashlib
+
+    assert not server.CANONICAL_CONNECTOR_URL.endswith("/"), (
+        "the connector URL is hashed as entered - no trailing slash"
+    )
+    expected = (
+        hashlib.sha256(server.CANONICAL_CONNECTOR_URL.encode("utf-8")).hexdigest()[:32]
+        + ".claudemcpcontent.com"
+    )
+    assert server.UI_DOMAIN == expected
+
+
+async def test_ui_resources_declare_the_sandbox_domain() -> None:
+    """Without ui.domain the host kills the iframe after reserving it."""
+    resources = await server.mcp.list_resources()
+    checked = 0
+    for r in resources:
+        if str(r.uri) in WIDGETS:
+            meta = r.meta or {}
+            assert meta.get("ui", {}).get("domain") == server.UI_DOMAIN, (
+                f"{r.uri} does not declare ui.domain"
+            )
+            checked += 1
+    assert checked == len(WIDGETS)


### PR DESCRIPTION
The 2026-08-19 live test through the claude.ai connector reproduced the predicted failure: tool calls succeed, the host reserves the widget iframe, the frame stays blank - the custom-connector `ui.domain` validation (same log signature observed for ai-pricing-hub the same day).

Fix: the three `ui://cloud-finops/*` resources declare `meta={"ui": {"domain": sha256(CANONICAL_CONNECTOR_URL)[:32] + ".claudemcpcontent.com"}}`, derived at import rather than pasted; tool-side widget links are declared under the three key shapes hosts read (nested, flat, `openai/outputTemplate`). Tests pin all of it. CLAUDE.md lesson updated accordingly.

No version bump (rides the next release for PyPI); **Alpic redeploy needed after merge** for the hosted connector to serve it, then re-run the widget test prompts.