### PR TITLE
find_references: persona_primary_only flag; log zero-result queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ patterns.
 |---|---|
 | `list_references()` | What is in the library? Every reference with its FinOps Framework metadata |
 | `get_reference(name)` | Give me the full text of one |
-| `find_references(domain?, capability?, phase?, persona?, maturity?)` | Which references serve Rate Optimization, at Walk maturity, written for Engineering? |
+| `find_references(domain?, capability?, phase?, persona?, maturity?, persona_primary_only?)` | Which references serve Rate Optimization, at Walk maturity, written for Engineering? (`persona_primary_only` cuts to the primary audience - broad personas collaborate on nearly everything) |
 
 **Playbooks** - small named-pattern runbooks, one waste pattern each. Reach for these for
 "how do I detect and fix this specific thing".

--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -21,7 +21,7 @@ Six tools, all read-only, split across two surfaces.
 |---|---|
 | `list_references()` | List all references with their FCP metadata. |
 | `get_reference(name)` | Fetch the full markdown body of one reference. |
-| `find_references(domain?, capability?, phase?, persona?, maturity?)` | Faceted query over the FinOps Capability/Phase frontmatter. |
+| `find_references(domain?, capability?, phase?, persona?, maturity?, persona_primary_only?)` | Faceted query over the FinOps Capability/Phase frontmatter. |
 
 The reference faceted query supports any combination of:
 
@@ -29,6 +29,9 @@ The reference faceted query supports any combination of:
 - `capability` - FinOps capability (matches both primary and secondary)
 - `phase` - `Inform`, `Optimize`, `Operate`
 - `persona` - matches both primary and collaborating personas
+- `persona_primary_only` - optional flag: match `persona` against the primary
+  list only. Broad personas (Engineering) collaborate on nearly every file,
+  so the default match barely narrows; the flag is the reading-list cut.
 - `maturity` - `Crawl`, `Walk`, `Run`
 
 **Playbooks** - small named-pattern runbooks (~80-130 lines each):

--- a/mcp_server/src/cloud_finops_mcp/server.py
+++ b/mcp_server/src/cloud_finops_mcp/server.py
@@ -114,8 +114,9 @@ mcp = FastMCP(
         "REFERENCES (long-form provider/discipline files) and PLAYBOOKS "
         "(small named-pattern runbooks for specific waste patterns). "
         "REFERENCES: list_references() to discover, find_references(domain=, "
-        "capability=, phase=, persona=, maturity=) to narrow by FinOps "
-        "Capability/Phase facets, get_reference(name=) to fetch one body. "
+        "capability=, phase=, persona=, maturity=, persona_primary_only=) to "
+        "narrow by FinOps Capability/Phase facets, get_reference(name=) to "
+        "fetch one body. "
         "PLAYBOOKS: list_playbooks() to discover, find_playbooks(scope=, "
         "service=, waste_category=, confidence=) to narrow by pattern facets, "
         "get_playbook(name=) to fetch one body. "
@@ -183,6 +184,7 @@ def find_references(
     phase: str | None = None,
     persona: str | None = None,
     maturity: str | None = None,
+    persona_primary_only: bool = False,
 ) -> dict[str, Any]:
     """Filter references by FinOps Capability/Phase (FCP) frontmatter.
 
@@ -195,6 +197,7 @@ def find_references(
 
     - ``find_references(domain="Optimize Usage & Cost")``
     - ``find_references(phase="Optimize", persona="Engineering")``
+    - ``find_references(persona="Engineering", persona_primary_only=True)``
     - ``find_references(capability="Rate Optimization")``
     - ``find_references(maturity="Crawl")``
 
@@ -207,6 +210,13 @@ def find_references(
         persona: Persona (matches ``fcp_personas_primary`` and
             ``fcp_personas_collaborating``).
         maturity: Entry maturity level (``"Crawl"``, ``"Walk"``, ``"Run"``).
+        persona_primary_only: when True, ``persona`` matches only the primary
+            list. Use it when the default match barely narrows the set -
+            broad personas like Engineering collaborate on nearly every file,
+            so filtering on collaboration is descriptive, not discriminating.
+            ``persona="Engineering", persona_primary_only=True`` is the
+            engineering reading list; the default is the everything-they-touch
+            view.
 
     Returns ``{"filters": {...}, "references": [...], "total": N}``. A query
     that matches nothing also returns `hint` and `valid_values`, so a typo is
@@ -218,6 +228,7 @@ def find_references(
         phase=phase,
         persona=persona,
         maturity=maturity,
+        persona_primary_only=persona_primary_only,
     )
 
 

--- a/mcp_server/src/cloud_finops_mcp/tools.py
+++ b/mcp_server/src/cloud_finops_mcp/tools.py
@@ -13,6 +13,7 @@ pattern each.
 from __future__ import annotations
 
 import difflib
+import logging
 from typing import Any
 
 from .metadata import (
@@ -23,6 +24,20 @@ from .metadata import (
     get_playbook_by_name,
     get_playbook_index,
 )
+
+logger = logging.getLogger(__name__)
+
+
+def _log_zero_result(tool: str, active: dict[str, Any]) -> None:
+    """Log a faceted query that matched nothing.
+
+    A zero-result query is the purest coverage signal there is: an agent
+    (so, a user) asked for something the bundled set does not have. The
+    marker string is grepped from the hosted deployment's logs during the
+    periodic coverage review (see the maintainer coverage-probe doctrine),
+    which is why it must stay stable.
+    """
+    logger.info("zero-result query: %s filters=%r", tool, active)
 
 
 def list_references() -> dict[str, Any]:
@@ -77,11 +92,20 @@ def _matches_list(values: list[str], filter_value: str) -> bool:
     return any(v.casefold() == fv for v in values)
 
 
-def _persona_match(ref: Reference, persona: str) -> bool:
-    """Persona filter checks both primary and collaborating lists."""
-    return _matches_list(ref.fcp_personas_primary, persona) or _matches_list(
-        ref.fcp_personas_collaborating, persona
-    )
+def _persona_match(ref: Reference, persona: str, primary_only: bool = False) -> bool:
+    """Persona filter checks the primary list, plus collaborating by default.
+
+    The collaborating check is opt-out for a reason found in the field: a
+    persona like Engineering collaborates on nearly everything in FinOps, so
+    the OR over both lists barely narrows anything (the 2026-08-19 test
+    measured exactly one exclusion across the whole library). The metadata is
+    descriptively correct; ``primary_only`` is the operational cut.
+    """
+    if _matches_list(ref.fcp_personas_primary, persona):
+        return True
+    if primary_only:
+        return False
+    return _matches_list(ref.fcp_personas_collaborating, persona)
 
 
 def _capability_match(ref: Reference, capability: str) -> bool:
@@ -189,6 +213,7 @@ def find_references(
     phase: str | None = None,
     persona: str | None = None,
     maturity: str | None = None,
+    persona_primary_only: bool = False,
 ) -> dict[str, Any]:
     """Filter references by FCP frontmatter.
 
@@ -208,6 +233,11 @@ def find_references(
             ``"Engineering"``.
         maturity: ``Crawl``, ``Walk``, or ``Run`` - the entry gate below which
             the reference is premature.
+        persona_primary_only: when True, ``persona`` matches only
+            ``fcp_personas_primary``. Use it when the default match barely
+            narrows the set - broad personas like Engineering collaborate on
+            nearly every file, so the collaborating list is descriptive
+            rather than discriminating.
     """
     filters = {
         "domain": domain,
@@ -226,7 +256,9 @@ def find_references(
             continue
         if "phase" in active and not _matches_list(ref.fcp_phases, active["phase"]):
             continue
-        if "persona" in active and not _persona_match(ref, active["persona"]):
+        if "persona" in active and not _persona_match(
+            ref, active["persona"], primary_only=persona_primary_only
+        ):
             continue
         if "maturity" in active and not _matches_scalar(
             ref.fcp_maturity_entry, active["maturity"]
@@ -234,13 +266,18 @@ def find_references(
             continue
         matches.append(ref)
 
+    reported_filters: dict[str, Any] = dict(active)
+    if persona_primary_only and "persona" in active:
+        reported_filters["persona_primary_only"] = True
+
     result: dict[str, Any] = {
-        "filters": active,
+        "filters": reported_filters,
         "references": [r.to_dict() for r in matches],
         "total": len(matches),
     }
     if not matches and active:
         result.update(_empty_result_help(active, reference_vocabulary()))
+        _log_zero_result("find_references", reported_filters)
     return result
 
 
@@ -352,4 +389,5 @@ def find_playbooks(
     }
     if not matches and active:
         result.update(_empty_result_help(active, playbook_vocabulary()))
+        _log_zero_result("find_playbooks", active)
     return result

--- a/mcp_server/tests/test_tools.py
+++ b/mcp_server/tests/test_tools.py
@@ -237,3 +237,43 @@ def test_vocabulary_helpers_are_derived_from_data() -> None:
     ref_vocab = tools.reference_vocabulary()
     assert set(ref_vocab["maturity"]) <= {"Crawl", "Walk", "Run"}
     assert set(ref_vocab["phase"]) <= {"Inform", "Optimize", "Operate"}
+
+
+# --- persona_primary_only (2026-08-20, from the connector field test) --------
+
+
+def test_persona_primary_only_narrows_the_set() -> None:
+    """Broad personas collaborate everywhere; the flag is the operational cut.
+
+    The 2026-08-19 field test measured persona="Engineering" excluding exactly
+    one reference over the whole library - the collaborating list makes the
+    default filter descriptive rather than discriminating.
+    """
+    default = tools.find_references(persona="Engineering")
+    primary = tools.find_references(persona="Engineering", persona_primary_only=True)
+    assert 0 < primary["total"] < default["total"]
+    names_default = {r["name"] for r in default["references"]}
+    names_primary = {r["name"] for r in primary["references"]}
+    assert names_primary < names_default
+    # finops-itam lists Engineering only as collaborating: kept by the
+    # default match, cut by the primary-only one.
+    assert "finops-itam" in names_default
+    assert "finops-itam" not in names_primary
+    # The applied flag is echoed in the filters so the caller can see that
+    # a narrowing actually happened.
+    assert primary["filters"].get("persona_primary_only") is True
+    assert "persona_primary_only" not in default["filters"]
+
+
+def test_zero_result_faceted_query_is_logged(caplog) -> None:
+    """A zero-result query is the purest coverage-gap signal; it must leave
+    a grep-able trace in the server logs."""
+    import logging
+
+    with caplog.at_level(logging.INFO, logger="cloud_finops_mcp.tools"):
+        tools.find_playbooks(scope="aws", waste_category="nonexistent")
+        tools.find_references(persona="Nonexistent Persona")
+    zero_logs = [r.message for r in caplog.records if "zero-result query" in r.message]
+    assert len(zero_logs) == 2
+    assert any("find_playbooks" in m for m in zero_logs)
+    assert any("find_references" in m for m in zero_logs)


### PR DESCRIPTION
Two additive instrumentation changes from the 2026-08-19 field test:

- **`persona_primary_only` flag on `find_references`** - the field test showed `persona="Engineering"` excluding exactly one reference across the whole library (broad personas collaborate on nearly everything). The flag gives the reading-list cut without touching the frontmatter, and is echoed in the result's `filters` so a caller can see that narrowing happened. Docstrings updated in all three copies per the tool-surface rule.
- **Zero-result query logging** in both faceted tools: `zero-result query: <tool> filters=...` at INFO. The hosted deployment's logs become a demand-side coverage sensor - each hit is a user asking for something the library lacks - read during the periodic coverage review alongside playbook-coverage.md and the probe battery.

No renamed or removed fields; tests added (87 pass locally).