### PR TITLE
Mirror the Skybridge widget shape so Claude renders the MCP Apps

### DIFF
--- a/mcp_server/src/cloud_finops_mcp/server.py
+++ b/mcp_server/src/cloud_finops_mcp/server.py
@@ -62,12 +62,41 @@ REFERENCE_BROWSER_URI = "ui://cloud-finops/reference-browser"
 # from the canonical URL rather than pasted, so the URL constant is the only
 # thing that has to stay true; hashing an internal path instead of the
 # public URL is exactly the mistake that broke ai-pricing-hub.
-CANONICAL_CONNECTOR_URL = "https://cloud-finops-skills-590a051d.alpic.live/mcp"
+CANONICAL_CONNECTOR_ORIGIN = "https://cloud-finops-skills-590a051d.alpic.live"
+CANONICAL_CONNECTOR_URL = CANONICAL_CONNECTOR_ORIGIN + "/mcp"
 UI_DOMAIN = (
     hashlib.sha256(CANONICAL_CONNECTOR_URL.encode("utf-8")).hexdigest()[:32]
     + ".claudemcpcontent.com"
 )
-_UI_RESOURCE_META = {"ui": {"domain": UI_DOMAIN}}
+
+# Skybridge parity (2026-08-20). The Skybridge-built companion connectors
+# (ai-pricing-hub, ai-roi-calculator) render their widgets in Claude as
+# plain custom connectors while this server, spec-conformant and with a
+# valid ui.domain, stayed text-only. Three observable deltas in what
+# Skybridge emits, mirrored here: (1) a ui.csp block in the widget
+# resource meta; (2) an apps-sdk VARIANT of every widget resource (mime
+# "text/html+skybridge", openai/* meta) alongside the SEP-1865 one; (3)
+# the tool's openai/outputTemplate pointing at that variant while
+# ui.resourceUri keeps pointing at the SEP-1865 resource. The HTML served
+# is identical - the widgets are self-contained and the bridge negotiates
+# the host protocol at runtime.
+_UI_CSP = {
+    "resourceDomains": [CANONICAL_CONNECTOR_ORIGIN],
+    "connectDomains": [CANONICAL_CONNECTOR_ORIGIN],
+}
+_UI_RESOURCE_META = {"ui": {"domain": UI_DOMAIN, "csp": _UI_CSP}}
+_APPS_SDK_RESOURCE_META = {
+    "openai/widgetDomain": UI_DOMAIN,
+    "openai/widgetCSP": {
+        "resource_domains": [CANONICAL_CONNECTOR_ORIGIN],
+        "connect_domains": [CANONICAL_CONNECTOR_ORIGIN],
+    },
+}
+
+
+def _apps_sdk_uri(resource_uri: str) -> str:
+    """The apps-sdk variant URI for a SEP-1865 widget resource."""
+    return resource_uri.replace("ui://cloud-finops/", "ui://cloud-finops/apps-sdk/")
 
 
 def _ui_tool_meta(resource_uri: str) -> dict[str, Any]:
@@ -81,7 +110,7 @@ def _ui_tool_meta(resource_uri: str) -> dict[str, Any]:
     return {
         "ui": {"resourceUri": resource_uri},
         "ui/resourceUri": resource_uri,
-        "openai/outputTemplate": resource_uri,
+        "openai/outputTemplate": _apps_sdk_uri(resource_uri),
     }
 
 _UI_DIR = Path(__file__).resolve().parent / "ui"
@@ -340,6 +369,44 @@ def reference_browser_ui() -> str:
     minimal-markdown reading panel fed by an app-initiated ``get_reference``
     call.
     """
+    return _REFERENCE_BROWSER_HTML
+
+
+# Apps-sdk variants of the three widgets (Skybridge parity - see the note
+# above _UI_CSP). Same HTML, different URI, mime and meta vocabulary; the
+# tool meta's openai/outputTemplate points here.
+
+
+@mcp.resource(
+    _apps_sdk_uri(PLAYBOOK_VIEWER_URI),
+    meta=_APPS_SDK_RESOURCE_META,
+    name="Playbook viewer (apps-sdk)",
+    mime_type="text/html+skybridge",
+)
+def playbook_viewer_ui_apps_sdk() -> str:
+    """Apps-sdk variant of the playbook viewer widget."""
+    return _PLAYBOOK_VIEWER_HTML
+
+
+@mcp.resource(
+    _apps_sdk_uri(PLAYBOOK_EXPLORER_URI),
+    meta=_APPS_SDK_RESOURCE_META,
+    name="Playbook explorer (apps-sdk)",
+    mime_type="text/html+skybridge",
+)
+def playbook_explorer_ui_apps_sdk() -> str:
+    """Apps-sdk variant of the playbook explorer widget."""
+    return _PLAYBOOK_EXPLORER_HTML
+
+
+@mcp.resource(
+    _apps_sdk_uri(REFERENCE_BROWSER_URI),
+    meta=_APPS_SDK_RESOURCE_META,
+    name="Reference browser (apps-sdk)",
+    mime_type="text/html+skybridge",
+)
+def reference_browser_ui_apps_sdk() -> str:
+    """Apps-sdk variant of the reference browser widget."""
     return _REFERENCE_BROWSER_HTML
 
 

--- a/mcp_server/tests/test_ui.py
+++ b/mcp_server/tests/test_ui.py
@@ -124,6 +124,11 @@ async def test_ui_resources_are_registered() -> None:
     for uri in WIDGETS:
         assert uri in by_uri, f"{uri} is not a registered resource"
         assert by_uri[uri].mimeType == "text/html;profile=mcp-app"
+        # Skybridge parity: every widget also ships an apps-sdk variant
+        # (the shape the connectors that DO render in Claude expose).
+        variant = server._apps_sdk_uri(uri)
+        assert variant in by_uri, f"{variant} is not a registered resource"
+        assert by_uri[variant].mimeType == "text/html+skybridge"
 
 
 async def test_tools_link_their_widgets() -> None:
@@ -137,7 +142,9 @@ async def test_tools_link_their_widgets() -> None:
             f"{tool_name} does not declare {uri}"
         )
         assert meta.get("ui/resourceUri") == uri
-        assert meta.get("openai/outputTemplate") == uri
+        # openai/outputTemplate points at the apps-sdk variant (Skybridge
+        # parity): the SEP-1865 keys keep the spec resource.
+        assert meta.get("openai/outputTemplate") == server._apps_sdk_uri(uri)
     # get_reference deliberately has no widget: its content is read inside
     # the reference browser via an app-initiated call.
     assert not (by_name["get_reference"].meta or {}).get("ui")
@@ -167,11 +174,26 @@ async def test_ui_resources_declare_the_sandbox_domain() -> None:
     """Without ui.domain the host kills the iframe after reserving it."""
     resources = await server.mcp.list_resources()
     checked = 0
+    variants = {server._apps_sdk_uri(u) for u in WIDGETS}
     for r in resources:
+        meta = r.meta or {}
         if str(r.uri) in WIDGETS:
-            meta = r.meta or {}
-            assert meta.get("ui", {}).get("domain") == server.UI_DOMAIN, (
+            ui = meta.get("ui", {})
+            assert ui.get("domain") == server.UI_DOMAIN, (
                 f"{r.uri} does not declare ui.domain"
             )
+            # Skybridge parity: the csp block the rendering connectors send.
+            assert ui.get("csp", {}).get("resourceDomains") == [
+                server.CANONICAL_CONNECTOR_ORIGIN
+            ]
+            assert ui.get("csp", {}).get("connectDomains") == [
+                server.CANONICAL_CONNECTOR_ORIGIN
+            ]
             checked += 1
-    assert checked == len(WIDGETS)
+        elif str(r.uri) in variants:
+            assert meta.get("openai/widgetDomain") == server.UI_DOMAIN, (
+                f"{r.uri} does not declare openai/widgetDomain"
+            )
+            assert "openai/widgetCSP" in meta
+            checked += 1
+    assert checked == len(WIDGETS) * 2


### PR DESCRIPTION
**Context.** The widgets never rendered in Claude despite spec-conformant HTML and a valid `ui.domain` (validation passes, no error logged, tool called, MCP Apps runtime engages, frame never shows). Meanwhile the two Skybridge-built companion connectors (ai-pricing-hub-mcp, ai-roi-calculator-mcp) DO render their widgets in Claude as plain custom connectors - user-confirmed with a screenshot on 2026-08-20. So the gate is implementation shape, not the Connectors Directory.

**What Skybridge emits that we did not**, mirrored in this PR:

1. A `ui.csp` block (`{resourceDomains, connectDomains}` = the canonical connector origin) in the SEP-1865 widget resource meta.
2. An **apps-sdk variant** of each widget resource: `ui://cloud-finops/apps-sdk/<name>`, mime `text/html+skybridge`, meta `openai/widgetDomain` + `openai/widgetCSP`.
3. The tool meta's `openai/outputTemplate` now points at the apps-sdk variant; `ui.resourceUri` / `ui/resourceUri` keep the SEP-1865 resource.

Same self-contained HTML behind both URIs - the bridge negotiates at runtime.

**Validation:** 102 tests pass (wiring tests pin the dual-resource shape). Actual rendering needs the release train: merge, redeploy Alpic, then a Desktop render test with the connector. If it renders, the remaining Skybridge delta (per-request dynamic `ui.domain`) can stay unimplemented; if not, that is the next experiment.