### PR TITLE
Hash the root connector URL for ui.domain

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -386,8 +386,13 @@ maintainer's control and on an unpublished timeline.
 **Update (2026-08-19): the gate now has an observable mechanism.** Claude
 Desktop's `mcp-ext-apps-host` attempts to set up MCP Apps for custom
 connectors and validates a `ui.domain` on the widget resource:
-sha256(connector URL as entered in Settings, no trailing slash)[:32] +
-`.claudemcpcontent.com`. A wrong or missing value logs
+sha256(connector URL exactly as the host displays it in its error log -
+for a root-entered connector that is the ROOT url WITH its trailing
+slash)[:32] + `.claudemcpcontent.com`. (Corrected 2026-08-20: the
+original "no trailing slash" note here was wrong - hashing `/mcp` while
+the host saw `https://.../` reproduced the failure on this repo's own
+connector; Skybridge, which passes, hashes https://<host><pathname> per
+request.) A wrong or missing value logs
 `ui.domain validation failed for connector "<url>"` in the Desktop logs
 (observed live for ai-pricing-hub on 2026-08-19, including the fix-it
 one-liner the error prints). So the 2026-08-16 claim that a custom

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -293,12 +293,15 @@ There are two ways to reach it.
 #### Hosted (nothing to install)
 
 ```bash
-claude mcp add --transport http cloud-finops https://cloud-finops-skills-590a051d.alpic.live/mcp
+claude mcp add --transport http cloud-finops https://cloud-finops-skills-590a051d.alpic.live/
 ```
 
 For Claude.ai / Claude Desktop, **Settings -> Connectors -> Add custom connector** and
-paste the same URL. Cursor, Windsurf, VS Code and ChatGPT take an HTTP MCP server entry
-pointing at it.
+paste exactly `https://cloud-finops-skills-590a051d.alpic.live/` - trailing slash
+included. The widget sandbox domain (MCP Apps) is derived from the URL as entered, so
+a variant form (`/mcp`, no slash) connects fine but silently disables widget rendering.
+Cursor, Windsurf, VS Code and ChatGPT take an HTTP MCP server entry pointing at the
+same URL.
 
 This is the same code as the package below, deployed on Alpic and tracking `main`. Prefer
 it unless you need the server to run offline or pinned to a version.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 | <img src="https://img.shields.io/badge/-Gemini-4285F4?logo=googlegemini&logoColor=white" alt="Gemini" height="22"/> | Self-host: `./install.sh --tool gemini` _(a public Cloud FinOps Gem is on the Roadmap)_ |
 | <img src="https://img.shields.io/badge/-Cursor-000000?logo=cursor&logoColor=white" alt="Cursor" height="22"/> <img src="https://img.shields.io/badge/-Windsurf-3DDC91?logoColor=white" alt="Windsurf" height="22"/> <img src="https://img.shields.io/badge/-Codex-412991?logo=openai&logoColor=white" alt="Codex" height="22"/> <img src="https://img.shields.io/badge/-Aider-0F172A?logoColor=white" alt="Aider" height="22"/> <img src="https://img.shields.io/badge/-Copilot-181717?logo=githubcopilot&logoColor=white" alt="Copilot" height="22"/> <img src="https://img.shields.io/badge/-Kiro%20IDE-FF6F00?logoColor=white" alt="Kiro IDE" height="22"/> <img src="https://img.shields.io/badge/-Gemini%20CLI-4285F4?logo=googlegemini&logoColor=white" alt="Gemini CLI" height="22"/> | One-liner: `curl -sL https://raw.githubusercontent.com/OptimNow/cloud-finops-skills/main/install.sh \| bash -s -- --tool <name>` |
 | <img src="https://img.shields.io/badge/-Auto--detect-555555?logo=gnubash&logoColor=white" alt="Auto-detect" height="22"/> | `curl -sL https://raw.githubusercontent.com/OptimNow/cloud-finops-skills/main/install.sh \| bash` |
-| <img src="https://img.shields.io/badge/-MCP%20hosted-7C3AED?logoColor=white" alt="MCP hosted" height="22"/> | Nothing to install: `claude mcp add --transport http cloud-finops https://cloud-finops-skills-590a051d.alpic.live/mcp`. For Claude.ai / Desktop, **Settings -> Connectors -> Add custom connector** with the same URL |
+| <img src="https://img.shields.io/badge/-MCP%20hosted-7C3AED?logoColor=white" alt="MCP hosted" height="22"/> | Nothing to install: `claude mcp add --transport http cloud-finops https://cloud-finops-skills-590a051d.alpic.live/`. For Claude.ai / Desktop, **Settings -> Connectors -> Add custom connector** with exactly that URL (trailing slash included - the widget sandbox domain is derived from it) |
 | <img src="https://img.shields.io/badge/-MCP%20package-7C3AED?logoColor=white" alt="MCP package" height="22"/> | `pip install cloud-finops-mcp` then add to your MCP client config (Claude Code / Cursor / Codex / Windsurf / Cline). Snippets: `./install.sh --tool mcp`. Six tools - faceted retrieval over the reference library and named-pattern playbooks. |
 
 Full options, troubleshooting, and the model-agnostic API loader: see [INSTALLATION.md](./INSTALLATION.md).
@@ -383,7 +383,7 @@ For agents that want tool-style retrieval rather than full-context injection, th
 is also an MCP server. Hosted, or as a PyPI package:
 
 ```bash
-claude mcp add --transport http cloud-finops https://cloud-finops-skills-590a051d.alpic.live/mcp
+claude mcp add --transport http cloud-finops https://cloud-finops-skills-590a051d.alpic.live/
 ```
 
 ```bash

--- a/mcp_server/src/cloud_finops_mcp/server.py
+++ b/mcp_server/src/cloud_finops_mcp/server.py
@@ -54,16 +54,22 @@ REFERENCE_BROWSER_URI = "ui://cloud-finops/reference-browser"
 
 # The claude.ai / Claude Desktop MCP Apps host only mounts a widget iframe
 # when the ui:// resource declares the sandbox domain it will be served from:
-# sha256(<connector URL exactly as the user entered it in Settings, no
-# trailing slash>)[:32] + ".claudemcpcontent.com". A wrong or missing value
-# logs "ui.domain validation failed for connector <url>" in the host log
-# (mcp-ext-apps-host) and leaves a dead blank frame - observed live on
-# 2026-08-19 for both this server and ai-pricing-hub. The hash is DERIVED
-# from the canonical URL rather than pasted, so the URL constant is the only
-# thing that has to stay true; hashing an internal path instead of the
-# public URL is exactly the mistake that broke ai-pricing-hub.
+# sha256(<connector URL exactly as the host displays it in its error log,
+# trailing slash included>)[:32] + ".claudemcpcontent.com". A wrong or
+# missing value logs 'ui.domain validation failed for connector "<url>"'
+# in the Desktop log (mcp-ext-apps-host) and leaves a dead blank frame.
+# Observed live on 2026-08-20 for THIS server: the host quoted the
+# connector as "https://cloud-finops-skills-590a051d.alpic.live/" - the
+# ROOT url with its trailing slash - while the hash here was computed over
+# "/mcp". Skybridge, whose connectors render, hashes
+# https://<host><request-pathname> per request, which for a root-entered
+# connector is exactly the root-with-slash form. Alpic serves the MCP at
+# the root as well as /mcp, so the documented connector URL (README,
+# INSTALLATION.md) is the root form and this constant must match it
+# byte-for-byte; hashing an internal path or the wrong variant is exactly
+# the mistake that broke ai-pricing-hub and then this server.
 CANONICAL_CONNECTOR_ORIGIN = "https://cloud-finops-skills-590a051d.alpic.live"
-CANONICAL_CONNECTOR_URL = CANONICAL_CONNECTOR_ORIGIN + "/mcp"
+CANONICAL_CONNECTOR_URL = CANONICAL_CONNECTOR_ORIGIN + "/"
 UI_DOMAIN = (
     hashlib.sha256(CANONICAL_CONNECTOR_URL.encode("utf-8")).hexdigest()[:32]
     + ".claudemcpcontent.com"

--- a/mcp_server/tests/test_ui.py
+++ b/mcp_server/tests/test_ui.py
@@ -153,16 +153,18 @@ async def test_tools_link_their_widgets() -> None:
 def test_ui_domain_is_derived_from_the_canonical_connector_url() -> None:
     """The sandbox-domain hash must follow the URL constant, never drift.
 
-    The claude host validates sha256(<connector URL as entered, no trailing
-    slash>)[:32] + ".claudemcpcontent.com" against the resource meta; a
-    pasted hash that stops matching the URL is the ai-pricing-hub failure
-    mode.
+    The claude host validates sha256(<connector URL as it displays it -
+    for a root-entered connector that is the ROOT url WITH its trailing
+    slash>)[:32] + ".claudemcpcontent.com" against the resource meta.
+    Observed live on 2026-08-20: hashing "/mcp" while the host saw the
+    root url logged 'ui.domain validation failed'. Skybridge hashes
+    https://<host><request-pathname>, i.e. root-with-slash.
     """
     import hashlib
 
-    assert not server.CANONICAL_CONNECTOR_URL.endswith("/"), (
-        "the connector URL is hashed as entered - no trailing slash"
-    )
+    assert server.CANONICAL_CONNECTOR_URL == (
+        server.CANONICAL_CONNECTOR_ORIGIN + "/"
+    ), "the connector URL is the root form, trailing slash included"
     expected = (
         hashlib.sha256(server.CANONICAL_CONNECTOR_URL.encode("utf-8")).hexdigest()[:32]
         + ".claudemcpcontent.com"


### PR DESCRIPTION
Follow-up to #174, which moved the widget failure one step forward: `mcp-ext-apps-host` now engages for this connector and logs

```
ui.domain validation failed for connector "https://cloud-finops-skills-590a051d.alpic.live/"
```

The host sees the connector as the **root URL with its trailing slash**, while `UI_DOMAIN` hashed the `/mcp` form. Skybridge (whose connectors render) computes the hash from `https://<host><request-pathname>` per request - for a root-entered connector that is exactly the root-with-slash form.

Changes:
- `CANONICAL_CONNECTOR_URL` is now the root form with trailing slash; `UI_DOMAIN` follows (`1ec24d63...claudemcpcontent.com`).
- README + INSTALLATION.md standardise on that URL for the claude.ai/Desktop connector and the `claude mcp add` snippet, with a warning that a variant form connects fine but silently disables widget rendering (Alpic serves the MCP at the root - verified live).
- CLAUDE.md lesson corrected: the earlier "no trailing slash" note was wrong.
- `server.json` still carries `/mcp`; moving it to the root form can ride the next release PR (registry-validated field).

Test sequence after merge: Alpic redeploy, remove + re-add the connector at exactly `https://cloud-finops-skills-590a051d.alpic.live/`, then "Show me the idle waste playbooks" on Desktop.