### PR TITLE
Lot C measurement + the routing fix it calls for

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,7 +451,7 @@ patterns.
 |---|---|
 | `list_playbooks()` | What cloud waste can we hunt with a ready-made runbook? |
 | `get_playbook(name)` | The step-by-step runbook: symptoms, detection queries, fix, anti-pattern |
-| `find_playbooks(scope?, service?, waste_category?, confidence?)` | "Which VMs run for nothing?" "Why is the NAT bill so high?" - finds the runbook for a specific waste suspicion |
+| `find_playbooks(scope?, service?, waste_category?, confidence?)` | "Which VMs run for nothing?" "Why is the NAT bill so high?" "Which of my RIs are about to expire?" - finds the runbook for a specific waste suspicion. The server cannot see your account; the runbook's detection query is the answer it hands over |
 
 Both listings carry `approx_tokens` per entry, because the references vary by more
 than tenfold - roughly 2K tokens for the smallest, over 25K for the provider pattern

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -314,6 +314,20 @@ maintainer file.
   c3 IMPROVISED probes (P06, P23 provider-billing-news; P25 finops-itam orphaned) were
   not re-run: nothing shipped for them, so their verdict stands unchanged.
 
+  **The routing work ships in the same PR as this entry**, in three places: two norms
+  in the server `instructions` string (you cannot see the user's account - hand over
+  the playbook's detection query instead of asking for a data export; check
+  find_playbooks before answering a waste question from model knowledge), service-noun
+  vocabulary in the find_playbooks / get_playbook descriptions (NAT gateways, expiring
+  RIs, snapshots, S3 lifecycle... - the words symptom phrasings actually contain, for
+  the host's tool-search layer), and an estate-phrasing trigger in the SKILL.md /
+  POWER.md descriptions. Precedent that this class of fix works on this surface: P05
+  and P14 both flipped after the PR #176 priority lines. Measurement: cycle 5 re-runs
+  P12, P13 and P31 with P11 as the do-not-regress control, after the next release
+  reaches Alpic. Stop rule: if two description iterations fail to convert P12/P13,
+  the failure is structural to claude.ai's tool-search gate - document it here and
+  stop investing; the loaded-skill surface is the fallback.
+
   Standing incident, third cycle running: every connector call renders "Unable to reach
   AI Cloud FinOps Skill & MCP" while the data arrives intact, and a tool-approval gate
   now appears per call. Full per-probe notes in `pipeline/coverage-probes.md`.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -280,12 +280,43 @@ maintainer file.
   file covers their useful parts and their Walk-to-Run engagement triggers have not
   fired.
 
-  **Lot C - measurement, once, to arbitrate the next lots.** After the Alpic redeploy
-  that follows #177: run the 24 never-played probes (P06-P07, P09-P10, P13, P15-P28,
-  naive twins P29-P32) with Sonnet. P21-P28 cover the twelve references nobody has
-  probed - where silent staleness settles - and every IMPROVISED verdict becomes a
-  content item with demand evidence. The connector-routing weakness seen on P05/P14
-  is *measured* by this cycle, not invested in; it may be structural to claude.ai web.
+  **Lot C - measurement: DONE 2026-08-29, and it changes the ordering rule.**
+
+  The original wording of this item ("run the 24 never-played probes ... with Sonnet")
+  was already stale when it was written: cycle 3 ran the FULL battery P01-P32 on
+  2026-08-20, one day earlier. What was actually needed, and what ran, is a *regression*
+  cycle - only the probes whose content shipped since c3, plus one new probe for the
+  #181 invoice-unit material. Deployment was verified first by calling the connector.
+
+  Result (c4, Sonnet 5 Medium, 4 probes): **content closes a gap only where the phrasing
+  already routed.**
+
+  - **P11** (S3 lifecycle, "how do I *detect*...") - 2 empty library calls in c3, now
+    GROUNDED: `find_playbooks` then `get_playbook(aws-s3-cold-data-in-standard)`, and the
+    answer carries the prerequisite-first rule, expire-don't-transition, the 128 KiB
+    threshold and weight-by-bytes. **PR #177 closed the trap.**
+  - **P12** ("which of *my* RIs are about to expire...") and **P13** ("*my* NAT processes
+    10TB/month...") - **unchanged, zero library calls each**, even though
+    `aws-expiring-commitment-no-decision` (#177) and
+    `aws-nat-gateway-endpoint-substitution` (#182) are both live on Alpic and the
+    connector toggle was verified ON. This is routing, not availability.
+  - **P33** (new, the real client question behind #181: "their AWS contact suggested Cost
+    Categories - is that right?") - GROUNDED via the claude.ai skill surface; the
+    anti-confusion framing holds ("they change how spend is sliced in reports, not how
+    AWS bills") and anchor sentence 3 comes back near-verbatim.
+
+  **Consequence for how this backlog is ordered.** The rule "every IMPROVISED verdict
+  becomes a content item with demand evidence" is now known to be wrong for one class:
+  account-data phrasing ("which of MY x") and symptom phrasing ("my NAT does X") do not
+  route, so shipping their playbook does not convert them. Those two probes are demand
+  evidence for **routing work** - tool descriptions, SKILL.md phrasing - not for more
+  playbooks. Only discovery- and advisory-phrased gaps are content items. The remaining
+  c3 IMPROVISED probes (P06, P23 provider-billing-news; P25 finops-itam orphaned) were
+  not re-run: nothing shipped for them, so their verdict stands unchanged.
+
+  Standing incident, third cycle running: every connector call renders "Unable to reach
+  AI Cloud FinOps Skill & MCP" while the data arrives intact, and a tool-approval gate
+  now appears per call. Full per-probe notes in `pipeline/coverage-probes.md`.
 
   Two composition notes from the same test, recorded as positioning decisions rather than
   defects until decided otherwise: (a) the library reads AI-workload-heavy (8 of 14 AWS

--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -78,7 +78,7 @@ get_reference("finops-aws-patterns", section="networking")  # ~2,600 tokens
 |---|---|
 | `list_playbooks()` | Browse the waste runbooks: which patterns of idle, orphaned, overprovisioned or leaking spend have a ready-made runbook. Carries the same `approx_tokens` hint. |
 | `get_playbook(name)` | Read one runbook: symptoms, detection queries, fix, anti-pattern. |
-| `find_playbooks(scope?, service?, waste_category?, confidence?)` | "We are wasting money on X - how do I find and fix it?" - filter runbooks by provider, service, waste category, confidence. |
+| `find_playbooks(scope?, service?, waste_category?, confidence?)` | "We are wasting money on X - how do I find and fix it?" - filter runbooks by provider, service, waste category, confidence. Also the route for questions about your own estate ("which of my RIs are about to expire"): the server cannot see your account, so the runbook's detection query is the answer it hands over. |
 
 The playbook faceted query supports:
 

--- a/mcp_server/src/cloud_finops_mcp/server.py
+++ b/mcp_server/src/cloud_finops_mcp/server.py
@@ -167,6 +167,19 @@ mcp = FastMCP(
         "(zombie NAT, snapshot sprawl, idle ELB, etc.). Use a reference for "
         "billing mechanics, commitment strategy, allocation methodology, "
         "or any cross-pattern reasoning. "
+        "Two routing rules that override instinct. First: you cannot see "
+        "the user's cloud account. When asked about THEIR resources - "
+        "'which of my RIs are about to expire', 'which of our VMs run "
+        "for nothing' - do NOT ask for a data export first: fetch the "
+        "matching playbook and hand over its detection query; the runbook "
+        "IS the answer. Second: before answering a specific waste or "
+        "cost-fix question from your own knowledge - 'my NAT gateway "
+        "processes 10TB to S3', 'should I delete these old snapshots' - "
+        "check find_playbooks first: a named runbook with a tested "
+        "detection query outranks a generic answer. Runbooks exist for "
+        "NAT gateways and VPC endpoints, expiring Savings Plans / RIs / "
+        "reservations, snapshots, S3 lifecycle, idle or stopped VMs, "
+        "orphaned disks and IPs, GPU and SageMaker sizing, and more. "
         "References carry billing mechanics, not current prices: any figure "
         "inside is illustrative and dated inline. For a current price, use a "
         "live pricing tool if one is available in the session, otherwise "
@@ -355,7 +368,9 @@ def get_playbook(name: str) -> dict[str, Any]:
 
     Use this when the user asks how to detect, confirm, or fix one specific
     named waste pattern (zombie NAT gateway, snapshot sprawl, idle SageMaker
-    endpoint, ...).
+    endpoint, ...) - including when the question is about their own
+    resources: deliver the runbook's detection query instead of asking
+    for an account export.
 
     Args:
         name: Playbook slug as returned by ``list_playbooks`` (e.g.
@@ -485,6 +500,16 @@ def find_playbooks(
     "why is our NAT bill so high", "what waste can we clean up safely
     without review" - anything that names a provider, a waste category, or
     how confident the detection needs to be before acting.
+
+    Route here even when you already know a good generic answer, and
+    even when the question is about the user's OWN estate ("which of my
+    RIs are about to expire", "my NAT gateway moves 10TB a month to S3"):
+    you cannot see their account, but the matching runbook carries the
+    exact detection query to hand over. Patterns covered include NAT
+    gateways and VPC endpoints, expiring Savings Plans / RIs /
+    reservations, snapshot sprawl, S3 lifecycle gaps, idle or stopped
+    VMs, orphaned disks / public IPs / EBS volumes, GPU and SageMaker
+    sizing, Kubernetes idle capacity, and schedule blindness.
 
     All filters are optional and combine with AND semantics. String matching
     is case-insensitive and exact. Examples:

--- a/skills/cloud-finops/POWER.md
+++ b/skills/cloud-finops/POWER.md
@@ -5,15 +5,16 @@ description: >
   Expert FinOps guidance for cloud, AI, and SaaS technology spend. Covers AI cost
   management, agentic FinOps, GenAI capacity planning, self-hosted vs managed inference,
   Anthropic billing, open-weight vendor APIs (DeepSeek, Qwen, Kimi, GLM), AWS (EC2,
-  Bedrock, SageMaker, GPU rightsizing, Savings Plans, CUR), Azure (reservations, AHB,
+  Bedrock, SageMaker, Savings Plans, CUR), Azure (reservations, AHB,
   OpenAI PTUs), GCP (Vertex AI, BigQuery), OCI, Kubernetes cost allocation, data
   platforms (Databricks, Fabric F-SKUs, Snowflake), tagging governance, SaaS management
-  (SAM, licence optimisation, shadow IT), AI coding tools (Cursor, Claude Code, Copilot,
-  Windsurf, Codex), ITAM, allocation, showback and chargeback, anomaly management, KPIs
+  (SAM, shadow IT), AI coding tools (Cursor, Claude Code, Copilot,
+  Codex), ITAM, allocation, showback, chargeback, anomaly management, KPIs
   and benchmarking, waste detection playbooks, workload onboarding and M&A, and GreenOps
-  (cloud carbon, CSRD). Use for any query about technology cost, commitment portfolio
-  management, rightsizing, cost allocation, SaaS sprawl, AI dev tool spend, or connecting
-  spend to business value. Built by OptimNow.
+  (cloud carbon, CSRD). Use for any question about technology cost or waste in your
+  estate - expiring commitments or RIs, NAT gateway bills, idle VMs, snapshot sprawl -
+  and for commitment sizing, rightsizing, allocation, SaaS sprawl, AI dev tool spend,
+  or connecting spend to business value. Built by OptimNow.
 keywords:
   - finops
   - cloud cost

--- a/skills/cloud-finops/SKILL.md
+++ b/skills/cloud-finops/SKILL.md
@@ -4,15 +4,16 @@ description: >
   Expert FinOps guidance for cloud, AI, and SaaS technology spend. Covers AI cost
   management, agentic FinOps, GenAI capacity planning, self-hosted vs managed inference,
   Anthropic billing, open-weight vendor APIs (DeepSeek, Qwen, Kimi, GLM), AWS (EC2,
-  Bedrock, SageMaker, GPU rightsizing, Savings Plans, CUR), Azure (reservations, AHB,
+  Bedrock, SageMaker, Savings Plans, CUR), Azure (reservations, AHB,
   OpenAI PTUs), GCP (Vertex AI, BigQuery), OCI, Kubernetes cost allocation, data
   platforms (Databricks, Fabric F-SKUs, Snowflake), tagging governance, SaaS management
-  (SAM, licence optimisation, shadow IT), AI coding tools (Cursor, Claude Code, Copilot,
-  Windsurf, Codex), ITAM, allocation, showback and chargeback, anomaly management, KPIs
+  (SAM, shadow IT), AI coding tools (Cursor, Claude Code, Copilot,
+  Codex), ITAM, allocation, showback, chargeback, anomaly management, KPIs
   and benchmarking, waste detection playbooks, workload onboarding and M&A, and GreenOps
-  (cloud carbon, CSRD). Use for any query about technology cost, commitment portfolio
-  management, rightsizing, cost allocation, SaaS sprawl, AI dev tool spend, or connecting
-  spend to business value. Built by OptimNow.
+  (cloud carbon, CSRD). Use for any question about technology cost or waste in your
+  estate - expiring commitments or RIs, NAT gateway bills, idle VMs, snapshot sprawl -
+  and for commitment sizing, rightsizing, allocation, SaaS sprawl, AI dev tool spend,
+  or connecting spend to business value. Built by OptimNow.
 ---
 
 # FinOps - Expert Guidance


### PR DESCRIPTION
## What this PR is

Two halves of one loop: the **Lot C behavioural measurement** (cycle 4), and the **routing fix** its result demands, shipped together so the finding and the response land as one reviewable unit.

## Half 1 - the measurement (docs/ROADMAP.md)

Lot C as written was stale before it could run: it asked for "the 24 never-played probes", but cycle 3 had run the full P01-P32 battery the day before the entry was written. What ran instead is a regression cycle over the probes whose content shipped since c3, plus one new probe (P33) for the #181 invoice-unit material. Deployment verified first by calling the connector.

| Probe | c3 | c4 | |
|---|---|---|---|
| **P11** S3 lifecycle, *"how do I detect..."* | trap, 2 empty calls | **GROUNDED** | #177 closed it |
| **P12** *"which of my RIs..."* | trap, 0 calls | **unchanged, 0 calls** | #177 did not |
| **P13** *"my NAT processes 10TB..."* | IMPROVISED | **unchanged, 0 calls** | #182 did not |
| **P33** invoice units (new) | - | **GROUNDED** via skill | #181 works |

**The finding: content closes a gap only where the phrasing already routed.** P12 and P13 ran with the connector verified enabled and made zero library calls, despite their playbooks being live on Alpic. Account-data and symptom phrasings are demand evidence for routing work, not for more playbooks - which corrects the roadmap's "every IMPROVISED becomes a content item" rule.

## Half 2 - the routing fix

**`server.py` `instructions`** gains two norms:
1. *You cannot see the user's cloud account. For their-resources questions ("which of my RIs are about to expire"), do NOT ask for a data export first - fetch the matching playbook and hand over its detection query; the runbook IS the answer.* (Directly counters P12's observed behaviour: it asked for a CSV.)
2. *Before answering a specific waste or cost-fix question from model knowledge ("my NAT processes 10TB to S3"), check find_playbooks first.* (Counters P13: confident parametric answer, no tool search.)

**`find_playbooks` / `get_playbook` descriptions** gain the service-noun vocabulary symptom phrasings actually contain - NAT gateways, expiring RIs/Savings Plans, snapshots, S3 lifecycle, idle VMs, orphaned disks/IPs, GPU/SageMaker sizing. Rationale: on claude.ai the connector tools sit behind a host-side tool-search layer (visible as "Searching available tools" on P11, absent on P13), and that index needs the words users actually type, not category jargon.

**`README.md` + `mcp_server/README.md`** tool tables updated in step - the three-copies rule.

**`SKILL.md` / `POWER.md` descriptions** gain an estate-phrasing trigger (P13 failed to invoke the skill surface too, while P33 succeeded). The description is budget-capped: body trimmed to land at **1014/1024** (CI-gated by `check-skill-description`).

**Precedent this class of fix works:** P05 and P14 both flipped GROUNDED after the PR #176 priority lines.

## Measurement plan + stop rule (recorded in the roadmap)

Cycle 5 re-runs **P12, P13, P31** with **P11 as the do-not-regress control**, after this reaches Alpic via the next release. Stop rule: if two description iterations fail to convert P12/P13, the gate is structural to claude.ai's tool-search and investment stops - the loaded-skill surface is the fallback.

## Verification

- All eleven CI guards pass; `server.py` parses; MCP suite **143 passed**
- SKILL/POWER descriptions identical, 1014 chars
- No dashes, no version bump (the instructions change ships to Alpic with the next release train)
- Per-probe notes and the new P33 regression probe live in the maintainer-local `pipeline/coverage-probes.md`