### PR TITLE
Cycle 5: zero conversions, but the failure moved one layer

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -328,6 +328,20 @@ maintainer file.
   the failure is structural to claude.ai's tool-search gate - document it here and
   stop investing; the loaded-skill surface is the fallback.
 
+  **Cycle 5 ran (2026-08-30, on the 1.35.0 deployment, norms verified live by curl
+  initialize first). Iteration 1: zero conversions, but the failure moved one layer.**
+  P11 control HOLDS (GROUNDED, multi-call) - the fix broke nothing. P13 and P31 now
+  fire the host's tool-search ("Searched available tools" / "Loaded tools"), which
+  never happened in c3/c4 - the service-noun descriptions reached the host index -
+  but no call follows: the remaining gate is the model preferring its parametric
+  answer once tools are loaded. P12 is unchanged at zero calls, and its transcript
+  shows the model claiming "no connector for AWS/Azure billing" without checking -
+  strong evidence claude.ai does not surface the server `instructions` string to the
+  model at all, so norms placed there are inert on this host. Iteration 2, the last
+  before the stop rule: move the two norms INTO the find_playbooks / get_playbook
+  descriptions - the only artefact proven to reach the model - and re-run the same
+  four probes. If that fails too, this entry closes as structural.
+
   Standing incident, third cycle running: every connector call renders "Unable to reach
   AI Cloud FinOps Skill & MCP" while the data arrives intact, and a tool-approval gate
   now appears per call. Full per-probe notes in `pipeline/coverage-probes.md`.


### PR DESCRIPTION
## What ran

Probe cycle 5 - the measurement gated on the 1.35.0 release reaching Alpic. Preflight per the hard rule: `curl` `initialize` on the hosted endpoint confirmed the two #184 routing norms live in the served `instructions` **before** any probe ran (`serverInfo` still says 1.29.1 - that field remains unreliable; content is the check).

Sonnet 5 Medium, fresh chat per probe, tool-call-visible criterion for GROUNDED.

## Result

| Probe | c4 | c5 | Movement |
|---|---|---|---|
| **P11** (control) | GROUNDED | **GROUNDED** | Control holds - the fix broke nothing |
| **P12** *"which of my RIs..."* | 0 calls | **0 calls** | None - and see below |
| **P13** *"my NAT processes 10TB..."* | no tool search | **tool search fires, no call** | Moved one layer |
| **P31** *naive NAT twin* | 0 calls | **tools load, no call** | Moved one layer |

## The two findings that decide iteration 2

**1. The service nouns worked at the host layer.** "Searched available tools" / "Loaded tools" now appear on P13 and P31 - they never did in c3 or c4. The host's tool-search index now surfaces the connector for symptom phrasings. The remaining gate is the model itself: tools loaded, parametric answer preferred.

**2. The server `instructions` string appears to be inert on claude.ai.** P12's transcript has the model asserting "no connector to Cost Explorer... none currently connected for AWS/Azure billing" - flatly contradicting the norm that sits in the served instructions, without any check. The most economical explanation: claude.ai never surfaces MCP server instructions to the model. Norms placed there cannot work on this host.

## Iteration 2 (the last before the stop rule)

Move the two norms **into the `find_playbooks` / `get_playbook` descriptions themselves** - the only artefact proven to reach the model (finding 1) - and re-run the same four probes. The stop rule from #184 stands: if this second description iteration fails to convert P12/P13, the entry closes as structural to claude.ai and investment stops; the loaded-skill surface is the fallback.

## Files

`docs/ROADMAP.md` only. Per-probe transcript notes in the maintainer-local `pipeline/coverage-probes.md` (P11/P12/P13/P31 cells + the c5 run-log row). Incidents logged there: the Chrome bridge lost keyboard input mid-cycle (worked around via `execCommand` injection), and the "Unable to reach" display regression persists on every connector call with data intact.

No version bump; `check-docs-drift` passes; no dashes.