### PR TITLE
Routing iteration 2: the norms move into the tool descriptions

### DIFF
--- a/mcp_server/src/cloud_finops_mcp/server.py
+++ b/mcp_server/src/cloud_finops_mcp/server.py
@@ -368,9 +368,10 @@ def get_playbook(name: str) -> dict[str, Any]:
 
     Use this when the user asks how to detect, confirm, or fix one specific
     named waste pattern (zombie NAT gateway, snapshot sprawl, idle SageMaker
-    endpoint, ...) - including when the question is about their own
-    resources: deliver the runbook's detection query instead of asking
-    for an account export.
+    endpoint, ...). When the question is about the user's OWN resources
+    ("which of my X..."), fetch the runbook and hand over its detection
+    query - never reply that you lack account access, and never ask for a
+    data export first. The runbook IS the answer.
 
     Args:
         name: Playbook slug as returned by ``list_playbooks`` (e.g.
@@ -492,24 +493,30 @@ def find_playbooks(
     waste_category: str | None = None,
     confidence: str | None = None,
 ) -> dict[str, Any]:
-    """Answer "we are wasting money on X - how do I find and fix it?":
-    filter the runbooks by provider, service, waste category or detection
-    confidence.
+    """ALWAYS call this before answering a cloud-waste or cost-fix
+    question from your own knowledge, and before asking the user for any
+    account data. Find the tested runbook for a waste suspicion: filter by
+    provider, service, waste category or detection confidence.
+
+    Two rules. (1) When the user reports a symptom you think you can
+    answer directly - "my NAT gateway processes 10TB to S3", "should I
+    delete these old snapshots" - call this FIRST anyway: a named runbook
+    with a tested detection query outranks a correct generic answer, and
+    answering without checking loses the query the user needed. (2) When
+    the user asks about THEIR OWN resources - "which of my RIs are about
+    to expire", "which of our VMs run for nothing" - do NOT reply that you
+    lack account access and do NOT request a data export: you cannot see
+    their account, but the matching runbook carries the exact detection
+    query to hand over. The runbook IS the answer.
 
     Use this for questions like "which VMs are running for nothing",
     "why is our NAT bill so high", "what waste can we clean up safely
     without review" - anything that names a provider, a waste category, or
-    how confident the detection needs to be before acting.
-
-    Route here even when you already know a good generic answer, and
-    even when the question is about the user's OWN estate ("which of my
-    RIs are about to expire", "my NAT gateway moves 10TB a month to S3"):
-    you cannot see their account, but the matching runbook carries the
-    exact detection query to hand over. Patterns covered include NAT
-    gateways and VPC endpoints, expiring Savings Plans / RIs /
-    reservations, snapshot sprawl, S3 lifecycle gaps, idle or stopped
-    VMs, orphaned disks / public IPs / EBS volumes, GPU and SageMaker
-    sizing, Kubernetes idle capacity, and schedule blindness.
+    how confident the detection needs to be before acting. Patterns
+    covered include NAT gateways and VPC endpoints, expiring Savings
+    Plans / RIs / reservations, snapshot sprawl, S3 lifecycle gaps, idle
+    or stopped VMs, orphaned disks / public IPs / EBS volumes, GPU and
+    SageMaker sizing, Kubernetes idle capacity, and schedule blindness.
 
     All filters are optional and combine with AND semantics. String matching
     is case-insensitive and exact. Examples:


### PR DESCRIPTION
## Why this placement

Cycle 5 (#186) established two facts that decide where routing norms can live on claude.ai:

1. **Tool descriptions reach the model.** The service nouns added in #184 made the host's tool-search fire on symptom phrasings ("Searched available tools" on P13/P31) - it never fired before.
2. **The server `instructions` string does not.** P12's transcript has the model asserting "no connector for AWS/Azure billing" in direct contradiction of a norm sitting in the served instructions - the most economical explanation is that claude.ai never surfaces that string.

So iteration 2 moves the two norms into the only proven channel: the `find_playbooks` and `get_playbook` docstrings, **imperative, at the top**, where truncation cannot drop them.

## The change

`find_playbooks` now opens with *"ALWAYS call this before answering a cloud-waste or cost-fix question from your own knowledge, and before asking the user for any account data"*, followed by the two rules:

1. Symptom you can answer directly ("my NAT processes 10TB to S3") -> call first anyway; a tested detection query outranks a correct generic answer.
2. Their-own-resources question ("which of my RIs are about to expire") -> never reply "I lack account access", never request an export; the runbook's detection query is the hand-over. **The runbook IS the answer.**

The iteration-1 mid-docstring paragraph is folded in (no duplication). `get_playbook` gets the same their-own-resources rule. The `instructions` string keeps its norms - inert on claude.ai, potentially read by other hosts. No behaviour change, no signature change, so the three-copies rule is satisfied by the #184 README text already in place.

## Measurement (cycle 6) and the stop rule

Once merged **and the Alpic deployment redeployed**, cycle 6 re-runs P12, P13, P31 with P11 as the do-not-regress control. Verification before the cycle: an MCP SDK `tools/list` against the hosted endpoint must show the new opening ("ALWAYS call this...") - the baseline capture against the current deployment shows the 1.35.0 text, so the check discriminates.

This is the **second and last description iteration** under the stop rule recorded in the roadmap (#184, confirmed #186): if it does not convert P12/P13, the entry closes as structural to claude.ai and investment stops.

## Verification

143 MCP tests pass; `server.py` parses; guards pass; no dashes; no version bump (reaches Alpic via redeploy from main - PyPI users get it on the next train).