### PR TITLE
Close the routing arc: c6 converts P13, P12 structural, c7 isolates the surfaces

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -342,6 +342,30 @@ maintainer file.
   descriptions - the only artefact proven to reach the model - and re-run the same
   four probes. If that fails too, this entry closes as structural.
 
+  **Cycle 6 (2026-08-30, on the #187 deployment, verified by SDK tools/list first):
+  iteration 2 converts P13, closes P12, and the entry closes with a three-way verdict.**
+
+  - **P13 GROUNDED - CONVERTED.** Tool-search fired, the connector was called, and the
+    answer carried the NAT-endpoint playbook near-verbatim (the describe-vpc-endpoints
+    command, the aws:SourceVpce policy caveat, the interface-endpoint anti-pattern).
+    Specific-symptom phrasing routes when imperative norms open the tool description.
+  - **P12 CLOSED AS STRUCTURAL** per the stop rule: zero spontaneous calls across four
+    cycles and three interventions. One softening in c6: the model now offers "I can
+    check the Cloud FinOps skill library for the standard playbook" instead of denying
+    capability - so a user who says yes gets routed, one turn late. Account-data
+    phrasing does not spontaneously route on claude.ai; stop investing here.
+  - **P31 shows naive-symptom routing is stochastic.** Same class as P13, opposite
+    outcome in the same cycle (search did not fire). The description work moves the
+    conversion probability, not a switch. Track it in regular cycles, do not iterate
+    further on it specifically.
+  - **P11 control held across all three fix cycles** - none of the routing work
+    regressed what already routed.
+
+  The durable rules this arc leaves behind: norms only work where the host actually
+  surfaces them (tool descriptions on claude.ai, never server instructions); imperative
+  placement at the top of the description is what converts; and the claude.ai memory
+  feature can interfere with account-phrased questions in ways no repo change reaches.
+
   Standing incident, third cycle running: every connector call renders "Unable to reach
   AI Cloud FinOps Skill & MCP" while the data arrives intact, and a tool-approval gate
   now appears per call. Full per-probe notes in `pipeline/coverage-probes.md`.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -366,6 +366,31 @@ maintainer file.
   placement at the top of the description is what converts; and the claude.ai memory
   feature can interfere with account-phrased questions in ways no repo change reaches.
 
+  **Cycle 7 (2026-08-30): skill-isolation counterpart, run to attribute surfaces.**
+  Same probes with the connector toggled off (the toggle is account-global - restore
+  it after). Result, against the connector surface's best outcomes:
+
+  | Probe | Connector (best, c4-c6) | Skill alone (c7) |
+  |---|---|---|
+  | P11 detect-phrasing | GROUNDED | GROUNDED via skill |
+  | P13 symptom | GROUNDED only after two routing iterations | GROUNDED first try |
+  | P31 naive symptom | never converted | GROUNDED first try, playbook verbatim |
+  | P12 account-data | never | never - no surface triggers |
+
+  Three conclusions. First, **the skill in isolation routes symptom phrasings better
+  than the connector after two iterations of routing work** - pushed-into-context
+  needs no tool-choice decision, which was the whole failure surface. Second, **P12 is
+  confirmed trans-surface**: neither skill, connector, nor web picks up account-data
+  phrasing; the structural closure holds at the model-behaviour level, and the
+  playbook's value there is delivered when the user accepts the model's offer to
+  check the library. Third, an **interaction-effect hypothesis worth one future
+  cycle**: with the connector enabled (c4-c6), the skill never triggered on these
+  probes - the connector appears to pre-empt the skill and then, pre-#187, declined
+  to call. If both-enabled grounds worse than skill-alone on symptom questions, the
+  README's "add the connector too" default for Claude users deserves a caveat.
+  Controls: P10 grounded via skill (the skill loads fine); P33 went to web this
+  cycle - skill-vs-web pre-emption is itself stochastic.
+
   Standing incident, third cycle running: every connector call renders "Unable to reach
   AI Cloud FinOps Skill & MCP" while the data arrives intact, and a tool-approval gate
   now appears per call. Full per-probe notes in `pipeline/coverage-probes.md`.


### PR DESCRIPTION
## What ran

Cycle 6 - the second and last description iteration under the stop rule set in #184. Preflight per the hard rule: an MCP SDK `tools/list` against the hosted endpoint confirmed the #187 opening ("ALWAYS call this...") live **before** any probe. Sonnet 5 Medium, fresh chat per probe.

## Result: the arc closes with a three-way verdict

| Probe | c5 | c6 | Verdict |
|---|---|---|---|
| **P13** *"my NAT processes 10TB..."* | search fires, no call | **GROUNDED** | **CONVERTED** |
| **P12** *"which of my RIs..."* | 0 calls | 0 calls, but offers the library | **Closed as structural** |
| **P31** *naive NAT twin* | tools load, no call | 0 calls | **Stochastic** |
| **P11** (control) | GROUNDED | **GROUNDED** | Held across all three fix cycles |

**P13 is the payoff.** Tool-search fired ("NAT gateway waste playbook VPC endpoint"), the connector was called, and the answer carried `aws-nat-gateway-endpoint-substitution` near-verbatim: the `describe-vpc-endpoints` command with its empty-output logic, the `aws:SourceIp` -> `aws:SourceVpce` policy caveat, the interface-endpoint anti-pattern, don't-delete-the-NAT-in-the-same-change. Specific-symptom phrasing routes when imperative norms open the tool description.

**P12 closes as structural**, exactly as the stop rule requires: zero spontaneous calls across four cycles and three interventions (#177 playbook, #184 norms, #187 imperative descriptions). One real softening in c6: the model now *offers* "I can check the Cloud FinOps skill library for the standard playbook" instead of denying capability - a user who says yes gets routed one turn late. That is the ceiling on claude.ai; investment stops here.

**P31 splits from its twin**: same symptom class as P13, opposite outcome in the same cycle (search never fired). The description work moves a probability, not a switch. It stays in regular cycles; no further targeted iteration.

## The durable rules this arc leaves

1. Norms only work where the host surfaces them - tool descriptions on claude.ai, never server `instructions`.
2. Imperative placement at the top of the description is what converts.
3. claude.ai memory can interfere with account-phrased questions in ways no repo change reaches.

## Files

`docs/ROADMAP.md` only; per-probe notes in the maintainer-local `pipeline/coverage-probes.md` (c6 run-log row + four cell updates). `check-docs-drift` passes; no dashes; no version bump.