### PR TITLE
Document the measured behaviour of the two surfaces

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -434,6 +434,60 @@ rename look expensive. 36 of them were the CC BY-SA attribution footer, which mu
 change - it is the string third-party reusers carry. The real surface was 8 occurrences
 in 5 files. Count the *kind* of hit before estimating effort from a grep total.
 
+### Skills inject, MCP tools decide: what the probe cycles taught about the two surfaces (2026-08-30)
+
+Probe cycles 4-7 (per-probe record in the maintainer-local
+`pipeline/coverage-probes.md`; the arc's public summary in the
+`docs/ROADMAP.md` routing entry) measured how the same library grounds
+answers through the MCP connector versus the uploaded skill on claude.ai,
+across three interventions: new playbooks (PRs #177, #182) and two rounds
+of routing work (PRs #184, #187). The mechanics that emerged are durable
+and generalise to any repo shipping both surfaces:
+
+1. **The two surfaces fail differently, because one decides and one does
+   not.** MCP grounding hangs on a per-question tool-choice the model makes;
+   the skill, once loaded, has no decision to make. The connector's weakness
+   therefore concentrates exactly where the model feels confident (symptom
+   questions it can answer from memory) or misreads the ask (account-data
+   questions). In isolation the skill grounded, first try and near-verbatim,
+   a symptom probe the connector never converted across four cycles.
+2. **Content closes a gap only where the phrasing already routes.** Shipping
+   the playbook a failing probe needed did not convert it - twice, on two
+   different playbooks. A coverage gap and a routing gap are different
+   defects with different fixes; classify before writing content.
+3. **On claude.ai, the MCP server `instructions` string is inert.** A norm
+   sitting in the served instructions was flatly contradicted by the model's
+   behaviour. Norms must live in the tool descriptions - the only artefact
+   proven to reach the model - and they convert only when placed imperatively
+   at the top ("ALWAYS call this before..."); the same norms mid-docstring
+   did nothing.
+4. **Tool descriptions feed two consumers.** claude.ai runs a host-side
+   tool-search layer that decides whether tools are even surfaced; concrete
+   service nouns (NAT gateway, expiring RIs, snapshots) made that layer fire
+   on symptom questions. The imperative rules then govern the model's actual
+   call. Optimise descriptions for both audiences at once.
+5. **Account-data phrasing ("which of my X") is trans-surface.** Neither
+   connector, skill, nor web triggers on it; the model asks for a data
+   export instead. The reachable ceiling is the model *offering* the
+   library; the practical answer is user education - ask for the playbook
+   explicitly - not more engineering.
+6. **Routing is stochastic, not binary.** Twin probes of the same class
+   grounded and failed in the same cycle; the same probe grounded via skill
+   one day and web the next. One run is a sample: verdicts need the
+   visible-evidence discipline (tool-call block, "Viewed N files" marker)
+   and re-runs before any conclusion.
+7. **Verify the surface you measure, by calling it, on content.** The hosted
+   server's `serverInfo` version stayed at an old value while serving
+   current content - it is not a deployment check; `tools/list` description
+   text and listing totals are. And the claude.ai connector toggle is
+   account-global, not per-chat: restore it after any isolation test.
+8. **claude.ai memory is a confounder no repo change reaches.** It recalled
+   a client file into an account-phrased probe and answered from there, and
+   twice made a failed call look grounded. Fresh chats are not clean-room.
+
+The user-facing version of the behavioural expectations lives in the README
+("Skill + installer, or MCP?" and its "What to expect in practice" note).
+
 ---
 
 ## Roadmap

--- a/README.md
+++ b/README.md
@@ -68,18 +68,31 @@ use them (field-tested with the same battery of practitioner questions through b
 - **Pushed into context** - as a native skill (Claude Code, Claude.ai / Desktop, Kiro),
   or as rules files written by `install.sh` for tools without skill support (Cursor,
   Windsurf, Codex, Aider, Copilot, Gemini). The guidance is already there when the
-  model reasons, which is what grounds *advisory* answers - commitment sizing,
-  chargeback design, allocation methodology - without the model having to decide
-  anything.
-- **Fetched on demand** - the MCP server. The model must decide to call a tool, which
-  it reliably does for lookup questions ("show me the idle waste runbooks") and much
-  less for advisory ones. Its strengths: distribution (paste one URL - the right path
-  for non-technical users and for hosts with neither skill support nor an installer
-  target), faceted queries over the library's metadata, and interactive widgets on
-  hosts that render MCP Apps.
+  model reasons, with no per-question decision to make - which is why this surface
+  grounds both *advisory* answers (commitment sizing, chargeback design, allocation
+  methodology) and *symptom* questions ("my NAT gateway processes 10TB/month to S3"),
+  where the measured probe runs show it handing over the matching runbook first try.
+- **Fetched on demand** - the MCP server. The model must decide to call a tool per
+  question, and that decision is this surface's real limit. Measured behaviour
+  (August 2026 probe cycles): lookup and discovery questions ("show me the idle waste
+  runbooks") route reliably; advisory and specific-symptom questions route since the
+  tool descriptions carry imperative routing rules, though not on every phrasing.
+  Its strengths: distribution (paste one URL - the right path for non-technical users
+  and for hosts with neither skill support nor an installer target), faceted queries
+  over the library's metadata, and interactive widgets on hosts that render MCP Apps.
 - **Both is legitimate.** Skill loaded for the doctrine, connector added for the
   widgets or for hosts where the skill is not loaded. Details on the six tools:
   [MCP server](#mcp-server-cross-tool-search-style-retrieval) below.
+
+**What to expect in practice, on either surface.** Neither the skill nor the server
+can see your cloud account. For "which of *my* X" questions ("which of my RIs are
+about to expire?") the deliverable is the playbook's detection query, which you run
+yourself - and the measured behaviour is that models tend to ask you for a data
+export instead of volunteering that runbook. The reliable way to get it is to ask
+explicitly: "check the playbook library" or "show me the runbook for this". Routing
+is also probabilistic, not guaranteed - the same question phrased two ways can ground
+differently - so when an answer arrives without a visible tool call or file read,
+asking for the library by name is the one-turn fix.
 
 Using a non-Claude model through an API? Add the **response contract** from
 [INSTALLATION.md](./INSTALLATION.md) ("API integration / Recommended response


### PR DESCRIPTION
## Why

The README's "Skill + installer, or MCP?" section has claimed a field-tested distinction since the August field test. Seven probe cycles later (c1-c7, including the routing arc #184-#188 and the c7 skill-isolation run), the claim can be upgraded to **measured behaviour with expectations** - which is worth doing publicly: the honest limits are exactly what a practitioner needs before choosing a surface, and no other FinOps knowledge repo publishes them.

## README changes

- The **pushed-into-context** bullet now explains *why* the skill grounds symptom questions ("my NAT gateway processes 10TB/month to S3"): no per-question decision to make - and cites that the measured runs show it handing over the matching runbook first try.
- The **fetched-on-demand** bullet names the per-question tool-choice as the MCP surface's real limit, with the measured shape: lookups route reliably; advisory and specific-symptom questions route since the imperative tool descriptions, though not on every phrasing.
- A new **"What to expect in practice"** note carries the two things a user must know: neither surface sees their cloud account, so a "which of *my* RIs" question is answered by a detection query they run themselves - and models tend to ask for a data export instead of volunteering that runbook, so **asking for the library explicitly is the one-turn fix**. Routing is stated as probabilistic, with the visible-tool-call tell.

Only measured facts made it in - the unconfirmed connector-pre-empts-skill hypothesis stays in the roadmap, not the README.

## CLAUDE.md: new Lessons learned entry

**"Skills inject, MCP tools decide"** - the eight durable mechanics from cycles 4-7, written to generalise beyond this repo:

1. The two surfaces fail differently because one decides per question and one does not.
2. Content closes a gap only where the phrasing already routes - coverage gaps and routing gaps are different defects.
3. On claude.ai the MCP server `instructions` string is inert; norms live in tool descriptions, imperatively, at the top.
4. Tool descriptions feed two consumers: the host's tool-search index (service nouns) and the model's tool choice (imperative rules).
5. Account-data phrasing is trans-surface; the fix is user education, not engineering.
6. Routing is stochastic - one run is a sample; verdicts need visible-evidence discipline.
7. Verify the surface you measure by calling it, on content (`serverInfo` version lies; the connector toggle is account-global).
8. claude.ai memory is a confounder no repo change reaches.

Division of record keeping: per-probe detail stays maintainer-local (`pipeline/coverage-probes.md`), the arc narrative stays in the roadmap, this entry carries only what generalises.

## Verification

All guards pass (`check-docs-drift`, `build-llms-full --check` included); no dashes; no version bump. Complements #188 (the c6/c7 results) without touching the same files.