### PR TITLE
Content update - 9 Sep 2026

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -332,6 +332,15 @@ An agent that stops instances autonomously is not - regardless of how sophistica
 reasoning is. Governance, not technology capability, is the real constraint on autonomous
 FinOps agents.
 
+**Billing-model flexibility for agent spend.** As of August 2026, Google's Gemini
+Enterprise / AI Cost Summary Agent offers a pay-as-you-go consumption edition
+alongside the existing per-user subscription model - see finops-gcp.md for guidance
+on choosing consumption versus subscription billing under budget guardrails. This
+matters for cost governance: consumption billing suits variable, unbounded agent
+workloads where per-user seats over- or under-provision, while subscription billing
+gives predictable spend for steady-state usage. Match the billing model to the
+workload's cost class (see Big-T notation above).
+
 AgentCore's policy capability now supports natural-language-to-Cedar tool-access controls,
 consistent with the policy-generation-over-direct-mutation pillar above.
 
@@ -609,14 +618,20 @@ question wherever developers can toggle it themselves.
   LiteLLM auto-detects Claude Code via User-Agent header
 - **Anthropic Console** - basic usage and billing data at the organisation level
 
-**Native gateway spend-limit warnings (as of August 2026).** Claude Code now surfaces
-gateway spend limits proactively in its usage warnings - showing the spending cap, the
-reset time, and the operator message - rather than only failing silently or after the
-fact. For teams enforcing per-user or per-team budget caps this improves cost-governance
-visibility and reduces surprise overage incidents. The practical effect is that ClaudeXray
-and LiteLLM are no longer needed *purely* for budget-cap visibility; they remain valuable
-for metadata injection, cross-tool aggregation, and analytics, but the cap-and-reset
-signal is now available natively.
+**Native gateway spend-limit warnings (as of September 2026).** Claude Code v2.1.251
+surfaces gateway spend limits proactively in its usage warnings - showing the spending
+cap, the reset time, and the operator message - rather than only failing silently or after
+the fact. The client now exposes a `rate_limits.spend_limit` status field and adds a
+spend-limit bar in the UI, giving FinOps teams a native signal for tracking token spend
+against caps. The same release also introduces prompt-cache visibility monitoring, so
+developers can observe cache efficiency directly in the client rather than inferring it
+from downstream billing data - useful for spotting the cache-miss patterns described in
+"The context-load tax" section below and for validating the cache multiplier mechanics
+documented in `finops-anthropic.md`. For teams enforcing per-user or per-team budget caps
+this improves cost-governance visibility and reduces surprise overage incidents. The
+practical effect is that ClaudeXray and LiteLLM are no longer needed *purely* for
+budget-cap visibility; they remain valuable for metadata injection, cross-tool
+aggregation, and analytics, but the cap-and-reset signal is now available natively.
 
 ---
 
@@ -2450,7 +2465,13 @@ billing data.** The usage surfaces to watch:
   (`InputTokenCount`, `OutputTokenCount`, `Invocations`, `InvocationThrottles`), per
   `ModelId`, at minute granularity. Application inference profiles carry cost-allocation
   tags for per-application attribution, but their cost side is daily-grained - use it for
-  ownership, not live alerting.
+  ownership, not live alerting. As of August 2026, AWS Cost Anomaly Detection also
+  natively monitors third-party foundation models on Bedrock (including provider-hosted
+  models such as Anthropic Claude), with root-cause breakdowns by account, region,
+  service, and usage type. Treat this native coverage as a complement to the
+  usage-telemetry-based detection above, not a replacement: it narrows the reliance on
+  CloudWatch-only detection for this gap, but its cost side remains too latent for the
+  minute-scale burn scenarios that follow.
 - **Anthropic** - the Usage & Cost Admin API usage endpoint
   (`/v1/organizations/usage_report/messages`) supports 1-minute buckets with data
   appearing within ~5 minutes; the cost endpoint is daily-only.
@@ -2914,6 +2935,17 @@ after the cap is hit. This gives teams enforcing per-user or per-team budget cap
 an additional native cost-governance signal alongside the July 2026 Enterprise
 admin tooling, reducing surprise overage incidents. See the "Cost tracking for
 Claude Code" section in `finops-ai-dev-tools.md` for detail.
+
+**Prompt-cache visibility (as of September 2026):** Claude Code v2.1.251 adds a
+spend-limit bar in the UI and a `rate_limits.spend_limit` status field, plus
+native prompt-cache visibility monitoring. The prompt-cache signal ties directly
+into the cache multiplier mechanics documented above (5-minute writes at 1.25x,
+1-hour writes at 2x, reads at 0.1x): native visibility into cache hit behaviour
+lets teams confirm that prefixes are actually being read back rather than silently
+re-written at full rate - the exact break-even question raised in the "Modifiers"
+section. This reduces reliance on third-party tooling purely for budget-cap
+visibility. See the "Cost tracking for Claude Code" section in
+`finops-ai-dev-tools.md` for detail.
 
 Sources: [Anthropic - New analytics and cost controls for Claude Enterprise](https://claude.com/blog/giving-admins-more-visibility-and-control-over-claude-usage-and-spend) (primary),
 [Anthropic keeps signaling where AI cost governance needs to go](https://www.finout.io/blog/anthropic-keeps-signaling-where-ai-cost-governance-needs-to-go.-its-not-all-the-way-there-yet) (Finout commentary).
@@ -4887,7 +4919,7 @@ While stopping an RDS instance reduces runtime cost, AWS enforces a 7-day limit 
 
 ---
 
-### Networking Optimization Patterns (14)
+### Networking Optimization Patterns (15)
 
 **Elastic Load Balancer With Only One Ec2 Instance**
 Service: AWS ELB | Type: Inefficient Architecture
@@ -4906,6 +4938,15 @@ Some architectures unintentionally route large volumes of traffic between resour
 - Identify resources that receive or send high volumes of traffic to other Availability Zones within the same region
 - Review VPC flow logs, CloudWatch metrics, or billing data to assess regional data transfer patterns
 - Determine whether the resource acts as a centralised destination for data aggregation, storage, or processing
+
+**Karpenter Spot Node Replacement Shifting Nodes Across Availability Zones**
+Service: AWS EKS | Type: Inefficient Architecture
+
+As of March 2026, Karpenter's Spot-driven node replacement can silently shift nodes across Availability Zones when Spot capacity in the original AZ is exhausted. The replacement node may land in a different AZ from the workloads it serves, generating cross-AZ data transfer charges that appear on the bill with no corresponding health or utilisation alert. This is easy to miss because the cluster remains healthy and the cost surfaces only in inter-AZ data transfer lines. See the Karpenter consolidation/disruption tuning guidance in `finops-kubernetes.md` and the Spot best practices in `finops-aws-commitments.md`.
+
+- Detect nodes that changed AZ due to Spot interruption or replacement, and correlate the timing with cross-AZ data transfer cost spikes
+- Apply Karpenter NodePool AZ-affinity or topology spread constraints to keep replacement capacity aligned with dependent workloads
+- Add cross-AZ traffic monitoring as a companion signal to Spot interruption handling, so replacements that cross AZ boundaries are surfaced promptly
 
 **Managed Nat Gateway With Excessive Data Transfer**
 Service: AWS NAT Gateway | Type: Inefficient Architecture
@@ -5227,6 +5268,23 @@ the receiving side and the export configuration on the source side.
   AWS Organizations (M&A integrations, multi-payer setups, partner-resold
   accounts).
 
+**SQL-based row filtering at the source (March 2026).** AWS Data Exports now
+supports SQL-based row filtering for CUR 2.0 data, in addition to the existing
+column selection. This lets teams produce pre-filtered per-account or
+per-service datasets at the source, without building custom Lambda / Glue /
+Athena post-processing pipelines. As of March 2026, this is directly useful for:
+- Partner sharing - publish a dataset scoped to only the accounts or services a
+  partner is entitled to see.
+- Program or cost-centre isolation - a pre-filtered export per program without a
+  downstream copy step.
+- Audit scoping - hand auditors a dataset limited to the rows in scope rather
+  than the full CUR.
+
+Filtering at the source reduces the operational overhead of sharing scoped cost
+data and removes the need for organisations to maintain their own filtering
+pipeline. Source:
+https://aws.amazon.com/blogs/aws-cloud-financial-management/automating-filtered-cost-and-usage-report-exports-with-aws-data-exports/
+
 Sources: https://aws.amazon.com/about-aws/whats-new/2025/11/aws-data-exports-focus-1-2-available/
 and https://aws.amazon.com/about-aws/whats-new/2026/03/aws-data-exports-cross-account-delivery-cost/
 
@@ -5310,6 +5368,19 @@ unexpected spending increases and sends alerts via SNS or email.
   (a 100% increase on $10 is $10; a 20% increase on $50,000 is $10,000)
 - Route alerts to both the FinOps practitioner and the engineering team lead
 - Review alert history monthly - tune thresholds to reduce false positives
+
+**Automated spend guardrails via AWS Budgets Actions (circuit breaker).** As of
+March 2026, AWS documents a programmatic "circuit breaker" pattern that uses AWS
+Budgets Actions to automatically restrict or revoke developer access when a
+budget threshold is exceeded, while maintaining an audit trail. This extends
+Budgets Actions beyond the existing SCP-apply and EC2-stop actions to IAM
+Identity Center permission-set assignments, giving FinOps teams a stronger
+automated governance guardrail: when a budget breaches, the action can detach or
+restrict IAM Identity Center permission sets (alongside applying an SCP or
+stopping EC2 instances) to halt further spend. Treat this as a complement to the
+reactive anomaly and budget alerts above, not a replacement - it is the
+preventive backstop that acts without waiting for a human. Source:
+https://aws.amazon.com/blogs/aws-cloud-financial-management/how-to-programmatically-manage-account-access-with-aws-budgets-alerts/
 
 ---
 
@@ -5933,6 +6004,15 @@ comparison is not close.
 - **Unsupported features block subscription.** The console refuses to attach a
   plan while the distribution still has Lambda@Edge, real-time logs or any
   other unsupported feature active.
+- **Programmatic management is now available.** As of September 2026, flat-rate
+  plan subscription, upgrade, downgrade and cancellation can be managed
+  programmatically via the CLI, SDKs, CloudFormation, CDK or the new
+  PricingPlanManager API - no longer console-only. Paid plans use a two-phase
+  create-then-approve activation flow so that provisioning a plan does not
+  silently commit you to a monthly charge; the approval step is a governance
+  safeguard that matters for IaC pipelines and agent-driven provisioning
+  workflows, where an unreviewed template change could otherwise attach a paid
+  plan. Source: https://aws.amazon.com/about-aws/whats-new/2026/09/cloudfront-flat-rate-pricing-plans-api/
 - **Maximum 100 plans per AWS account, 3 Free plans maximum. AWS Free Tier
   accounts are not eligible.**
 
@@ -6900,6 +6980,17 @@ conversations.
 calculation from the cost-plus-utilisation join, reconcile differences. Differences are
 diagnostic - they usually reveal AHB not factored, scope mismatches, or workload context
 Advisor cannot know.
+
+**Agentic access to commitment recommendation data.** As of September 2026, the Azure
+Resource Manager MCP Server (public preview) exposes cost query and pricing tools by
+default, with optional capabilities for reservation, Savings Plan, and Advisor
+recommendation data (plus forecasting, budgets/alerts, and idle AKS capacity detection).
+This lets AI agents pull the same backward-looking recommendation feed described above
+natively. The same calibration caveats apply: agent-surfaced recommendations remain a
+sanity check, not a source of truth, and still need reconciling against your own
+cost-plus-utilisation join. See the agentic FinOps discussion in `finops-azure.md` and
+the tag-hygiene pattern in `finops-tagging.md` for the broader MCP governance context.
+Source: Microsoft Learn (Azure Resource Manager MCP Server, public preview).
 
 Source: https://learn.microsoft.com/en-us/azure/advisor/advisor-reference-cost-recommendations
 
@@ -10079,8 +10170,6 @@ for Azure cost reporting.
 
 ---
 
----
-
 > *Cloud FinOps Skill by [OptimNow](https://optimnow.io) - licensed under [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/).*
 
 
@@ -10222,6 +10311,21 @@ Key dimensions available for filtering and grouping:
 **Limitation:** native Cost Explorer does not provide token-level granularity. For
 unit economics (cost per 1,000 tokens, cost per API call), you need to combine billing
 data with application-level metrics from CloudWatch or your own instrumentation.
+
+### Cost Anomaly Detection for Bedrock foundation models
+
+As of August 2026, **AWS Cost Anomaly Detection** natively monitors third-party
+foundation models on Bedrock, including provider-hosted models such as Anthropic Claude.
+Detected anomalies come with root-cause breakdowns by account, region, service, and
+usage type. This reduces reliance on CloudWatch-only detection for this specific gap:
+spend spikes on Bedrock foundation models can now be surfaced through the native
+anomaly-detection path rather than requiring custom CloudWatch alarms on token metrics.
+
+**FinOps positioning:** use native Cost Anomaly Detection as the first line of spend-spike
+detection for Bedrock foundation models, and complement it with usage-telemetry-based
+detection (token-count metrics, invocation logging) for the token-level granularity that
+billing-based anomaly detection does not provide. See `finops-anomaly-management.md`
+for the AI/token-workload anomaly approach.
 
 ### Tagging strategy for Bedrock
 
@@ -12369,6 +12473,12 @@ deployments:
 - Set spending limits at the feature level, not just the account level
 - Anomaly alerts should trigger within minutes, not surface on the monthly bill
 - Define thresholds that require review before spend, not after
+- Where the platform offers native token-budget enforcement, use it as a proactive
+  guardrail rather than relying on alerts alone. As of September 2026, BigQuery
+  supports daily token quotas for its generative AI SQL functions (ML.GENERATE_TEXT
+  and related), letting teams cap daily token consumption at the platform level - a
+  GCP-native example of token budget enforcement that complements budget alerts and
+  anomaly detection (see `finops-gcp.md`).
 
 **Governance policies to establish:**
 - Require AI cost estimates (COGS modelling) before feature deployment
@@ -12962,6 +13072,25 @@ face when managing AI workloads on GCP.
 - Native tooling for AI spend attribution without third-party tools
 - Integrated into the Cloud Billing console for unified cost management
 
+**Gemini Enterprise consumption edition - pay-as-you-go alongside subscription.**
+As of August 2026, Gemini Enterprise added a **pay-as-you-go consumption edition**
+alongside the existing per-user subscription model. This gives FinOps teams a choice
+of billing shape for agent workloads rather than a single seat-based commitment.
+
+- **Subscription (per-user)**: predictable per-seat cost; best where a stable,
+  known population of users runs agents regularly, and where flat budgeting matters
+  more than usage sensitivity.
+- **Consumption (pay-as-you-go)**: cost scales with actual agent usage; best for
+  spiky, exploratory, or uneven adoption where many seats would sit idle under a
+  subscription, or where new agent workloads have uncertain demand.
+
+**Choosing between them, with budget guardrails:** default to consumption for new
+or variable agent workloads and pair it with budget alerts (50% / 80% / 100%) and
+anomaly detection so unpredictable usage cannot silently overrun the budget. Move to
+subscription once adoption stabilises and per-user cost is consistently below the
+observed consumption run-rate. Reassess the mix periodically as adoption matures. See
+`finops-agentic.md` under cost governance for agent spend flexibility.
+
 **Originating products filter and Gemini Enterprise preset report.** As of August 2026,
 Cloud Billing added an **"Originating products"** filter/group-by dimension in Billing
 Reports, plus a **Gemini Enterprise preset report**. Together these give more precise
@@ -13247,6 +13376,26 @@ per-principal budget guardrails inside a single shared reservation.
 
 Sources: https://docs.cloud.google.com/bigquery/docs/reservations-assignments (primary),
 https://finopsweekly.com/news/gcp-updates-2026-07-02/ (secondary source - verify against Google Cloud docs)
+
+#### Daily token quotas for generative AI SQL functions - native spend guardrail
+
+As of September 2026, BigQuery has restored **daily token quotas** for its
+generative AI SQL functions (`ML.GENERATE_TEXT` and related functions), allowing
+teams to cap daily token consumption directly at the platform level. This gives
+FinOps and data teams a proactive, native guardrail against unexpected GenAI spend
+spikes from BigQuery-based AI workloads, complementing existing budget alerts and
+anomaly detection.
+
+- Cap daily token consumption per project at the platform level, so a runaway
+  GenAI SQL workload cannot silently blow through the budget before an alert fires
+- Complements (does not replace) budget alerts and anomaly detection - use it as a
+  hard ceiling while budget alerts remain the softer, notification-based signal
+- Enforce token budgets on `ML.GENERATE_TEXT` and related generative AI functions
+  before spend materialises, rather than reacting after the invoice
+
+See `finops-for-ai.md` for the broader proactive guardrail and token-budget
+enforcement guidance; this is the GCP-native example of platform-level token
+budget enforcement.
 
 **Frame for clients**: BigQuery commitments trade flexibility for
 predictability, and often performance for predictability. The right
@@ -14719,6 +14868,29 @@ governing how aggressively Karpenter replaces nodes.
 Tune up or down based on the observed pod-disruption rate vs the savings
 delivered.
 
+#### Waste pattern: silent cross-AZ node drift from Spot replacement
+
+When Karpenter replaces a Spot node whose original availability zone has
+exhausted Spot capacity, it may provision the replacement in a different AZ.
+This is a legitimate resilience behaviour, but it can silently shift a
+workload's pods across zones and generate cross-AZ data transfer charges that
+appear on the bill with no corresponding health or utilisation alert. The cost
+lands in networking, disconnected from any Karpenter or Spot signal.
+
+As of March 2026, this is a named detection pattern:
+
+- **Detect** nodes that changed AZ following a Spot interruption or
+  replacement, and correlate the timing with cross-AZ data transfer cost
+  spikes on the same cluster.
+- **Mitigate** with NodePool AZ-affinity or topology spread constraints where
+  the workload's cross-AZ chatter is expensive enough to outweigh the
+  resilience benefit of free AZ selection. This is a per-workload trade-off,
+  not a cluster-wide default.
+- **Monitor** cross-AZ traffic as a companion signal to Spot interruption
+  handling, so a spike is attributable to the replacement event that caused
+  it. See the Spot best practices in `finops-aws-commitments.md` and the
+  networking patterns in `finops-aws-patterns.md`.
+
 ### Pod Disruption Budgets are non-negotiable
 
 Every workload with an SLO must have a PDB. No exceptions. PDBs are how the
@@ -14882,7 +15054,11 @@ own. It belongs to the Platform team's budget, not the application teams'.
   K8s allocation is one source feeding the broader allocation pipeline
 - `finops-tagging.md` - tag (label) hygiene is the prerequisite
 - `finops-aws-commitments.md` - EKS-specific commitment options; Karpenter
-  integration with EC2 Savings Plans and Compute Savings Plans
+  integration with EC2 Savings Plans and Compute Savings Plans; Spot best
+  practices and cross-AZ traffic monitoring as a companion signal to Spot
+  interruption handling
+- `finops-aws-patterns.md` - networking patterns, including cross-AZ data
+  transfer cost attribution for Spot-driven node AZ drift
 - `finops-azure.md` - AKS-specific deep cuts (Node Auto Provisioning,
   Azure Linux 2 retirement, MIG / MPS / DRA for GPU partitioning)
 - `finops-gcp.md` - GKE-specific options (Spot VMs, Autopilot vs Standard,
@@ -16736,6 +16912,14 @@ where writes are needed). Microsoft's own PoC catalogue includes a "Tag Hygiene 
 agent that finds resources missing required tags, generates a patch template, and deploys
 on approval - the same read-freely / write-behind-confirmation guardrail described above.
 See `finops-azure.md` ("Agentic FinOps on Azure") for the full treatment.
+
+As of September 2026, the Azure Resource Manager MCP Server (public preview) also
+extends this agentic pattern beyond tag hygiene into cost analysis and optimisation:
+it now exposes cost query and pricing tools by default, with optional tools for cost
+forecasting, budgets and alerts, reservations, Savings Plans, and Advisor
+recommendations, plus idle AKS capacity identification. This enables agents to
+analyse spend and estimate deployment costs natively, under the same identity-scoped,
+read-freely / write-behind-confirmation guardrails ([FinOps Weekly](https://finopsweekly.com/news/azure-updates-2026-09-03/)).
 
 ---
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2129,6 +2129,9 @@ likely to happen.
 Better: surface unallocated spend as a discrete line item. Make it visible to
 leadership. Drive the tagging programme on the back of it. See `finops-tagging.md`
 for the enforcement work that brings unallocated spend below the 10% threshold.
+An unallocated euro has no owner, and unowned spend only grows: nobody rightsizes
+what nobody is charged for, so the unallocated line drifts upward until someone is
+made to look at it.
 
 **AI spend needs its own unallocated-% treatment.** Token and harness cost
 attributes at the session level rather than the resource level, and one engineer
@@ -13952,6 +13955,18 @@ $/PTU/hour rates for any client decision.
 For some models, provisioned capacity never generates token-cost savings - it is purely
 a performance and SLA product.
 
+**Worked example (illustrative, September 2026).** Tarrowmere Assurance, a fictional
+insurer, runs a claims-summarisation workload on Azure OpenAI at a steady 1.4M input
+tokens an hour on weekdays and about a third of that at night and at weekends: a
+peak-to-trough ratio of 3.1:1. Normalised at 100% utilisation, the one-year PTU
+reservation it was quoted works out at 0.79x the pay-as-you-go input rate, so its
+break-even utilisation is 79%; below that, the reservation costs more per token than
+paying as you go. Load testing put weekday utilisation at 83% and the weekly average
+at 57%. Reserving for the whole curve loses money; reserving for the night-and-weekend
+floor and spilling the weekday peak to pay-as-you-go clears break-even with room to
+spare. The pair to remember is 3.1:1 against 79%: the traffic shape decides, the
+discount does not.
+
 ### Normalisation checklist
 
 - [ ] Identify the capacity unit type (PTU, throughput unit, scale tier unit)
@@ -18890,7 +18905,9 @@ this organisation at this stage?"
 ### Visibility before optimisation
 Cost visibility is a prerequisite, not a phase. You cannot rightsize what you cannot see.
 You cannot allocate savings to a team that has no cost attribution. This principle prevents
-the common mistake of jumping to optimisation before the foundation is in place.
+the common mistake of jumping to optimisation before the foundation is in place. An
+unallocated euro has no owner, and unowned spend only grows - which is why allocation,
+not tooling, is the first deliverable.
 
 Corollary: **physical tagging must precede virtual tagging**. Virtual tagging (applying
 metadata in the billing layer without changing resource tags) is powerful but fragile if

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -207,7 +207,7 @@ as "agents":
 |---|---|---|---|
 | **Workflow** | Traditional software with GenAI bolted into one or more steps | Bounded per invocation | Standard test set |
 | **Pipeline** | Predetermined steps, LLM called at one or more of them (most chatbots) | Bounded: per-call cost × known number of calls | LLM-as-judge works (fixed trajectory) |
-| **True agent** | Broad objective, tools available, decides at run time what to call, in what order, for how long | **Unbounded per task** - up to ~30x token variance on the same prompt (Pay-i-reported) | LLM-as-judge breaks: the agent constructs its own prompts, signal lives in the trajectory, not the final output |
+| **True agent** | Broad objective, tools available, decides at run time what to call, in what order, for how long | **Unbounded per task** - up to ~30x token variance on the same prompt (Bai et al. 2026, cited below) | LLM-as-judge breaks: the agent constructs its own prompts, signal lives in the trajectory, not the final output |
 
 **FinOps implications:**
 
@@ -332,14 +332,14 @@ An agent that stops instances autonomously is not - regardless of how sophistica
 reasoning is. Governance, not technology capability, is the real constraint on autonomous
 FinOps agents.
 
-**Billing-model flexibility for agent spend.** As of August 2026, Google's Gemini
-Enterprise / AI Cost Summary Agent offers a pay-as-you-go consumption edition
-alongside the existing per-user subscription model - see finops-gcp.md for guidance
-on choosing consumption versus subscription billing under budget guardrails. This
+**Billing-model flexibility for agent spend.** Since 26 August 2026, Gemini
+Enterprise offers a Pay-as-you-go edition (compute and tokens at standard model API
+rates, no base fee) alongside its per-seat editions - see `finops-gcp.md` for the
+eligibility caveat and for choosing between them under budget guardrails. This
 matters for cost governance: consumption billing suits variable, unbounded agent
-workloads where per-user seats over- or under-provision, while subscription billing
-gives predictable spend for steady-state usage. Match the billing model to the
-workload's cost class (see Big-T notation above).
+workloads where per-seat licences over- or under-provision, while subscription
+billing gives predictable spend for steady-state usage. Match the billing model to
+the workload's cost class (see Big-T notation above).
 
 AgentCore's policy capability now supports natural-language-to-Cedar tool-access controls,
 consistent with the policy-generation-over-direct-mutation pillar above.
@@ -366,7 +366,7 @@ verifies, settles, and returns the resource with a receipt.
 
 | Layer | What exists (as of July 2026) |
 |---|---|
-| Protocol | **x402** - open standard, created by Coinbase, now a Linux Foundation project (x402 Foundation; Coinbase and Cloudflare founding members; AWS, Stripe, Vercel among members). **MPP** (Machine Payments Protocol) - Stripe + Tempo Labs, IETF standards track, adds card rails and streaming payment sessions, backwards-compatible with x402 |
+| Protocol | **x402** - open standard, created by Coinbase, now a Linux Foundation project (x402 Foundation; Coinbase and Cloudflare founding members; AWS, Stripe, Google and Visa among the premier members; 40 members at the July 2026 launch). **MPP** (Machine Payments Protocol) - Stripe + Tempo Labs, IETF standards track, adds card rails and streaming payment sessions, backwards-compatible with x402 |
 | Platform rails | **Amazon Bedrock AgentCore Payments** - managed wallets via Coinbase CDP or Stripe (Privy); every payment runs in a *payment session* with a spending cap (`maxSpendAmount`) and expiry; wallets start empty and the end user explicitly grants the agent transaction permission; AgentCore Gateway reaches paid MCP servers/APIs incl. the Coinbase x402 Bazaar catalogue. **Cloudflare Agents SDK** - agents that pay (optional human-in-the-loop confirmation per payment) and services that charge (`paidTool`, one-line middleware) |
 | Control plane | **Ampersend** (Edge & Node, on x402 + Google A2A) - team wallets, funding automation, approvals, spend observability. Early entrant; expect a category |
 
@@ -595,12 +595,14 @@ standard API rates:
 | Model | Input ($/MTok) | Output ($/MTok) |
 |---|---|---|
 | Claude Haiku 4.5 | $1.00 | $5.00 |
-| Claude Sonnet 5 / 4.6 | $3.00 | $15.00 (Sonnet 5 introductory $2/$10 through 31 August 2026) |
+| Claude Sonnet 5 | $2.00 | $10.00 (introductory rate made permanent in August 2026) |
+| Claude Sonnet 4.6 | $3.00 | $15.00 |
 | Claude Opus 5 / 4.8 / 4.6 | $5.00 | $25.00 |
 
-Anthropic's own data indicates the average Claude Code user on API key mode costs ~$6/day,
-with 90% of users staying under $12/day. At sustained full-time usage, expect
-$100-$200/developer/month.
+Anthropic's own data (as of September 2026) puts the average Claude Code user on API
+key mode at around $13 per developer per active day, with 90% of users staying under
+$30 per active day, and $150-250 per developer per month at sustained usage. Source:
+https://code.claude.com/docs/en/costs.
 
 **Important cross-reference:** Claude Code usage on API key mode is subject to the same
 billing mechanics documented in `finops-anthropic.md` - Fast mode (2x, Opus-tier only),
@@ -618,20 +620,25 @@ question wherever developers can toggle it themselves.
   LiteLLM auto-detects Claude Code via User-Agent header
 - **Anthropic Console** - basic usage and billing data at the organisation level
 
-**Native gateway spend-limit warnings (as of September 2026).** Claude Code v2.1.251
-surfaces gateway spend limits proactively in its usage warnings - showing the spending
-cap, the reset time, and the operator message - rather than only failing silently or after
-the fact. The client now exposes a `rate_limits.spend_limit` status field and adds a
-spend-limit bar in the UI, giving FinOps teams a native signal for tracking token spend
-against caps. The same release also introduces prompt-cache visibility monitoring, so
-developers can observe cache efficiency directly in the client rather than inferring it
-from downstream billing data - useful for spotting the cache-miss patterns described in
-"The context-load tax" section below and for validating the cache multiplier mechanics
-documented in `finops-anthropic.md`. For teams enforcing per-user or per-team budget caps
-this improves cost-governance visibility and reduces surprise overage incidents. The
-practical effect is that ClaudeXray and LiteLLM are no longer needed *purely* for
-budget-cap visibility; they remain valuable for metadata injection, cross-tool
-aggregation, and analytics, but the cap-and-reset signal is now available natively.
+**Native gateway spend-limit warnings (as of September 2026).** For teams that run
+Claude Code behind a self-hosted Claude apps gateway with spend limits configured, the
+client surfaces those limits proactively in its usage warnings - the spending cap, the
+reset time and the operator message - rather than only failing silently or after the
+fact (since v2.1.225). Since v2.1.251 (28 August 2026) it also shows a spend-limit bar
+in `/usage` and exposes a `rate_limits.spend_limit` status-line field, both as a
+percentage of the cap rather than a dollar amount; the gateway server must be v2.1.225
+or later. None of this applies to Console API keys or to Team and Enterprise seats,
+which have their own admin-side alerts. The same release added a per-session
+prompt-cache line to `/cost` (hit ratio, misses, tokens re-cached, warm or cold) and a
+matching `prompt_cache` status object, so developers can see cache efficiency in the
+client rather than inferring it from billing data - useful for spotting the cache-miss
+patterns described in "The context-load tax" section below. Related: v2.1.243 added
+`modelPricing` (contracted rates shown in `/cost`) and a configurable `promptCacheTtl`.
+For gateway users the practical effect is that ClaudeXray and LiteLLM are no longer
+needed *purely* for budget-cap visibility; they remain valuable for metadata injection,
+cross-tool aggregation and analytics. Sources:
+https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md,
+https://code.claude.com/docs/en/costs, https://code.claude.com/docs/en/statusline.
 
 ---
 
@@ -829,12 +836,14 @@ less per request.
 
 ### For BYOK tools (Claude Code, Codex)
 
-**Model selection** - the mid tier runs at roughly 0.6x the large tier on the Claude side,
-and the gap between a mini and a frontier model on the OpenAI side is wider still. Choose
+**Model selection** - the mid tier runs at roughly 0.4x the large tier on the Claude side
+(Sonnet 5 against Opus 5, as of September 2026; 0.6x for Sonnet 4.6), and the gap
+between a mini and a frontier model on the OpenAI side is wider still. Choose
 the model that matches the task complexity, default to the more efficient one, and escalate
 only when needed. Pull the current rates before quantifying the saving.
 
-**Prompt caching** (Anthropic) - cache reads cost 0.1x the base input price. Cache writes
+**Prompt caching** (Anthropic) - cache reads cost 0.1x the base input price (0.025x on
+Fable 5.1). Cache writes
 cost 1.25x (5-minute TTL) or 2x (1-hour TTL). For repetitive workflows with stable system
 prompts, caching provides significant savings. See `finops-anthropic.md` for the full
 mechanics.
@@ -878,8 +887,10 @@ sessions/day is a material daily line item for capability nobody used that day.
 
 **Interaction with prompt caching.** The context prefix is cached, so within the cache window
 the marginal cost is small (cache reads are 0.1x base input; see `finops-anthropic.md` for
-the full mechanics). Two things break that: (1) the ~5-minute cache TTL - an idle gap longer
-than the window forces the whole prefix to be reprocessed at full price on the next turn (in
+the full mechanics). Two things break that: (1) the cache TTL - about 5 minutes on API-key
+or usage-credit billing, 1 hour on subscription sessions, configurable via `promptCacheTtl`
+since v2.1.243 - an idle gap longer than the window forces the whole prefix to be
+reprocessed at full price on the next turn (in
 the walkthrough, a cache miss after a coffee break turned a ~$0.02 turn into ~$0.12), and
 (2) enabling a new server mid-prefix invalidates the cache from that point on. Long,
 unfocused sessions make it worse: the resent context keeps growing, so every miss reprocesses
@@ -2465,10 +2476,12 @@ billing data.** The usage surfaces to watch:
   (`InputTokenCount`, `OutputTokenCount`, `Invocations`, `InvocationThrottles`), per
   `ModelId`, at minute granularity. Application inference profiles carry cost-allocation
   tags for per-application attribution, but their cost side is daily-grained - use it for
-  ownership, not live alerting. As of August 2026, AWS Cost Anomaly Detection also
-  natively monitors third-party foundation models on Bedrock (including provider-hosted
-  models such as Anthropic Claude), with root-cause breakdowns by account, region,
-  service, and usage type. Treat this native coverage as a complement to the
+  ownership, not live alerting. Since 19 August 2026, AWS Cost Anomaly Detection also
+  covers third-party foundation models on Bedrock (Anthropic Claude and other
+  provider-hosted models) through the AWS services managed monitor, with a root-cause
+  breakdown ranked by dollar impact across service, account, Region and usage type
+  ([AWS What's New](https://aws.amazon.com/about-aws/whats-new/2026/08/aws-cost-anomaly-detection-bedrock-3P/)).
+  Treat this native coverage as a complement to the
   usage-telemetry-based detection above, not a replacement: it narrows the reliance on
   CloudWatch-only detection for this gap, but its cost side remains too latent for the
   minute-scale burn scenarios that follow.
@@ -2654,7 +2667,7 @@ Total cost is now shaped by a combination of variables that FinOps must track ex
 | Performance tier | Standard vs Fast mode - 2x price multiplier, and only on the models that offer it |
 | Context length | **Per-model**: the current generation prices flat across a 1M-token window with no long-context premium. Older models applied premium rates above 200K input tokens. Verify per model rather than assuming either behaviour. |
 | Data residency | US-only inference adds a 1.1× multiplier |
-| Prompt caching | Writes are priced (1.25× or 2×), reads are discounted (0.1×) |
+| Prompt caching | Writes are priced (1.25× or 2×), reads are discounted (0.1×; 0.025× on Fable 5.1) |
 | Tool usage | Web search and code execution have separate meters |
 | Batch processing | 50% discount via Batch API (Fast mode excluded) |
 | Service tier | Standard, Priority, or Batch - affects capacity and pricing |
@@ -2664,7 +2677,7 @@ Total cost is now shaped by a combination of variables that FinOps must track ex
 
 ## Rate structure: Claude models
 
-> *Illustrative rates, list price, as of June 2026 (Anthropic model documentation).
+> *Illustrative rates, list price, as of September 2026 (Anthropic model documentation).
 > Prices move and this file does not. For a current figure, call a live pricing tool or
 > check <https://optimtoken.optimnow.io>. What is durable below is the tier structure and
 > the multipliers, not the absolute numbers.*
@@ -2678,7 +2691,7 @@ Total cost is now shaped by a combination of variables that FinOps must track ex
 | Claude Opus 4.8 | $5 | $25 | 1M | Previous Opus |
 | Claude Opus 4.7 | $5 | $25 | 1M | |
 | Claude Opus 4.6 | $5 | $25 | 1M | |
-| Claude Sonnet 5 | $3 | $15 | 1M | Introductory $2/$10 through 31 August 2026 |
+| Claude Sonnet 5 | $2 | $10 | 1M | Launched at an introductory rate; Anthropic made it the standard price in August 2026 and cancelled the scheduled 1 September increase |
 | Claude Sonnet 4.6 | $3 | $15 | 1M | |
 | Claude Haiku 4.5 | $1 | $5 | 200K | 200K window - the 1M window applies to 4.6-generation and later models only (the still-active Opus 4.5 and Sonnet 4.5 are likewise 200K) |
 
@@ -2689,9 +2702,13 @@ older Opus for price reasons. Second, Fable 5 sits at 2x Opus pricing, which mak
 "use the most capable model" a materially different decision from "use the newest
 Opus": route to Fable 5 on evidence, not by default.
 
-The introductory Sonnet 5 rate is a scheduled increase, not a discount to
-negotiate: budgets built on $2/$10 rise 50% on 1 September 2026 with no change in
-usage. Flag it now if Sonnet 5 carries meaningful volume.
+**The Sonnet 5 introductory rate became the standard rate.** The $2/$10 launch
+price was announced as temporary, with a 50% increase scheduled for 1 September
+2026. Anthropic cancelled the increase before it took effect (pricing page, checked
+9 September 2026: the previously scheduled increase "will not occur"). Two
+consequences: budgets built on the introductory rate stay valid, and Sonnet 5 now
+sits at 0.4x Opus rather than 0.6x, which widens the payoff from tiered routing.
+Verify the current figure on the pricing page or the live hub before quoting it.
 
 ### Fast mode pricing
 
@@ -2727,7 +2744,7 @@ an hour; the ceiling is 24 hours. Results are retained 29 days.
 | Model | Input ($/MTok) | Output ($/MTok) |
 |---|---|---|
 | Claude Opus 5 Batch | $2.50 | $12.50 |
-| Claude Sonnet 5 Batch | $1.50 | $7.50 ($1 / $5 introductory through 31 August 2026) |
+| Claude Sonnet 5 Batch | $1 | $5 |
 | Claude Haiku 4.5 Batch | $0.50 | $2.50 |
 
 Batch is the single largest rate lever available without a commercial negotiation.
@@ -2741,7 +2758,8 @@ completion - which makes it a workload-classification exercise, not a procuremen
   parameter is set
 - **5-minute cache writes**: x1.25 on base input price
 - **1-hour cache writes**: x2 on base input price
-- **Cache reads**: x0.1 on base input price (90% discount)
+- **Cache reads**: x0.1 on base input price (90% discount). Fable 5.1 reads at
+  x0.025 (97.5% discount), which moves the cache break-even for that tier
 - **Modifiers stack** - Fast mode plus US-only inference compounds
 
 **Cache break-even depends on the TTL, and the 1-hour TTL is not a free upgrade.**
@@ -2936,16 +2954,20 @@ an additional native cost-governance signal alongside the July 2026 Enterprise
 admin tooling, reducing surprise overage incidents. See the "Cost tracking for
 Claude Code" section in `finops-ai-dev-tools.md` for detail.
 
-**Prompt-cache visibility (as of September 2026):** Claude Code v2.1.251 adds a
-spend-limit bar in the UI and a `rate_limits.spend_limit` status field, plus
-native prompt-cache visibility monitoring. The prompt-cache signal ties directly
-into the cache multiplier mechanics documented above (5-minute writes at 1.25x,
-1-hour writes at 2x, reads at 0.1x): native visibility into cache hit behaviour
-lets teams confirm that prefixes are actually being read back rather than silently
-re-written at full rate - the exact break-even question raised in the "Modifiers"
-section. This reduces reliance on third-party tooling purely for budget-cap
-visibility. See the "Cost tracking for Claude Code" section in
-`finops-ai-dev-tools.md` for detail.
+**Prompt-cache visibility (Claude Code v2.1.251, 28 August 2026):** the `/cost`
+command now shows a per-session prompt-cache line (hit ratio, misses, tokens
+re-cached, warm or cold), with a matching `prompt_cache` object for status-line
+scripts; it covers the main conversation only, not subagents. That signal ties
+directly into the cache multiplier mechanics documented above (5-minute writes at
+1.25x, 1-hour writes at 2x, reads at 0.1x): it lets teams confirm that prefixes are
+actually being read back rather than silently re-written at full rate - the exact
+break-even question raised in the "Modifiers" section. The same release added a
+spend-limit bar to `/usage` and a `rate_limits.spend_limit` status field, but only
+for developers behind a self-hosted Claude apps gateway with spend limits
+configured; Console, Team and Enterprise users do not see it. See the "Cost
+tracking for Claude Code" section in `finops-ai-dev-tools.md` for detail. Sources:
+https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md (2.1.251),
+https://code.claude.com/docs/en/costs.
 
 Sources: [Anthropic - New analytics and cost controls for Claude Enterprise](https://claude.com/blog/giving-admins-more-visibility-and-control-over-claude-usage-and-spend) (primary),
 [Anthropic keeps signaling where AI cost governance needs to go](https://www.finout.io/blog/anthropic-keeps-signaling-where-ai-cost-governance-needs-to-go.-its-not-all-the-way-there-yet) (Finout commentary).
@@ -4939,14 +4961,14 @@ Some architectures unintentionally route large volumes of traffic between resour
 - Review VPC flow logs, CloudWatch metrics, or billing data to assess regional data transfer patterns
 - Determine whether the resource acts as a centralised destination for data aggregation, storage, or processing
 
-**Karpenter Spot Node Replacement Shifting Nodes Across Availability Zones**
+**Karpenter Nodes Landing In Other Availability Zones After Spot Exhaustion**
 Service: AWS EKS | Type: Inefficient Architecture
 
-As of March 2026, Karpenter's Spot-driven node replacement can silently shift nodes across Availability Zones when Spot capacity in the original AZ is exhausted. The replacement node may land in a different AZ from the workloads it serves, generating cross-AZ data transfer charges that appear on the bill with no corresponding health or utilisation alert. This is easy to miss because the cluster remains healthy and the cost surfaces only in inter-AZ data transfer lines. See the Karpenter consolidation/disruption tuning guidance in `finops-kubernetes.md` and the Spot best practices in `finops-aws-commitments.md`.
+When Spot capacity runs out in one Availability Zone, Karpenter places new nodes (often On-Demand fallback) in the zones that still have capacity. The cluster stays healthy, but calls that used to stay zone-local now cross zones and are billed at the Regional data transfer rate in each direction, with no health or utilisation alert. The cost surfaces only in inter-AZ data transfer lines. See the waste pattern in `finops-kubernetes.md` and the Spot best practices in `finops-aws-commitments.md`. Source: AWS Fundamentals, "Networking Is Still Hard" (8 September 2026), https://awsfundamentals.com/blog/cross-az-traffic-karpenter (practitioner write-up, not AWS documentation).
 
-- Detect nodes that changed AZ due to Spot interruption or replacement, and correlate the timing with cross-AZ data transfer cost spikes
-- Apply Karpenter NodePool AZ-affinity or topology spread constraints to keep replacement capacity aligned with dependent workloads
-- Add cross-AZ traffic monitoring as a companion signal to Spot interruption handling, so replacements that cross AZ boundaries are surfaced promptly
+- Alert on the On-Demand to Spot ratio, on nodes per zone, and on `DataTransfer-Regional-Bytes`, and correlate spikes with Spot exhaustion events
+- Widen NodePool instance families and sizes so more Spot pools qualify and the fallback fires less often
+- Set `trafficDistribution: PreferClose` on Services and use topology spread constraints; even spread alone only makes the cross-zone charge consistent
 
 **Managed Nat Gateway With Excessive Data Transfer**
 Service: AWS NAT Gateway | Type: Inefficient Architecture
@@ -5268,11 +5290,13 @@ the receiving side and the export configuration on the source side.
   AWS Organizations (M&A integrations, multi-payer setups, partner-resold
   accounts).
 
-**SQL-based row filtering at the source (March 2026).** AWS Data Exports now
-supports SQL-based row filtering for CUR 2.0 data, in addition to the existing
-column selection. This lets teams produce pre-filtered per-account or
-per-service datasets at the source, without building custom Lambda / Glue /
-Athena post-processing pipelines. As of March 2026, this is directly useful for:
+**SQL-based row filtering at the source.** AWS Data Exports has supported SQL
+row filtering (a `WHERE` clause on the CUR 2.0 table) alongside column
+selection since its launch in November 2023. It is an existing capability, not
+a recent one, but it is under-used: an AWS how-to published on 26 August 2026
+shows how to automate pre-filtered per-account or per-service exports at the
+source, without a custom Lambda / Glue / Athena post-processing pipeline. Where
+this pays off:
 - Partner sharing - publish a dataset scoped to only the accounts or services a
   partner is entitled to see.
 - Program or cost-centre isolation - a pre-filtered export per program without a
@@ -5282,7 +5306,7 @@ Athena post-processing pipelines. As of March 2026, this is directly useful for:
 
 Filtering at the source reduces the operational overhead of sharing scoped cost
 data and removes the need for organisations to maintain their own filtering
-pipeline. Source:
+pipeline. Source (AWS how-to, 26 August 2026):
 https://aws.amazon.com/blogs/aws-cloud-financial-management/automating-filtered-cost-and-usage-report-exports-with-aws-data-exports/
 
 Sources: https://aws.amazon.com/about-aws/whats-new/2025/11/aws-data-exports-focus-1-2-available/
@@ -5369,17 +5393,18 @@ unexpected spending increases and sends alerts via SNS or email.
 - Route alerts to both the FinOps practitioner and the engineering team lead
 - Review alert history monthly - tune thresholds to reduce false positives
 
-**Automated spend guardrails via AWS Budgets Actions (circuit breaker).** As of
-March 2026, AWS documents a programmatic "circuit breaker" pattern that uses AWS
-Budgets Actions to automatically restrict or revoke developer access when a
-budget threshold is exceeded, while maintaining an audit trail. This extends
-Budgets Actions beyond the existing SCP-apply and EC2-stop actions to IAM
-Identity Center permission-set assignments, giving FinOps teams a stronger
-automated governance guardrail: when a budget breaches, the action can detach or
-restrict IAM Identity Center permission sets (alongside applying an SCP or
-stopping EC2 instances) to halt further spend. Treat this as a complement to the
-reactive anomaly and budget alerts above, not a replacement - it is the
-preventive backstop that acts without waiting for a human. Source:
+**Automated spend guardrails: Budgets Actions and the access circuit breaker.**
+AWS Budgets Actions natively support three responses when a budget threshold is
+crossed: apply an IAM policy, apply an SCP, or stop EC2 / RDS instances. An AWS
+how-to published on 1 September 2026 extends the idea to developer access
+itself, which native actions do not cover: a budget alert publishes to SNS, and
+a Lambda function then removes the user's IAM Identity Center permission-set
+assignment or swaps it for a read-only one, with an audit trail. It is custom
+automation on top of a Budgets alert, not a new Budgets Action type, so it needs
+owning like any other Lambda. Treat both the native actions and the circuit
+breaker as a complement to the reactive anomaly and budget alerts above, not a
+replacement - they are the preventive backstop that acts without waiting for a
+human. Source (AWS how-to, 1 September 2026):
 https://aws.amazon.com/blogs/aws-cloud-financial-management/how-to-programmatically-manage-account-access-with-aws-budgets-alerts/
 
 ---
@@ -6004,11 +6029,12 @@ comparison is not close.
 - **Unsupported features block subscription.** The console refuses to attach a
   plan while the distribution still has Lambda@Edge, real-time logs or any
   other unsupported feature active.
-- **Programmatic management is now available.** As of September 2026, flat-rate
+- **Programmatic management is now available.** Since 3 September 2026, flat-rate
   plan subscription, upgrade, downgrade and cancellation can be managed
   programmatically via the CLI, SDKs, CloudFormation, CDK or the new
-  PricingPlanManager API - no longer console-only. Paid plans use a two-phase
-  create-then-approve activation flow so that provisioning a plan does not
+  PricingPlanManager API - no longer console-only. Paid plans support an optional
+  two-phase activation flow (create the plan, then approve it to start billing;
+  free plans activate immediately) so that provisioning a plan does not
   silently commit you to a monthly charge; the approval step is a governance
   safeguard that matters for IaC pipelines and agent-driven provisioning
   workflows, where an unreviewed template change could otherwise attach a paid
@@ -6981,16 +7007,20 @@ calculation from the cost-plus-utilisation join, reconcile differences. Differen
 diagnostic - they usually reveal AHB not factored, scope mismatches, or workload context
 Advisor cannot know.
 
-**Agentic access to commitment recommendation data.** As of September 2026, the Azure
-Resource Manager MCP Server (public preview) exposes cost query and pricing tools by
-default, with optional capabilities for reservation, Savings Plan, and Advisor
-recommendation data (plus forecasting, budgets/alerts, and idle AKS capacity detection).
-This lets AI agents pull the same backward-looking recommendation feed described above
-natively. The same calibration caveats apply: agent-surfaced recommendations remain a
-sanity check, not a source of truth, and still need reconciling against your own
-cost-plus-utilisation join. See the agentic FinOps discussion in `finops-azure.md` and
-the tag-hygiene pattern in `finops-tagging.md` for the broader MCP governance context.
-Source: Microsoft Learn (Azure Resource Manager MCP Server, public preview).
+**Agentic access to commitment recommendation data.** Since August 2026, the Azure
+Resource Manager MCP server (preview) exposes cost query and pricing tools by default,
+and an optional Cost Management toolset that adds reservation and Savings Plan
+insights alongside forecasting, budgets and alerts. This lets AI agents pull the same
+backward-looking recommendation feed described above natively (Advisor cost
+recommendations are mentioned in Microsoft's blog but not listed as a tool in the
+server's README, so verify before relying on that path). The same calibration caveats
+apply: agent-surfaced recommendations remain a sanity check, not a source of truth,
+and still need reconciling against your own cost-plus-utilisation join. See the
+agentic FinOps discussion in `finops-azure.md` and the tag-hygiene pattern in
+`finops-tagging.md` for the broader MCP governance context. Sources:
+https://github.com/Azure/Azure-Resource-Manager-MCP (README),
+https://techcommunity.microsoft.com/blog/finopsblog/cost-management-with-azure-resource-manager-mcp/4550182
+(Microsoft FinOps blog, 25 August 2026).
 
 Source: https://learn.microsoft.com/en-us/azure/advisor/advisor-reference-cost-recommendations
 
@@ -10314,10 +10344,12 @@ data with application-level metrics from CloudWatch or your own instrumentation.
 
 ### Cost Anomaly Detection for Bedrock foundation models
 
-As of August 2026, **AWS Cost Anomaly Detection** natively monitors third-party
-foundation models on Bedrock, including provider-hosted models such as Anthropic Claude.
-Detected anomalies come with root-cause breakdowns by account, region, service, and
-usage type. This reduces reliance on CloudWatch-only detection for this specific gap:
+Since 19 August 2026, **AWS Cost Anomaly Detection** monitors spend on third-party
+foundation models on Bedrock, such as Anthropic Claude and other provider-hosted models,
+through the AWS services managed monitor with no setup required (all commercial Regions
+except GovCloud and China). Detected anomalies come with a root-cause breakdown ranked by
+dollar impact across service, account, Region and usage type. This reduces reliance on
+CloudWatch-only detection for this specific gap:
 spend spikes on Bedrock foundation models can now be surfaced through the native
 anomaly-detection path rather than requiring custom CloudWatch alarms on token metrics.
 
@@ -10326,6 +10358,8 @@ detection for Bedrock foundation models, and complement it with usage-telemetry-
 detection (token-count metrics, invocation logging) for the token-level granularity that
 billing-based anomaly detection does not provide. See `finops-anomaly-management.md`
 for the AI/token-workload anomaly approach.
+
+Source: https://aws.amazon.com/about-aws/whats-new/2026/08/aws-cost-anomaly-detection-bedrock-3P/
 
 ### Tagging strategy for Bedrock
 
@@ -12338,18 +12372,19 @@ for every feature is the AI equivalent of running all workloads on ml.p4d.24xlar
 
 What drives the routing decision is the **spread between tiers**, not the absolute rate.
 The spread is the durable, transferable number; the rate card behind it changes every
-few months. Tier structure as observed August 2026:
+few months. Tier structure as observed September 2026:
 
 | Model tier | Use case | Cost ratio vs small tier (Claude) |
 |---|---|---|
 | Small / fast (Haiku class) | Classification, routing, simple Q&A | 1x |
-| Mid-tier (Sonnet class) | Complex reasoning, code generation | 3x |
+| Mid-tier (Sonnet class) | Complex reasoning, code generation | 2x (Sonnet 5; 3x for Sonnet 4.6) |
 | Large (Opus class) | Research, nuanced judgment | 5x |
 | Frontier (Fable class) | Hardest reasoning, high-stakes work | 10x |
 
 The spread is vendor-specific and compresses across generations: the Claude 3-era
-small-to-large ratio was roughly 60x, the current one is 5-10x, while OpenAI's
-mini-to-reasoning spread remains near 100x. A vendor whose spread is 100x rewards
+small-to-large ratio was roughly 60x, the current one is 5-10x, while OpenAI's spread
+depends on the pairing: about 20x within one model family and 150x or more from a nano
+model to a pro reasoning model. A vendor whose spread is 100x rewards
 tiered routing far more than one at 5x, and that alone can decide whether the routing
 harness is worth building.
 
@@ -12410,7 +12445,8 @@ The following inference parameters directly affect output length and therefore c
 
 #### Token engineering - the input/output optimisation menu
 
-Per-token, input is roughly 4-5x cheaper than output. That price signal misleads:
+Per-token, input is roughly 4-8x cheaper than output (5x across Anthropic's line, 4-8x
+across OpenAI's, as of September 2026). That price signal misleads:
 **in multi-turn conversations and agent loops, the entire history is re-billed as
 input on every turn.** Input token spend compounds quadratically with conversation
 length and routinely dominates. Optimise both sides.
@@ -12474,11 +12510,12 @@ deployments:
 - Anomaly alerts should trigger within minutes, not surface on the monthly bill
 - Define thresholds that require review before spend, not after
 - Where the platform offers native token-budget enforcement, use it as a proactive
-  guardrail rather than relying on alerts alone. As of September 2026, BigQuery
-  supports daily token quotas for its generative AI SQL functions (ML.GENERATE_TEXT
-  and related), letting teams cap daily token consumption at the platform level - a
-  GCP-native example of token budget enforcement that complements budget alerts and
-  anomaly detection (see `finops-gcp.md`).
+  guardrail rather than relying on alerts alone. Since 31 August 2026, BigQuery
+  again supports daily token quotas for its generative AI functions (AI.GENERATE_TEXT
+  and the other Gemini-based inference functions), per project and per user; the
+  defaults are high, so the control is the stricter override you set - a GCP-native
+  example of token budget enforcement that complements budget alerts and anomaly
+  detection (see `finops-gcp.md`).
 
 **Governance policies to establish:**
 - Require AI cost estimates (COGS modelling) before feature deployment
@@ -12534,9 +12571,10 @@ calls, validation loops, or agents that invoke themselves multiply token consump
 per query - each retry or validation loop triggers additional SaaS charges alongside
 model costs.
 
-*Real example:* A sales intelligence agent validated its own output with a second API
-call. When validation failed, it retried the full sequence. A single user query generated
-47 API calls at $2.30 each. At 12,000 queries/month: $27,600 in unintended cost. When
+*Real example (figures illustrative):* A sales intelligence agent validated its own output
+with a second API call. When validation failed, it retried the full sequence. A single user
+query generated 47 API calls, about $2.30 per query where a single call would have cost
+$0.05. At 12,000 queries/month: $27,600 in unintended cost. When
 the same agent began querying Salesforce data, per-query charges added another $18,000/month
 that appeared in the SaaS bill, not the AI infrastructure budget.
 
@@ -12557,10 +12595,12 @@ cross-region data transfer appearing in billing without a clear infrastructure c
 A feature appears viable at low volume. Each interaction loses money, but losses are
 small and unnoticed. As adoption grows, the scale-up accelerates the loss.
 
-*Real example:* An AI-powered search feature was included in a standard $15/user/month
-subscription. Each user performed 120 searches/month at $0.08 each - $9.60 in AI costs
-per user, against $15 in subscription revenue. Profitable only for users performing fewer
-than 25 searches/month. Feature adoption growth increased losses, not margins.
+*Real example (figures illustrative):* An AI-powered search feature was included in a
+standard $15/user/month subscription. Power users performed 220 searches/month at $0.08
+each - $17.60 in AI costs per user, against $15 in subscription revenue, before any other
+cost of serving the account. Break-even sat at roughly 187 searches/month, and the users
+who adopted the feature most were exactly the ones above it. Feature adoption growth
+increased losses, not margins.
 
 *Detection signal:* AI costs growing proportionally with user adoption; unit margin
 declining as volume increases.
@@ -13072,24 +13112,31 @@ face when managing AI workloads on GCP.
 - Native tooling for AI spend attribution without third-party tools
 - Integrated into the Cloud Billing console for unified cost management
 
-**Gemini Enterprise consumption edition - pay-as-you-go alongside subscription.**
-As of August 2026, Gemini Enterprise added a **pay-as-you-go consumption edition**
-alongside the existing per-user subscription model. This gives FinOps teams a choice
-of billing shape for agent workloads rather than a single seat-based commitment.
+**Gemini Enterprise Pay-as-you-go edition - consumption alongside subscription.**
+On 26 August 2026 Google announced a **Gemini Enterprise Pay-as-you-go** edition
+alongside the per-seat editions (Business, Standard, Plus, Frontline). There is no
+base subscription fee: you pay for the compute and tokens your teams consume at
+standard model API rates, with no feature quota limits. At announcement it was
+available to select customers on invoiced Cloud Billing accounts and "rolling out
+broadly soon", so check eligibility before planning around it. This gives FinOps
+teams a choice of billing shape for agent workloads rather than a single seat-based
+commitment.
 
-- **Subscription (per-user)**: predictable per-seat cost; best where a stable,
-  known population of users runs agents regularly, and where flat budgeting matters
-  more than usage sensitivity.
-- **Consumption (pay-as-you-go)**: cost scales with actual agent usage; best for
-  spiky, exploratory, or uneven adoption where many seats would sit idle under a
-  subscription, or where new agent workloads have uncertain demand.
+- **Subscription (per-seat)**: predictable cost; best where a stable, known
+  population of users runs agents regularly, and where flat budgeting matters more
+  than usage sensitivity. Idle seats are the waste to watch.
+- **Pay-as-you-go**: cost scales with actual usage; best for spiky, exploratory or
+  uneven adoption where many seats would sit idle, or where new agent workloads have
+  uncertain demand. Unbounded usage is the risk to watch.
 
-**Choosing between them, with budget guardrails:** default to consumption for new
-or variable agent workloads and pair it with budget alerts (50% / 80% / 100%) and
-anomaly detection so unpredictable usage cannot silently overrun the budget. Move to
-subscription once adoption stabilises and per-user cost is consistently below the
-observed consumption run-rate. Reassess the mix periodically as adoption matures. See
-`finops-agentic.md` under cost governance for agent spend flexibility.
+**Choosing between them, with budget guardrails:** default to pay-as-you-go for new
+or variable agent workloads and pair it with a budget, threshold alerts and anomaly
+detection so unpredictable usage cannot silently overrun the budget. Move to a
+subscription edition once adoption stabilises and per-seat cost is consistently
+below the observed consumption run-rate. Reassess the mix as adoption matures. See
+`finops-agentic.md` under cost governance for agent spend flexibility. Sources:
+https://cloud.google.com/blog/products/ai-machine-learning/flexible-billing-and-cost-controls-for-agents-on-google-cloud
+(primary, 26 August 2026), https://docs.cloud.google.com/gemini/enterprise/docs/editions.
 
 **Originating products filter and Gemini Enterprise preset report.** As of August 2026,
 Cloud Billing added an **"Originating products"** filter/group-by dimension in Billing
@@ -13379,21 +13426,24 @@ https://finopsweekly.com/news/gcp-updates-2026-07-02/ (secondary source - verify
 
 #### Daily token quotas for generative AI SQL functions - native spend guardrail
 
-As of September 2026, BigQuery has restored **daily token quotas** for its
-generative AI SQL functions (`ML.GENERATE_TEXT` and related functions), allowing
-teams to cap daily token consumption directly at the platform level. This gives
-FinOps and data teams a proactive, native guardrail against unexpected GenAI spend
-spikes from BigQuery-based AI workloads, complementing existing budget alerts and
-anomaly detection.
+On 31 August 2026 BigQuery restored **daily token quotas** for its generative AI
+functions (`AI.GENERATE_TEXT`, `AI.CLASSIFY` and the other Gemini-based inference
+functions; embedding functions such as `AI.EMBED` are excluded). The quotas went GA
+on 8 June 2026, were disabled a week later, and came back at the end of August.
+They are the platform-level cap on GenAI spend from BigQuery workloads,
+complementing budget alerts and anomaly detection.
 
-- Cap daily token consumption per project at the platform level, so a runaway
-  GenAI SQL workload cannot silently blow through the budget before an alert fires
-- Complements (does not replace) budget alerts and anomaly detection - use it as a
-  hard ceiling while budget alerts remain the softer, notification-based signal
-- Enforce token budgets on `ML.GENERATE_TEXT` and related generative AI functions
-  before spend materialises, rather than reacting after the invoice
+- Four quota metrics, tracked globally across regions: input and output tokens per
+  day, each at project level and per user. Cached tokens do not count.
+- The defaults are very high, so the quota does nothing until you lower it: set a
+  stricter override on the IAM & Admin > Quotas & System Limits page. That override
+  is the actual cost control.
+- Complements (does not replace) budget alerts and anomaly detection - it is the
+  hard ceiling while budget alerts remain the softer, notification-based signal.
 
-See `finops-for-ai.md` for the broader proactive guardrail and token-budget
+Sources: https://docs.cloud.google.com/bigquery/docs/control-genai-costs (primary),
+https://docs.cloud.google.com/bigquery/docs/release-notes#August_31_2026 (release
+note). See `finops-for-ai.md` for the broader proactive guardrail and token-budget
 enforcement guidance; this is the GCP-native example of platform-level token
 budget enforcement.
 
@@ -14868,28 +14918,34 @@ governing how aggressively Karpenter replaces nodes.
 Tune up or down based on the observed pod-disruption rate vs the savings
 delivered.
 
-#### Waste pattern: silent cross-AZ node drift from Spot replacement
+#### Waste pattern: silent cross-AZ drift after Spot exhaustion
 
-When Karpenter replaces a Spot node whose original availability zone has
-exhausted Spot capacity, it may provision the replacement in a different AZ.
-This is a legitimate resilience behaviour, but it can silently shift a
-workload's pods across zones and generate cross-AZ data transfer charges that
-appear on the bill with no corresponding health or utilisation alert. The cost
-lands in networking, disconnected from any Karpenter or Spot signal.
+When Spot capacity runs out in one zone, Karpenter keeps the cluster healthy by
+placing new nodes wherever capacity exists: the busy zone goes first, so the
+replacements land in the other zones, often as On-Demand fallback. Nothing
+fails, but calls that used to stay zone-local now cross zones and are billed
+at the Regional data transfer rate in each direction. The cost lands in
+networking, disconnected from any Karpenter or Spot signal, and no health or
+utilisation alert fires.
 
-As of March 2026, this is a named detection pattern:
+Detection and mitigation (a named pattern since September 2026):
 
-- **Detect** nodes that changed AZ following a Spot interruption or
-  replacement, and correlate the timing with cross-AZ data transfer cost
-  spikes on the same cluster.
-- **Mitigate** with NodePool AZ-affinity or topology spread constraints where
-  the workload's cross-AZ chatter is expensive enough to outweigh the
-  resilience benefit of free AZ selection. This is a per-workload trade-off,
-  not a cluster-wide default.
-- **Monitor** cross-AZ traffic as a companion signal to Spot interruption
-  handling, so a spike is attributable to the replacement event that caused
-  it. See the Spot best practices in `finops-aws-commitments.md` and the
-  networking patterns in `finops-aws-patterns.md`.
+- **Detect** by alerting on the On-Demand to Spot ratio, on nodes per zone,
+  and on `DataTransfer-Regional-Bytes` usage on the cluster's accounts, then
+  correlate a spike with the Spot exhaustion event that caused it.
+- **Reduce the trigger**: widen the NodePool's instance families and sizes so
+  more Spot pools qualify and the fallback fires less often.
+- **Keep traffic local**: set `trafficDistribution: PreferClose` on Services
+  so requests prefer same-zone endpoints, and use topology spread constraints
+  to keep pods spread evenly. Even spread on its own does not help; it only
+  makes you pay the cross-zone rate consistently. Zones are a filter for
+  Karpenter, not a preference, so pinning a NodePool to one zone trades away
+  the resilience that makes Spot workable.
+- See the Spot best practices in `finops-aws-commitments.md` and the
+  networking patterns in `finops-aws-patterns.md`. Source: AWS Fundamentals,
+  "Networking Is Still Hard" (Tobias Schmidt, 8 September 2026),
+  https://awsfundamentals.com/blog/cross-az-traffic-karpenter - a practitioner
+  write-up, not AWS documentation.
 
 ### Pod Disruption Budgets are non-negotiable
 
@@ -16913,13 +16969,18 @@ agent that finds resources missing required tags, generates a patch template, an
 on approval - the same read-freely / write-behind-confirmation guardrail described above.
 See `finops-azure.md` ("Agentic FinOps on Azure") for the full treatment.
 
-As of September 2026, the Azure Resource Manager MCP Server (public preview) also
-extends this agentic pattern beyond tag hygiene into cost analysis and optimisation:
-it now exposes cost query and pricing tools by default, with optional tools for cost
-forecasting, budgets and alerts, reservations, Savings Plans, and Advisor
-recommendations, plus idle AKS capacity identification. This enables agents to
-analyse spend and estimate deployment costs natively, under the same identity-scoped,
-read-freely / write-behind-confirmation guardrails ([FinOps Weekly](https://finopsweekly.com/news/azure-updates-2026-09-03/)).
+Since August 2026, the Azure Resource Manager MCP server (preview) also extends this
+agentic pattern beyond tag hygiene into cost analysis: its Cost Management and Pricing
+tools (cost queries, AKS cost by cluster, namespace and active-versus-idle capacity,
+retail prices, price sheet download) are enabled by default, and an optional Cost
+Management toolset (forecasting, dimensions, budgets, alerts, reservation and Savings
+Plan insights) is switched on per client with the `x-mcp-toolset: CostManagement`
+header. This enables agents to analyse spend and estimate deployment costs natively,
+under the same identity-scoped, read-freely / write-behind-confirmation guardrails.
+Do not confuse it with the separate Azure MCP Server, which has its own pricing and
+Advisor tools. Sources: https://github.com/Azure/Azure-Resource-Manager-MCP (README),
+https://techcommunity.microsoft.com/blog/finopsblog/cost-management-with-azure-resource-manager-mcp/4550182
+(Microsoft FinOps blog, 25 August 2026).
 
 ---
 

--- a/mcp_server/tests/test_tools.py
+++ b/mcp_server/tests/test_tools.py
@@ -199,7 +199,9 @@ def test_section_match_is_case_insensitive_and_partial() -> None:
 def test_section_match_tolerates_word_order() -> None:
     """Tier 4: every word of the query appears in the heading, order-free."""
     result = tools.get_reference(CATALOGUE, section="patterns networking")
-    assert result["section"] == "Networking Optimization Patterns (14)"
+    # The trailing "(N)" is a pattern count that content updates bump; the
+    # match under test is the heading words, so do not pin the count.
+    assert result["section"].startswith("Networking Optimization Patterns (")
 
 
 def test_h2_sections_are_selectable_too() -> None:

--- a/skills/cloud-finops/references/finops-agentic.md
+++ b/skills/cloud-finops/references/finops-agentic.md
@@ -30,7 +30,7 @@ as "agents":
 |---|---|---|---|
 | **Workflow** | Traditional software with GenAI bolted into one or more steps | Bounded per invocation | Standard test set |
 | **Pipeline** | Predetermined steps, LLM called at one or more of them (most chatbots) | Bounded: per-call cost × known number of calls | LLM-as-judge works (fixed trajectory) |
-| **True agent** | Broad objective, tools available, decides at run time what to call, in what order, for how long | **Unbounded per task** - up to ~30x token variance on the same prompt (Pay-i-reported) | LLM-as-judge breaks: the agent constructs its own prompts, signal lives in the trajectory, not the final output |
+| **True agent** | Broad objective, tools available, decides at run time what to call, in what order, for how long | **Unbounded per task** - up to ~30x token variance on the same prompt (Bai et al. 2026, cited below) | LLM-as-judge breaks: the agent constructs its own prompts, signal lives in the trajectory, not the final output |
 
 **FinOps implications:**
 
@@ -155,14 +155,14 @@ An agent that stops instances autonomously is not - regardless of how sophistica
 reasoning is. Governance, not technology capability, is the real constraint on autonomous
 FinOps agents.
 
-**Billing-model flexibility for agent spend.** As of August 2026, Google's Gemini
-Enterprise / AI Cost Summary Agent offers a pay-as-you-go consumption edition
-alongside the existing per-user subscription model - see finops-gcp.md for guidance
-on choosing consumption versus subscription billing under budget guardrails. This
+**Billing-model flexibility for agent spend.** Since 26 August 2026, Gemini
+Enterprise offers a Pay-as-you-go edition (compute and tokens at standard model API
+rates, no base fee) alongside its per-seat editions - see `finops-gcp.md` for the
+eligibility caveat and for choosing between them under budget guardrails. This
 matters for cost governance: consumption billing suits variable, unbounded agent
-workloads where per-user seats over- or under-provision, while subscription billing
-gives predictable spend for steady-state usage. Match the billing model to the
-workload's cost class (see Big-T notation above).
+workloads where per-seat licences over- or under-provision, while subscription
+billing gives predictable spend for steady-state usage. Match the billing model to
+the workload's cost class (see Big-T notation above).
 
 AgentCore's policy capability now supports natural-language-to-Cedar tool-access controls,
 consistent with the policy-generation-over-direct-mutation pillar above.
@@ -189,7 +189,7 @@ verifies, settles, and returns the resource with a receipt.
 
 | Layer | What exists (as of July 2026) |
 |---|---|
-| Protocol | **x402** - open standard, created by Coinbase, now a Linux Foundation project (x402 Foundation; Coinbase and Cloudflare founding members; AWS, Stripe, Vercel among members). **MPP** (Machine Payments Protocol) - Stripe + Tempo Labs, IETF standards track, adds card rails and streaming payment sessions, backwards-compatible with x402 |
+| Protocol | **x402** - open standard, created by Coinbase, now a Linux Foundation project (x402 Foundation; Coinbase and Cloudflare founding members; AWS, Stripe, Google and Visa among the premier members; 40 members at the July 2026 launch). **MPP** (Machine Payments Protocol) - Stripe + Tempo Labs, IETF standards track, adds card rails and streaming payment sessions, backwards-compatible with x402 |
 | Platform rails | **Amazon Bedrock AgentCore Payments** - managed wallets via Coinbase CDP or Stripe (Privy); every payment runs in a *payment session* with a spending cap (`maxSpendAmount`) and expiry; wallets start empty and the end user explicitly grants the agent transaction permission; AgentCore Gateway reaches paid MCP servers/APIs incl. the Coinbase x402 Bazaar catalogue. **Cloudflare Agents SDK** - agents that pay (optional human-in-the-loop confirmation per payment) and services that charge (`paidTool`, one-line middleware) |
 | Control plane | **Ampersend** (Edge & Node, on x402 + Google A2A) - team wallets, funding automation, approvals, spend observability. Early entrant; expect a category |
 

--- a/skills/cloud-finops/references/finops-agentic.md
+++ b/skills/cloud-finops/references/finops-agentic.md
@@ -155,6 +155,15 @@ An agent that stops instances autonomously is not - regardless of how sophistica
 reasoning is. Governance, not technology capability, is the real constraint on autonomous
 FinOps agents.
 
+**Billing-model flexibility for agent spend.** As of August 2026, Google's Gemini
+Enterprise / AI Cost Summary Agent offers a pay-as-you-go consumption edition
+alongside the existing per-user subscription model - see finops-gcp.md for guidance
+on choosing consumption versus subscription billing under budget guardrails. This
+matters for cost governance: consumption billing suits variable, unbounded agent
+workloads where per-user seats over- or under-provision, while subscription billing
+gives predictable spend for steady-state usage. Match the billing model to the
+workload's cost class (see Big-T notation above).
+
 AgentCore's policy capability now supports natural-language-to-Cedar tool-access controls,
 consistent with the policy-generation-over-direct-mutation pillar above.
 

--- a/skills/cloud-finops/references/finops-ai-dev-tools.md
+++ b/skills/cloud-finops/references/finops-ai-dev-tools.md
@@ -180,12 +180,14 @@ standard API rates:
 | Model | Input ($/MTok) | Output ($/MTok) |
 |---|---|---|
 | Claude Haiku 4.5 | $1.00 | $5.00 |
-| Claude Sonnet 5 / 4.6 | $3.00 | $15.00 (Sonnet 5 introductory $2/$10 through 31 August 2026) |
+| Claude Sonnet 5 | $2.00 | $10.00 (introductory rate made permanent in August 2026) |
+| Claude Sonnet 4.6 | $3.00 | $15.00 |
 | Claude Opus 5 / 4.8 / 4.6 | $5.00 | $25.00 |
 
-Anthropic's own data indicates the average Claude Code user on API key mode costs ~$6/day,
-with 90% of users staying under $12/day. At sustained full-time usage, expect
-$100-$200/developer/month.
+Anthropic's own data (as of September 2026) puts the average Claude Code user on API
+key mode at around $13 per developer per active day, with 90% of users staying under
+$30 per active day, and $150-250 per developer per month at sustained usage. Source:
+https://code.claude.com/docs/en/costs.
 
 **Important cross-reference:** Claude Code usage on API key mode is subject to the same
 billing mechanics documented in `finops-anthropic.md` - Fast mode (2x, Opus-tier only),
@@ -203,20 +205,25 @@ question wherever developers can toggle it themselves.
   LiteLLM auto-detects Claude Code via User-Agent header
 - **Anthropic Console** - basic usage and billing data at the organisation level
 
-**Native gateway spend-limit warnings (as of September 2026).** Claude Code v2.1.251
-surfaces gateway spend limits proactively in its usage warnings - showing the spending
-cap, the reset time, and the operator message - rather than only failing silently or after
-the fact. The client now exposes a `rate_limits.spend_limit` status field and adds a
-spend-limit bar in the UI, giving FinOps teams a native signal for tracking token spend
-against caps. The same release also introduces prompt-cache visibility monitoring, so
-developers can observe cache efficiency directly in the client rather than inferring it
-from downstream billing data - useful for spotting the cache-miss patterns described in
-"The context-load tax" section below and for validating the cache multiplier mechanics
-documented in `finops-anthropic.md`. For teams enforcing per-user or per-team budget caps
-this improves cost-governance visibility and reduces surprise overage incidents. The
-practical effect is that ClaudeXray and LiteLLM are no longer needed *purely* for
-budget-cap visibility; they remain valuable for metadata injection, cross-tool
-aggregation, and analytics, but the cap-and-reset signal is now available natively.
+**Native gateway spend-limit warnings (as of September 2026).** For teams that run
+Claude Code behind a self-hosted Claude apps gateway with spend limits configured, the
+client surfaces those limits proactively in its usage warnings - the spending cap, the
+reset time and the operator message - rather than only failing silently or after the
+fact (since v2.1.225). Since v2.1.251 (28 August 2026) it also shows a spend-limit bar
+in `/usage` and exposes a `rate_limits.spend_limit` status-line field, both as a
+percentage of the cap rather than a dollar amount; the gateway server must be v2.1.225
+or later. None of this applies to Console API keys or to Team and Enterprise seats,
+which have their own admin-side alerts. The same release added a per-session
+prompt-cache line to `/cost` (hit ratio, misses, tokens re-cached, warm or cold) and a
+matching `prompt_cache` status object, so developers can see cache efficiency in the
+client rather than inferring it from billing data - useful for spotting the cache-miss
+patterns described in "The context-load tax" section below. Related: v2.1.243 added
+`modelPricing` (contracted rates shown in `/cost`) and a configurable `promptCacheTtl`.
+For gateway users the practical effect is that ClaudeXray and LiteLLM are no longer
+needed *purely* for budget-cap visibility; they remain valuable for metadata injection,
+cross-tool aggregation and analytics. Sources:
+https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md,
+https://code.claude.com/docs/en/costs, https://code.claude.com/docs/en/statusline.
 
 ---
 
@@ -414,12 +421,14 @@ less per request.
 
 ### For BYOK tools (Claude Code, Codex)
 
-**Model selection** - the mid tier runs at roughly 0.6x the large tier on the Claude side,
-and the gap between a mini and a frontier model on the OpenAI side is wider still. Choose
+**Model selection** - the mid tier runs at roughly 0.4x the large tier on the Claude side
+(Sonnet 5 against Opus 5, as of September 2026; 0.6x for Sonnet 4.6), and the gap
+between a mini and a frontier model on the OpenAI side is wider still. Choose
 the model that matches the task complexity, default to the more efficient one, and escalate
 only when needed. Pull the current rates before quantifying the saving.
 
-**Prompt caching** (Anthropic) - cache reads cost 0.1x the base input price. Cache writes
+**Prompt caching** (Anthropic) - cache reads cost 0.1x the base input price (0.025x on
+Fable 5.1). Cache writes
 cost 1.25x (5-minute TTL) or 2x (1-hour TTL). For repetitive workflows with stable system
 prompts, caching provides significant savings. See `finops-anthropic.md` for the full
 mechanics.
@@ -463,8 +472,10 @@ sessions/day is a material daily line item for capability nobody used that day.
 
 **Interaction with prompt caching.** The context prefix is cached, so within the cache window
 the marginal cost is small (cache reads are 0.1x base input; see `finops-anthropic.md` for
-the full mechanics). Two things break that: (1) the ~5-minute cache TTL - an idle gap longer
-than the window forces the whole prefix to be reprocessed at full price on the next turn (in
+the full mechanics). Two things break that: (1) the cache TTL - about 5 minutes on API-key
+or usage-credit billing, 1 hour on subscription sessions, configurable via `promptCacheTtl`
+since v2.1.243 - an idle gap longer than the window forces the whole prefix to be
+reprocessed at full price on the next turn (in
 the walkthrough, a cache miss after a coffee break turned a ~$0.02 turn into ~$0.12), and
 (2) enabling a new server mid-prefix invalidates the cache from that point on. Long,
 unfocused sessions make it worse: the resent context keeps growing, so every miss reprocesses

--- a/skills/cloud-finops/references/finops-ai-dev-tools.md
+++ b/skills/cloud-finops/references/finops-ai-dev-tools.md
@@ -203,14 +203,20 @@ question wherever developers can toggle it themselves.
   LiteLLM auto-detects Claude Code via User-Agent header
 - **Anthropic Console** - basic usage and billing data at the organisation level
 
-**Native gateway spend-limit warnings (as of August 2026).** Claude Code now surfaces
-gateway spend limits proactively in its usage warnings - showing the spending cap, the
-reset time, and the operator message - rather than only failing silently or after the
-fact. For teams enforcing per-user or per-team budget caps this improves cost-governance
-visibility and reduces surprise overage incidents. The practical effect is that ClaudeXray
-and LiteLLM are no longer needed *purely* for budget-cap visibility; they remain valuable
-for metadata injection, cross-tool aggregation, and analytics, but the cap-and-reset
-signal is now available natively.
+**Native gateway spend-limit warnings (as of September 2026).** Claude Code v2.1.251
+surfaces gateway spend limits proactively in its usage warnings - showing the spending
+cap, the reset time, and the operator message - rather than only failing silently or after
+the fact. The client now exposes a `rate_limits.spend_limit` status field and adds a
+spend-limit bar in the UI, giving FinOps teams a native signal for tracking token spend
+against caps. The same release also introduces prompt-cache visibility monitoring, so
+developers can observe cache efficiency directly in the client rather than inferring it
+from downstream billing data - useful for spotting the cache-miss patterns described in
+"The context-load tax" section below and for validating the cache multiplier mechanics
+documented in `finops-anthropic.md`. For teams enforcing per-user or per-team budget caps
+this improves cost-governance visibility and reduces surprise overage incidents. The
+practical effect is that ClaudeXray and LiteLLM are no longer needed *purely* for
+budget-cap visibility; they remain valuable for metadata injection, cross-tool
+aggregation, and analytics, but the cap-and-reset signal is now available natively.
 
 ---
 

--- a/skills/cloud-finops/references/finops-allocation-showback.md
+++ b/skills/cloud-finops/references/finops-allocation-showback.md
@@ -278,6 +278,9 @@ likely to happen.
 Better: surface unallocated spend as a discrete line item. Make it visible to
 leadership. Drive the tagging programme on the back of it. See `finops-tagging.md`
 for the enforcement work that brings unallocated spend below the 10% threshold.
+An unallocated euro has no owner, and unowned spend only grows: nobody rightsizes
+what nobody is charged for, so the unallocated line drifts upward until someone is
+made to look at it.
 
 **AI spend needs its own unallocated-% treatment.** Token and harness cost
 attributes at the session level rather than the resource level, and one engineer

--- a/skills/cloud-finops/references/finops-anomaly-management.md
+++ b/skills/cloud-finops/references/finops-anomaly-management.md
@@ -224,10 +224,12 @@ billing data.** The usage surfaces to watch:
   (`InputTokenCount`, `OutputTokenCount`, `Invocations`, `InvocationThrottles`), per
   `ModelId`, at minute granularity. Application inference profiles carry cost-allocation
   tags for per-application attribution, but their cost side is daily-grained - use it for
-  ownership, not live alerting. As of August 2026, AWS Cost Anomaly Detection also
-  natively monitors third-party foundation models on Bedrock (including provider-hosted
-  models such as Anthropic Claude), with root-cause breakdowns by account, region,
-  service, and usage type. Treat this native coverage as a complement to the
+  ownership, not live alerting. Since 19 August 2026, AWS Cost Anomaly Detection also
+  covers third-party foundation models on Bedrock (Anthropic Claude and other
+  provider-hosted models) through the AWS services managed monitor, with a root-cause
+  breakdown ranked by dollar impact across service, account, Region and usage type
+  ([AWS What's New](https://aws.amazon.com/about-aws/whats-new/2026/08/aws-cost-anomaly-detection-bedrock-3P/)).
+  Treat this native coverage as a complement to the
   usage-telemetry-based detection above, not a replacement: it narrows the reliance on
   CloudWatch-only detection for this gap, but its cost side remains too latent for the
   minute-scale burn scenarios that follow.

--- a/skills/cloud-finops/references/finops-anomaly-management.md
+++ b/skills/cloud-finops/references/finops-anomaly-management.md
@@ -224,7 +224,13 @@ billing data.** The usage surfaces to watch:
   (`InputTokenCount`, `OutputTokenCount`, `Invocations`, `InvocationThrottles`), per
   `ModelId`, at minute granularity. Application inference profiles carry cost-allocation
   tags for per-application attribution, but their cost side is daily-grained - use it for
-  ownership, not live alerting.
+  ownership, not live alerting. As of August 2026, AWS Cost Anomaly Detection also
+  natively monitors third-party foundation models on Bedrock (including provider-hosted
+  models such as Anthropic Claude), with root-cause breakdowns by account, region,
+  service, and usage type. Treat this native coverage as a complement to the
+  usage-telemetry-based detection above, not a replacement: it narrows the reliance on
+  CloudWatch-only detection for this gap, but its cost side remains too latent for the
+  minute-scale burn scenarios that follow.
 - **Anthropic** - the Usage & Cost Admin API usage endpoint
   (`/v1/organizations/usage_report/messages`) supports 1-minute buckets with data
   appearing within ~5 minutes; the cost endpoint is daily-only.

--- a/skills/cloud-finops/references/finops-anthropic.md
+++ b/skills/cloud-finops/references/finops-anthropic.md
@@ -42,7 +42,7 @@ Total cost is now shaped by a combination of variables that FinOps must track ex
 | Performance tier | Standard vs Fast mode - 2x price multiplier, and only on the models that offer it |
 | Context length | **Per-model**: the current generation prices flat across a 1M-token window with no long-context premium. Older models applied premium rates above 200K input tokens. Verify per model rather than assuming either behaviour. |
 | Data residency | US-only inference adds a 1.1× multiplier |
-| Prompt caching | Writes are priced (1.25× or 2×), reads are discounted (0.1×) |
+| Prompt caching | Writes are priced (1.25× or 2×), reads are discounted (0.1×; 0.025× on Fable 5.1) |
 | Tool usage | Web search and code execution have separate meters |
 | Batch processing | 50% discount via Batch API (Fast mode excluded) |
 | Service tier | Standard, Priority, or Batch - affects capacity and pricing |
@@ -52,7 +52,7 @@ Total cost is now shaped by a combination of variables that FinOps must track ex
 
 ## Rate structure: Claude models
 
-> *Illustrative rates, list price, as of June 2026 (Anthropic model documentation).
+> *Illustrative rates, list price, as of September 2026 (Anthropic model documentation).
 > Prices move and this file does not. For a current figure, call a live pricing tool or
 > check <https://optimtoken.optimnow.io>. What is durable below is the tier structure and
 > the multipliers, not the absolute numbers.*
@@ -66,7 +66,7 @@ Total cost is now shaped by a combination of variables that FinOps must track ex
 | Claude Opus 4.8 | $5 | $25 | 1M | Previous Opus |
 | Claude Opus 4.7 | $5 | $25 | 1M | |
 | Claude Opus 4.6 | $5 | $25 | 1M | |
-| Claude Sonnet 5 | $3 | $15 | 1M | Introductory $2/$10 through 31 August 2026 |
+| Claude Sonnet 5 | $2 | $10 | 1M | Launched at an introductory rate; Anthropic made it the standard price in August 2026 and cancelled the scheduled 1 September increase |
 | Claude Sonnet 4.6 | $3 | $15 | 1M | |
 | Claude Haiku 4.5 | $1 | $5 | 200K | 200K window - the 1M window applies to 4.6-generation and later models only (the still-active Opus 4.5 and Sonnet 4.5 are likewise 200K) |
 
@@ -77,9 +77,13 @@ older Opus for price reasons. Second, Fable 5 sits at 2x Opus pricing, which mak
 "use the most capable model" a materially different decision from "use the newest
 Opus": route to Fable 5 on evidence, not by default.
 
-The introductory Sonnet 5 rate is a scheduled increase, not a discount to
-negotiate: budgets built on $2/$10 rise 50% on 1 September 2026 with no change in
-usage. Flag it now if Sonnet 5 carries meaningful volume.
+**The Sonnet 5 introductory rate became the standard rate.** The $2/$10 launch
+price was announced as temporary, with a 50% increase scheduled for 1 September
+2026. Anthropic cancelled the increase before it took effect (pricing page, checked
+9 September 2026: the previously scheduled increase "will not occur"). Two
+consequences: budgets built on the introductory rate stay valid, and Sonnet 5 now
+sits at 0.4x Opus rather than 0.6x, which widens the payoff from tiered routing.
+Verify the current figure on the pricing page or the live hub before quoting it.
 
 ### Fast mode pricing
 
@@ -115,7 +119,7 @@ an hour; the ceiling is 24 hours. Results are retained 29 days.
 | Model | Input ($/MTok) | Output ($/MTok) |
 |---|---|---|
 | Claude Opus 5 Batch | $2.50 | $12.50 |
-| Claude Sonnet 5 Batch | $1.50 | $7.50 ($1 / $5 introductory through 31 August 2026) |
+| Claude Sonnet 5 Batch | $1 | $5 |
 | Claude Haiku 4.5 Batch | $0.50 | $2.50 |
 
 Batch is the single largest rate lever available without a commercial negotiation.
@@ -129,7 +133,8 @@ completion - which makes it a workload-classification exercise, not a procuremen
   parameter is set
 - **5-minute cache writes**: x1.25 on base input price
 - **1-hour cache writes**: x2 on base input price
-- **Cache reads**: x0.1 on base input price (90% discount)
+- **Cache reads**: x0.1 on base input price (90% discount). Fable 5.1 reads at
+  x0.025 (97.5% discount), which moves the cache break-even for that tier
 - **Modifiers stack** - Fast mode plus US-only inference compounds
 
 **Cache break-even depends on the TTL, and the 1-hour TTL is not a free upgrade.**
@@ -324,16 +329,20 @@ an additional native cost-governance signal alongside the July 2026 Enterprise
 admin tooling, reducing surprise overage incidents. See the "Cost tracking for
 Claude Code" section in `finops-ai-dev-tools.md` for detail.
 
-**Prompt-cache visibility (as of September 2026):** Claude Code v2.1.251 adds a
-spend-limit bar in the UI and a `rate_limits.spend_limit` status field, plus
-native prompt-cache visibility monitoring. The prompt-cache signal ties directly
-into the cache multiplier mechanics documented above (5-minute writes at 1.25x,
-1-hour writes at 2x, reads at 0.1x): native visibility into cache hit behaviour
-lets teams confirm that prefixes are actually being read back rather than silently
-re-written at full rate - the exact break-even question raised in the "Modifiers"
-section. This reduces reliance on third-party tooling purely for budget-cap
-visibility. See the "Cost tracking for Claude Code" section in
-`finops-ai-dev-tools.md` for detail.
+**Prompt-cache visibility (Claude Code v2.1.251, 28 August 2026):** the `/cost`
+command now shows a per-session prompt-cache line (hit ratio, misses, tokens
+re-cached, warm or cold), with a matching `prompt_cache` object for status-line
+scripts; it covers the main conversation only, not subagents. That signal ties
+directly into the cache multiplier mechanics documented above (5-minute writes at
+1.25x, 1-hour writes at 2x, reads at 0.1x): it lets teams confirm that prefixes are
+actually being read back rather than silently re-written at full rate - the exact
+break-even question raised in the "Modifiers" section. The same release added a
+spend-limit bar to `/usage` and a `rate_limits.spend_limit` status field, but only
+for developers behind a self-hosted Claude apps gateway with spend limits
+configured; Console, Team and Enterprise users do not see it. See the "Cost
+tracking for Claude Code" section in `finops-ai-dev-tools.md` for detail. Sources:
+https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md (2.1.251),
+https://code.claude.com/docs/en/costs.
 
 Sources: [Anthropic - New analytics and cost controls for Claude Enterprise](https://claude.com/blog/giving-admins-more-visibility-and-control-over-claude-usage-and-spend) (primary),
 [Anthropic keeps signaling where AI cost governance needs to go](https://www.finout.io/blog/anthropic-keeps-signaling-where-ai-cost-governance-needs-to-go.-its-not-all-the-way-there-yet) (Finout commentary).

--- a/skills/cloud-finops/references/finops-anthropic.md
+++ b/skills/cloud-finops/references/finops-anthropic.md
@@ -324,6 +324,17 @@ an additional native cost-governance signal alongside the July 2026 Enterprise
 admin tooling, reducing surprise overage incidents. See the "Cost tracking for
 Claude Code" section in `finops-ai-dev-tools.md` for detail.
 
+**Prompt-cache visibility (as of September 2026):** Claude Code v2.1.251 adds a
+spend-limit bar in the UI and a `rate_limits.spend_limit` status field, plus
+native prompt-cache visibility monitoring. The prompt-cache signal ties directly
+into the cache multiplier mechanics documented above (5-minute writes at 1.25x,
+1-hour writes at 2x, reads at 0.1x): native visibility into cache hit behaviour
+lets teams confirm that prefixes are actually being read back rather than silently
+re-written at full rate - the exact break-even question raised in the "Modifiers"
+section. This reduces reliance on third-party tooling purely for budget-cap
+visibility. See the "Cost tracking for Claude Code" section in
+`finops-ai-dev-tools.md` for detail.
+
 Sources: [Anthropic - New analytics and cost controls for Claude Enterprise](https://claude.com/blog/giving-admins-more-visibility-and-control-over-claude-usage-and-spend) (primary),
 [Anthropic keeps signaling where AI cost governance needs to go](https://www.finout.io/blog/anthropic-keeps-signaling-where-ai-cost-governance-needs-to-go.-its-not-all-the-way-there-yet) (Finout commentary).
 

--- a/skills/cloud-finops/references/finops-aws-patterns.md
+++ b/skills/cloud-finops/references/finops-aws-patterns.md
@@ -1235,14 +1235,14 @@ Some architectures unintentionally route large volumes of traffic between resour
 - Review VPC flow logs, CloudWatch metrics, or billing data to assess regional data transfer patterns
 - Determine whether the resource acts as a centralised destination for data aggregation, storage, or processing
 
-**Karpenter Spot Node Replacement Shifting Nodes Across Availability Zones**
+**Karpenter Nodes Landing In Other Availability Zones After Spot Exhaustion**
 Service: AWS EKS | Type: Inefficient Architecture
 
-As of March 2026, Karpenter's Spot-driven node replacement can silently shift nodes across Availability Zones when Spot capacity in the original AZ is exhausted. The replacement node may land in a different AZ from the workloads it serves, generating cross-AZ data transfer charges that appear on the bill with no corresponding health or utilisation alert. This is easy to miss because the cluster remains healthy and the cost surfaces only in inter-AZ data transfer lines. See the Karpenter consolidation/disruption tuning guidance in `finops-kubernetes.md` and the Spot best practices in `finops-aws-commitments.md`.
+When Spot capacity runs out in one Availability Zone, Karpenter places new nodes (often On-Demand fallback) in the zones that still have capacity. The cluster stays healthy, but calls that used to stay zone-local now cross zones and are billed at the Regional data transfer rate in each direction, with no health or utilisation alert. The cost surfaces only in inter-AZ data transfer lines. See the waste pattern in `finops-kubernetes.md` and the Spot best practices in `finops-aws-commitments.md`. Source: AWS Fundamentals, "Networking Is Still Hard" (8 September 2026), https://awsfundamentals.com/blog/cross-az-traffic-karpenter (practitioner write-up, not AWS documentation).
 
-- Detect nodes that changed AZ due to Spot interruption or replacement, and correlate the timing with cross-AZ data transfer cost spikes
-- Apply Karpenter NodePool AZ-affinity or topology spread constraints to keep replacement capacity aligned with dependent workloads
-- Add cross-AZ traffic monitoring as a companion signal to Spot interruption handling, so replacements that cross AZ boundaries are surfaced promptly
+- Alert on the On-Demand to Spot ratio, on nodes per zone, and on `DataTransfer-Regional-Bytes`, and correlate spikes with Spot exhaustion events
+- Widen NodePool instance families and sizes so more Spot pools qualify and the fallback fires less often
+- Set `trafficDistribution: PreferClose` on Services and use topology spread constraints; even spread alone only makes the cross-zone charge consistent
 
 **Managed Nat Gateway With Excessive Data Transfer**
 Service: AWS NAT Gateway | Type: Inefficient Architecture

--- a/skills/cloud-finops/references/finops-aws-patterns.md
+++ b/skills/cloud-finops/references/finops-aws-patterns.md
@@ -1215,7 +1215,7 @@ While stopping an RDS instance reduces runtime cost, AWS enforces a 7-day limit 
 
 ---
 
-### Networking Optimization Patterns (14)
+### Networking Optimization Patterns (15)
 
 **Elastic Load Balancer With Only One Ec2 Instance**
 Service: AWS ELB | Type: Inefficient Architecture
@@ -1234,6 +1234,15 @@ Some architectures unintentionally route large volumes of traffic between resour
 - Identify resources that receive or send high volumes of traffic to other Availability Zones within the same region
 - Review VPC flow logs, CloudWatch metrics, or billing data to assess regional data transfer patterns
 - Determine whether the resource acts as a centralised destination for data aggregation, storage, or processing
+
+**Karpenter Spot Node Replacement Shifting Nodes Across Availability Zones**
+Service: AWS EKS | Type: Inefficient Architecture
+
+As of March 2026, Karpenter's Spot-driven node replacement can silently shift nodes across Availability Zones when Spot capacity in the original AZ is exhausted. The replacement node may land in a different AZ from the workloads it serves, generating cross-AZ data transfer charges that appear on the bill with no corresponding health or utilisation alert. This is easy to miss because the cluster remains healthy and the cost surfaces only in inter-AZ data transfer lines. See the Karpenter consolidation/disruption tuning guidance in `finops-kubernetes.md` and the Spot best practices in `finops-aws-commitments.md`.
+
+- Detect nodes that changed AZ due to Spot interruption or replacement, and correlate the timing with cross-AZ data transfer cost spikes
+- Apply Karpenter NodePool AZ-affinity or topology spread constraints to keep replacement capacity aligned with dependent workloads
+- Add cross-AZ traffic monitoring as a companion signal to Spot interruption handling, so replacements that cross AZ boundaries are surfaced promptly
 
 **Managed Nat Gateway With Excessive Data Transfer**
 Service: AWS NAT Gateway | Type: Inefficient Architecture

--- a/skills/cloud-finops/references/finops-aws.md
+++ b/skills/cloud-finops/references/finops-aws.md
@@ -83,6 +83,23 @@ the receiving side and the export configuration on the source side.
   AWS Organizations (M&A integrations, multi-payer setups, partner-resold
   accounts).
 
+**SQL-based row filtering at the source (March 2026).** AWS Data Exports now
+supports SQL-based row filtering for CUR 2.0 data, in addition to the existing
+column selection. This lets teams produce pre-filtered per-account or
+per-service datasets at the source, without building custom Lambda / Glue /
+Athena post-processing pipelines. As of March 2026, this is directly useful for:
+- Partner sharing - publish a dataset scoped to only the accounts or services a
+  partner is entitled to see.
+- Program or cost-centre isolation - a pre-filtered export per program without a
+  downstream copy step.
+- Audit scoping - hand auditors a dataset limited to the rows in scope rather
+  than the full CUR.
+
+Filtering at the source reduces the operational overhead of sharing scoped cost
+data and removes the need for organisations to maintain their own filtering
+pipeline. Source:
+https://aws.amazon.com/blogs/aws-cloud-financial-management/automating-filtered-cost-and-usage-report-exports-with-aws-data-exports/
+
 Sources: https://aws.amazon.com/about-aws/whats-new/2025/11/aws-data-exports-focus-1-2-available/
 and https://aws.amazon.com/about-aws/whats-new/2026/03/aws-data-exports-cross-account-delivery-cost/
 
@@ -166,6 +183,19 @@ unexpected spending increases and sends alerts via SNS or email.
   (a 100% increase on $10 is $10; a 20% increase on $50,000 is $10,000)
 - Route alerts to both the FinOps practitioner and the engineering team lead
 - Review alert history monthly - tune thresholds to reduce false positives
+
+**Automated spend guardrails via AWS Budgets Actions (circuit breaker).** As of
+March 2026, AWS documents a programmatic "circuit breaker" pattern that uses AWS
+Budgets Actions to automatically restrict or revoke developer access when a
+budget threshold is exceeded, while maintaining an audit trail. This extends
+Budgets Actions beyond the existing SCP-apply and EC2-stop actions to IAM
+Identity Center permission-set assignments, giving FinOps teams a stronger
+automated governance guardrail: when a budget breaches, the action can detach or
+restrict IAM Identity Center permission sets (alongside applying an SCP or
+stopping EC2 instances) to halt further spend. Treat this as a complement to the
+reactive anomaly and budget alerts above, not a replacement - it is the
+preventive backstop that acts without waiting for a human. Source:
+https://aws.amazon.com/blogs/aws-cloud-financial-management/how-to-programmatically-manage-account-access-with-aws-budgets-alerts/
 
 ---
 
@@ -789,6 +819,15 @@ comparison is not close.
 - **Unsupported features block subscription.** The console refuses to attach a
   plan while the distribution still has Lambda@Edge, real-time logs or any
   other unsupported feature active.
+- **Programmatic management is now available.** As of September 2026, flat-rate
+  plan subscription, upgrade, downgrade and cancellation can be managed
+  programmatically via the CLI, SDKs, CloudFormation, CDK or the new
+  PricingPlanManager API - no longer console-only. Paid plans use a two-phase
+  create-then-approve activation flow so that provisioning a plan does not
+  silently commit you to a monthly charge; the approval step is a governance
+  safeguard that matters for IaC pipelines and agent-driven provisioning
+  workflows, where an unreviewed template change could otherwise attach a paid
+  plan. Source: https://aws.amazon.com/about-aws/whats-new/2026/09/cloudfront-flat-rate-pricing-plans-api/
 - **Maximum 100 plans per AWS account, 3 Free plans maximum. AWS Free Tier
   accounts are not eligible.**
 

--- a/skills/cloud-finops/references/finops-aws.md
+++ b/skills/cloud-finops/references/finops-aws.md
@@ -83,11 +83,13 @@ the receiving side and the export configuration on the source side.
   AWS Organizations (M&A integrations, multi-payer setups, partner-resold
   accounts).
 
-**SQL-based row filtering at the source (March 2026).** AWS Data Exports now
-supports SQL-based row filtering for CUR 2.0 data, in addition to the existing
-column selection. This lets teams produce pre-filtered per-account or
-per-service datasets at the source, without building custom Lambda / Glue /
-Athena post-processing pipelines. As of March 2026, this is directly useful for:
+**SQL-based row filtering at the source.** AWS Data Exports has supported SQL
+row filtering (a `WHERE` clause on the CUR 2.0 table) alongside column
+selection since its launch in November 2023. It is an existing capability, not
+a recent one, but it is under-used: an AWS how-to published on 26 August 2026
+shows how to automate pre-filtered per-account or per-service exports at the
+source, without a custom Lambda / Glue / Athena post-processing pipeline. Where
+this pays off:
 - Partner sharing - publish a dataset scoped to only the accounts or services a
   partner is entitled to see.
 - Program or cost-centre isolation - a pre-filtered export per program without a
@@ -97,7 +99,7 @@ Athena post-processing pipelines. As of March 2026, this is directly useful for:
 
 Filtering at the source reduces the operational overhead of sharing scoped cost
 data and removes the need for organisations to maintain their own filtering
-pipeline. Source:
+pipeline. Source (AWS how-to, 26 August 2026):
 https://aws.amazon.com/blogs/aws-cloud-financial-management/automating-filtered-cost-and-usage-report-exports-with-aws-data-exports/
 
 Sources: https://aws.amazon.com/about-aws/whats-new/2025/11/aws-data-exports-focus-1-2-available/
@@ -184,17 +186,18 @@ unexpected spending increases and sends alerts via SNS or email.
 - Route alerts to both the FinOps practitioner and the engineering team lead
 - Review alert history monthly - tune thresholds to reduce false positives
 
-**Automated spend guardrails via AWS Budgets Actions (circuit breaker).** As of
-March 2026, AWS documents a programmatic "circuit breaker" pattern that uses AWS
-Budgets Actions to automatically restrict or revoke developer access when a
-budget threshold is exceeded, while maintaining an audit trail. This extends
-Budgets Actions beyond the existing SCP-apply and EC2-stop actions to IAM
-Identity Center permission-set assignments, giving FinOps teams a stronger
-automated governance guardrail: when a budget breaches, the action can detach or
-restrict IAM Identity Center permission sets (alongside applying an SCP or
-stopping EC2 instances) to halt further spend. Treat this as a complement to the
-reactive anomaly and budget alerts above, not a replacement - it is the
-preventive backstop that acts without waiting for a human. Source:
+**Automated spend guardrails: Budgets Actions and the access circuit breaker.**
+AWS Budgets Actions natively support three responses when a budget threshold is
+crossed: apply an IAM policy, apply an SCP, or stop EC2 / RDS instances. An AWS
+how-to published on 1 September 2026 extends the idea to developer access
+itself, which native actions do not cover: a budget alert publishes to SNS, and
+a Lambda function then removes the user's IAM Identity Center permission-set
+assignment or swaps it for a read-only one, with an audit trail. It is custom
+automation on top of a Budgets alert, not a new Budgets Action type, so it needs
+owning like any other Lambda. Treat both the native actions and the circuit
+breaker as a complement to the reactive anomaly and budget alerts above, not a
+replacement - they are the preventive backstop that acts without waiting for a
+human. Source (AWS how-to, 1 September 2026):
 https://aws.amazon.com/blogs/aws-cloud-financial-management/how-to-programmatically-manage-account-access-with-aws-budgets-alerts/
 
 ---
@@ -819,11 +822,12 @@ comparison is not close.
 - **Unsupported features block subscription.** The console refuses to attach a
   plan while the distribution still has Lambda@Edge, real-time logs or any
   other unsupported feature active.
-- **Programmatic management is now available.** As of September 2026, flat-rate
+- **Programmatic management is now available.** Since 3 September 2026, flat-rate
   plan subscription, upgrade, downgrade and cancellation can be managed
   programmatically via the CLI, SDKs, CloudFormation, CDK or the new
-  PricingPlanManager API - no longer console-only. Paid plans use a two-phase
-  create-then-approve activation flow so that provisioning a plan does not
+  PricingPlanManager API - no longer console-only. Paid plans support an optional
+  two-phase activation flow (create the plan, then approve it to start billing;
+  free plans activate immediately) so that provisioning a plan does not
   silently commit you to a monthly charge; the approval step is a governance
   safeguard that matters for IaC pipelines and agent-driven provisioning
   workflows, where an unreviewed template change could otherwise attach a paid

--- a/skills/cloud-finops/references/finops-azure-commitments.md
+++ b/skills/cloud-finops/references/finops-azure-commitments.md
@@ -540,6 +540,17 @@ calculation from the cost-plus-utilisation join, reconcile differences. Differen
 diagnostic - they usually reveal AHB not factored, scope mismatches, or workload context
 Advisor cannot know.
 
+**Agentic access to commitment recommendation data.** As of September 2026, the Azure
+Resource Manager MCP Server (public preview) exposes cost query and pricing tools by
+default, with optional capabilities for reservation, Savings Plan, and Advisor
+recommendation data (plus forecasting, budgets/alerts, and idle AKS capacity detection).
+This lets AI agents pull the same backward-looking recommendation feed described above
+natively. The same calibration caveats apply: agent-surfaced recommendations remain a
+sanity check, not a source of truth, and still need reconciling against your own
+cost-plus-utilisation join. See the agentic FinOps discussion in `finops-azure.md` and
+the tag-hygiene pattern in `finops-tagging.md` for the broader MCP governance context.
+Source: Microsoft Learn (Azure Resource Manager MCP Server, public preview).
+
 Source: https://learn.microsoft.com/en-us/azure/advisor/advisor-reference-cost-recommendations
 
 #### Tooling decision - Power BI / FinOps Hubs / third-party

--- a/skills/cloud-finops/references/finops-azure-commitments.md
+++ b/skills/cloud-finops/references/finops-azure-commitments.md
@@ -540,16 +540,20 @@ calculation from the cost-plus-utilisation join, reconcile differences. Differen
 diagnostic - they usually reveal AHB not factored, scope mismatches, or workload context
 Advisor cannot know.
 
-**Agentic access to commitment recommendation data.** As of September 2026, the Azure
-Resource Manager MCP Server (public preview) exposes cost query and pricing tools by
-default, with optional capabilities for reservation, Savings Plan, and Advisor
-recommendation data (plus forecasting, budgets/alerts, and idle AKS capacity detection).
-This lets AI agents pull the same backward-looking recommendation feed described above
-natively. The same calibration caveats apply: agent-surfaced recommendations remain a
-sanity check, not a source of truth, and still need reconciling against your own
-cost-plus-utilisation join. See the agentic FinOps discussion in `finops-azure.md` and
-the tag-hygiene pattern in `finops-tagging.md` for the broader MCP governance context.
-Source: Microsoft Learn (Azure Resource Manager MCP Server, public preview).
+**Agentic access to commitment recommendation data.** Since August 2026, the Azure
+Resource Manager MCP server (preview) exposes cost query and pricing tools by default,
+and an optional Cost Management toolset that adds reservation and Savings Plan
+insights alongside forecasting, budgets and alerts. This lets AI agents pull the same
+backward-looking recommendation feed described above natively (Advisor cost
+recommendations are mentioned in Microsoft's blog but not listed as a tool in the
+server's README, so verify before relying on that path). The same calibration caveats
+apply: agent-surfaced recommendations remain a sanity check, not a source of truth,
+and still need reconciling against your own cost-plus-utilisation join. See the
+agentic FinOps discussion in `finops-azure.md` and the tag-hygiene pattern in
+`finops-tagging.md` for the broader MCP governance context. Sources:
+https://github.com/Azure/Azure-Resource-Manager-MCP (README),
+https://techcommunity.microsoft.com/blog/finopsblog/cost-management-with-azure-resource-manager-mcp/4550182
+(Microsoft FinOps blog, 25 August 2026).
 
 Source: https://learn.microsoft.com/en-us/azure/advisor/advisor-reference-cost-recommendations
 

--- a/skills/cloud-finops/references/finops-azure.md
+++ b/skills/cloud-finops/references/finops-azure.md
@@ -1814,6 +1814,4 @@ for Azure cost reporting.
 
 ---
 
----
-
 > *Cloud FinOps Skill by [OptimNow](https://optimnow.io) - licensed under [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/).*

--- a/skills/cloud-finops/references/finops-bedrock.md
+++ b/skills/cloud-finops/references/finops-bedrock.md
@@ -140,6 +140,21 @@ Key dimensions available for filtering and grouping:
 unit economics (cost per 1,000 tokens, cost per API call), you need to combine billing
 data with application-level metrics from CloudWatch or your own instrumentation.
 
+### Cost Anomaly Detection for Bedrock foundation models
+
+As of August 2026, **AWS Cost Anomaly Detection** natively monitors third-party
+foundation models on Bedrock, including provider-hosted models such as Anthropic Claude.
+Detected anomalies come with root-cause breakdowns by account, region, service, and
+usage type. This reduces reliance on CloudWatch-only detection for this specific gap:
+spend spikes on Bedrock foundation models can now be surfaced through the native
+anomaly-detection path rather than requiring custom CloudWatch alarms on token metrics.
+
+**FinOps positioning:** use native Cost Anomaly Detection as the first line of spend-spike
+detection for Bedrock foundation models, and complement it with usage-telemetry-based
+detection (token-count metrics, invocation logging) for the token-level granularity that
+billing-based anomaly detection does not provide. See `finops-anomaly-management.md`
+for the AI/token-workload anomaly approach.
+
 ### Tagging strategy for Bedrock
 
 AWS Bedrock supports resource tagging on provisioned throughput resources. For on-demand

--- a/skills/cloud-finops/references/finops-bedrock.md
+++ b/skills/cloud-finops/references/finops-bedrock.md
@@ -142,10 +142,12 @@ data with application-level metrics from CloudWatch or your own instrumentation.
 
 ### Cost Anomaly Detection for Bedrock foundation models
 
-As of August 2026, **AWS Cost Anomaly Detection** natively monitors third-party
-foundation models on Bedrock, including provider-hosted models such as Anthropic Claude.
-Detected anomalies come with root-cause breakdowns by account, region, service, and
-usage type. This reduces reliance on CloudWatch-only detection for this specific gap:
+Since 19 August 2026, **AWS Cost Anomaly Detection** monitors spend on third-party
+foundation models on Bedrock, such as Anthropic Claude and other provider-hosted models,
+through the AWS services managed monitor with no setup required (all commercial Regions
+except GovCloud and China). Detected anomalies come with a root-cause breakdown ranked by
+dollar impact across service, account, Region and usage type. This reduces reliance on
+CloudWatch-only detection for this specific gap:
 spend spikes on Bedrock foundation models can now be surfaced through the native
 anomaly-detection path rather than requiring custom CloudWatch alarms on token metrics.
 
@@ -154,6 +156,8 @@ detection for Bedrock foundation models, and complement it with usage-telemetry-
 detection (token-count metrics, invocation logging) for the token-level granularity that
 billing-based anomaly detection does not provide. See `finops-anomaly-management.md`
 for the AI/token-workload anomaly approach.
+
+Source: https://aws.amazon.com/about-aws/whats-new/2026/08/aws-cost-anomaly-detection-bedrock-3P/
 
 ### Tagging strategy for Bedrock
 

--- a/skills/cloud-finops/references/finops-for-ai.md
+++ b/skills/cloud-finops/references/finops-for-ai.md
@@ -577,6 +577,12 @@ deployments:
 - Set spending limits at the feature level, not just the account level
 - Anomaly alerts should trigger within minutes, not surface on the monthly bill
 - Define thresholds that require review before spend, not after
+- Where the platform offers native token-budget enforcement, use it as a proactive
+  guardrail rather than relying on alerts alone. As of September 2026, BigQuery
+  supports daily token quotas for its generative AI SQL functions (ML.GENERATE_TEXT
+  and related), letting teams cap daily token consumption at the platform level - a
+  GCP-native example of token budget enforcement that complements budget alerts and
+  anomaly detection (see `finops-gcp.md`).
 
 **Governance policies to establish:**
 - Require AI cost estimates (COGS modelling) before feature deployment

--- a/skills/cloud-finops/references/finops-for-ai.md
+++ b/skills/cloud-finops/references/finops-for-ai.md
@@ -442,18 +442,19 @@ for every feature is the AI equivalent of running all workloads on ml.p4d.24xlar
 
 What drives the routing decision is the **spread between tiers**, not the absolute rate.
 The spread is the durable, transferable number; the rate card behind it changes every
-few months. Tier structure as observed August 2026:
+few months. Tier structure as observed September 2026:
 
 | Model tier | Use case | Cost ratio vs small tier (Claude) |
 |---|---|---|
 | Small / fast (Haiku class) | Classification, routing, simple Q&A | 1x |
-| Mid-tier (Sonnet class) | Complex reasoning, code generation | 3x |
+| Mid-tier (Sonnet class) | Complex reasoning, code generation | 2x (Sonnet 5; 3x for Sonnet 4.6) |
 | Large (Opus class) | Research, nuanced judgment | 5x |
 | Frontier (Fable class) | Hardest reasoning, high-stakes work | 10x |
 
 The spread is vendor-specific and compresses across generations: the Claude 3-era
-small-to-large ratio was roughly 60x, the current one is 5-10x, while OpenAI's
-mini-to-reasoning spread remains near 100x. A vendor whose spread is 100x rewards
+small-to-large ratio was roughly 60x, the current one is 5-10x, while OpenAI's spread
+depends on the pairing: about 20x within one model family and 150x or more from a nano
+model to a pro reasoning model. A vendor whose spread is 100x rewards
 tiered routing far more than one at 5x, and that alone can decide whether the routing
 harness is worth building.
 
@@ -514,7 +515,8 @@ The following inference parameters directly affect output length and therefore c
 
 #### Token engineering - the input/output optimisation menu
 
-Per-token, input is roughly 4-5x cheaper than output. That price signal misleads:
+Per-token, input is roughly 4-8x cheaper than output (5x across Anthropic's line, 4-8x
+across OpenAI's, as of September 2026). That price signal misleads:
 **in multi-turn conversations and agent loops, the entire history is re-billed as
 input on every turn.** Input token spend compounds quadratically with conversation
 length and routinely dominates. Optimise both sides.
@@ -578,11 +580,12 @@ deployments:
 - Anomaly alerts should trigger within minutes, not surface on the monthly bill
 - Define thresholds that require review before spend, not after
 - Where the platform offers native token-budget enforcement, use it as a proactive
-  guardrail rather than relying on alerts alone. As of September 2026, BigQuery
-  supports daily token quotas for its generative AI SQL functions (ML.GENERATE_TEXT
-  and related), letting teams cap daily token consumption at the platform level - a
-  GCP-native example of token budget enforcement that complements budget alerts and
-  anomaly detection (see `finops-gcp.md`).
+  guardrail rather than relying on alerts alone. Since 31 August 2026, BigQuery
+  again supports daily token quotas for its generative AI functions (AI.GENERATE_TEXT
+  and the other Gemini-based inference functions), per project and per user; the
+  defaults are high, so the control is the stricter override you set - a GCP-native
+  example of token budget enforcement that complements budget alerts and anomaly
+  detection (see `finops-gcp.md`).
 
 **Governance policies to establish:**
 - Require AI cost estimates (COGS modelling) before feature deployment
@@ -638,9 +641,10 @@ calls, validation loops, or agents that invoke themselves multiply token consump
 per query - each retry or validation loop triggers additional SaaS charges alongside
 model costs.
 
-*Real example:* A sales intelligence agent validated its own output with a second API
-call. When validation failed, it retried the full sequence. A single user query generated
-47 API calls at $2.30 each. At 12,000 queries/month: $27,600 in unintended cost. When
+*Real example (figures illustrative):* A sales intelligence agent validated its own output
+with a second API call. When validation failed, it retried the full sequence. A single user
+query generated 47 API calls, about $2.30 per query where a single call would have cost
+$0.05. At 12,000 queries/month: $27,600 in unintended cost. When
 the same agent began querying Salesforce data, per-query charges added another $18,000/month
 that appeared in the SaaS bill, not the AI infrastructure budget.
 
@@ -661,10 +665,12 @@ cross-region data transfer appearing in billing without a clear infrastructure c
 A feature appears viable at low volume. Each interaction loses money, but losses are
 small and unnoticed. As adoption grows, the scale-up accelerates the loss.
 
-*Real example:* An AI-powered search feature was included in a standard $15/user/month
-subscription. Each user performed 120 searches/month at $0.08 each - $9.60 in AI costs
-per user, against $15 in subscription revenue. Profitable only for users performing fewer
-than 25 searches/month. Feature adoption growth increased losses, not margins.
+*Real example (figures illustrative):* An AI-powered search feature was included in a
+standard $15/user/month subscription. Power users performed 220 searches/month at $0.08
+each - $17.60 in AI costs per user, against $15 in subscription revenue, before any other
+cost of serving the account. Break-even sat at roughly 187 searches/month, and the users
+who adopted the feature most were exactly the ones above it. Feature adoption growth
+increased losses, not margins.
 
 *Detection signal:* AI costs growing proportionally with user adoption; unit margin
 declining as volume increases.

--- a/skills/cloud-finops/references/finops-gcp.md
+++ b/skills/cloud-finops/references/finops-gcp.md
@@ -52,24 +52,31 @@ face when managing AI workloads on GCP.
 - Native tooling for AI spend attribution without third-party tools
 - Integrated into the Cloud Billing console for unified cost management
 
-**Gemini Enterprise consumption edition - pay-as-you-go alongside subscription.**
-As of August 2026, Gemini Enterprise added a **pay-as-you-go consumption edition**
-alongside the existing per-user subscription model. This gives FinOps teams a choice
-of billing shape for agent workloads rather than a single seat-based commitment.
+**Gemini Enterprise Pay-as-you-go edition - consumption alongside subscription.**
+On 26 August 2026 Google announced a **Gemini Enterprise Pay-as-you-go** edition
+alongside the per-seat editions (Business, Standard, Plus, Frontline). There is no
+base subscription fee: you pay for the compute and tokens your teams consume at
+standard model API rates, with no feature quota limits. At announcement it was
+available to select customers on invoiced Cloud Billing accounts and "rolling out
+broadly soon", so check eligibility before planning around it. This gives FinOps
+teams a choice of billing shape for agent workloads rather than a single seat-based
+commitment.
 
-- **Subscription (per-user)**: predictable per-seat cost; best where a stable,
-  known population of users runs agents regularly, and where flat budgeting matters
-  more than usage sensitivity.
-- **Consumption (pay-as-you-go)**: cost scales with actual agent usage; best for
-  spiky, exploratory, or uneven adoption where many seats would sit idle under a
-  subscription, or where new agent workloads have uncertain demand.
+- **Subscription (per-seat)**: predictable cost; best where a stable, known
+  population of users runs agents regularly, and where flat budgeting matters more
+  than usage sensitivity. Idle seats are the waste to watch.
+- **Pay-as-you-go**: cost scales with actual usage; best for spiky, exploratory or
+  uneven adoption where many seats would sit idle, or where new agent workloads have
+  uncertain demand. Unbounded usage is the risk to watch.
 
-**Choosing between them, with budget guardrails:** default to consumption for new
-or variable agent workloads and pair it with budget alerts (50% / 80% / 100%) and
-anomaly detection so unpredictable usage cannot silently overrun the budget. Move to
-subscription once adoption stabilises and per-user cost is consistently below the
-observed consumption run-rate. Reassess the mix periodically as adoption matures. See
-`finops-agentic.md` under cost governance for agent spend flexibility.
+**Choosing between them, with budget guardrails:** default to pay-as-you-go for new
+or variable agent workloads and pair it with a budget, threshold alerts and anomaly
+detection so unpredictable usage cannot silently overrun the budget. Move to a
+subscription edition once adoption stabilises and per-seat cost is consistently
+below the observed consumption run-rate. Reassess the mix as adoption matures. See
+`finops-agentic.md` under cost governance for agent spend flexibility. Sources:
+https://cloud.google.com/blog/products/ai-machine-learning/flexible-billing-and-cost-controls-for-agents-on-google-cloud
+(primary, 26 August 2026), https://docs.cloud.google.com/gemini/enterprise/docs/editions.
 
 **Originating products filter and Gemini Enterprise preset report.** As of August 2026,
 Cloud Billing added an **"Originating products"** filter/group-by dimension in Billing
@@ -359,21 +366,24 @@ https://finopsweekly.com/news/gcp-updates-2026-07-02/ (secondary source - verify
 
 #### Daily token quotas for generative AI SQL functions - native spend guardrail
 
-As of September 2026, BigQuery has restored **daily token quotas** for its
-generative AI SQL functions (`ML.GENERATE_TEXT` and related functions), allowing
-teams to cap daily token consumption directly at the platform level. This gives
-FinOps and data teams a proactive, native guardrail against unexpected GenAI spend
-spikes from BigQuery-based AI workloads, complementing existing budget alerts and
-anomaly detection.
+On 31 August 2026 BigQuery restored **daily token quotas** for its generative AI
+functions (`AI.GENERATE_TEXT`, `AI.CLASSIFY` and the other Gemini-based inference
+functions; embedding functions such as `AI.EMBED` are excluded). The quotas went GA
+on 8 June 2026, were disabled a week later, and came back at the end of August.
+They are the platform-level cap on GenAI spend from BigQuery workloads,
+complementing budget alerts and anomaly detection.
 
-- Cap daily token consumption per project at the platform level, so a runaway
-  GenAI SQL workload cannot silently blow through the budget before an alert fires
-- Complements (does not replace) budget alerts and anomaly detection - use it as a
-  hard ceiling while budget alerts remain the softer, notification-based signal
-- Enforce token budgets on `ML.GENERATE_TEXT` and related generative AI functions
-  before spend materialises, rather than reacting after the invoice
+- Four quota metrics, tracked globally across regions: input and output tokens per
+  day, each at project level and per user. Cached tokens do not count.
+- The defaults are very high, so the quota does nothing until you lower it: set a
+  stricter override on the IAM & Admin > Quotas & System Limits page. That override
+  is the actual cost control.
+- Complements (does not replace) budget alerts and anomaly detection - it is the
+  hard ceiling while budget alerts remain the softer, notification-based signal.
 
-See `finops-for-ai.md` for the broader proactive guardrail and token-budget
+Sources: https://docs.cloud.google.com/bigquery/docs/control-genai-costs (primary),
+https://docs.cloud.google.com/bigquery/docs/release-notes#August_31_2026 (release
+note). See `finops-for-ai.md` for the broader proactive guardrail and token-budget
 enforcement guidance; this is the GCP-native example of platform-level token
 budget enforcement.
 

--- a/skills/cloud-finops/references/finops-gcp.md
+++ b/skills/cloud-finops/references/finops-gcp.md
@@ -52,6 +52,25 @@ face when managing AI workloads on GCP.
 - Native tooling for AI spend attribution without third-party tools
 - Integrated into the Cloud Billing console for unified cost management
 
+**Gemini Enterprise consumption edition - pay-as-you-go alongside subscription.**
+As of August 2026, Gemini Enterprise added a **pay-as-you-go consumption edition**
+alongside the existing per-user subscription model. This gives FinOps teams a choice
+of billing shape for agent workloads rather than a single seat-based commitment.
+
+- **Subscription (per-user)**: predictable per-seat cost; best where a stable,
+  known population of users runs agents regularly, and where flat budgeting matters
+  more than usage sensitivity.
+- **Consumption (pay-as-you-go)**: cost scales with actual agent usage; best for
+  spiky, exploratory, or uneven adoption where many seats would sit idle under a
+  subscription, or where new agent workloads have uncertain demand.
+
+**Choosing between them, with budget guardrails:** default to consumption for new
+or variable agent workloads and pair it with budget alerts (50% / 80% / 100%) and
+anomaly detection so unpredictable usage cannot silently overrun the budget. Move to
+subscription once adoption stabilises and per-user cost is consistently below the
+observed consumption run-rate. Reassess the mix periodically as adoption matures. See
+`finops-agentic.md` under cost governance for agent spend flexibility.
+
 **Originating products filter and Gemini Enterprise preset report.** As of August 2026,
 Cloud Billing added an **"Originating products"** filter/group-by dimension in Billing
 Reports, plus a **Gemini Enterprise preset report**. Together these give more precise
@@ -337,6 +356,26 @@ per-principal budget guardrails inside a single shared reservation.
 
 Sources: https://docs.cloud.google.com/bigquery/docs/reservations-assignments (primary),
 https://finopsweekly.com/news/gcp-updates-2026-07-02/ (secondary source - verify against Google Cloud docs)
+
+#### Daily token quotas for generative AI SQL functions - native spend guardrail
+
+As of September 2026, BigQuery has restored **daily token quotas** for its
+generative AI SQL functions (`ML.GENERATE_TEXT` and related functions), allowing
+teams to cap daily token consumption directly at the platform level. This gives
+FinOps and data teams a proactive, native guardrail against unexpected GenAI spend
+spikes from BigQuery-based AI workloads, complementing existing budget alerts and
+anomaly detection.
+
+- Cap daily token consumption per project at the platform level, so a runaway
+  GenAI SQL workload cannot silently blow through the budget before an alert fires
+- Complements (does not replace) budget alerts and anomaly detection - use it as a
+  hard ceiling while budget alerts remain the softer, notification-based signal
+- Enforce token budgets on `ML.GENERATE_TEXT` and related generative AI functions
+  before spend materialises, rather than reacting after the invoice
+
+See `finops-for-ai.md` for the broader proactive guardrail and token-budget
+enforcement guidance; this is the GCP-native example of platform-level token
+budget enforcement.
 
 **Frame for clients**: BigQuery commitments trade flexibility for
 predictability, and often performance for predictability. The right

--- a/skills/cloud-finops/references/finops-genai-capacity.md
+++ b/skills/cloud-finops/references/finops-genai-capacity.md
@@ -159,6 +159,18 @@ $/PTU/hour rates for any client decision.
 For some models, provisioned capacity never generates token-cost savings - it is purely
 a performance and SLA product.
 
+**Worked example (illustrative, September 2026).** Tarrowmere Assurance, a fictional
+insurer, runs a claims-summarisation workload on Azure OpenAI at a steady 1.4M input
+tokens an hour on weekdays and about a third of that at night and at weekends: a
+peak-to-trough ratio of 3.1:1. Normalised at 100% utilisation, the one-year PTU
+reservation it was quoted works out at 0.79x the pay-as-you-go input rate, so its
+break-even utilisation is 79%; below that, the reservation costs more per token than
+paying as you go. Load testing put weekday utilisation at 83% and the weekly average
+at 57%. Reserving for the whole curve loses money; reserving for the night-and-weekend
+floor and spilling the weekday peak to pay-as-you-go clears break-even with room to
+spare. The pair to remember is 3.1:1 against 79%: the traffic shape decides, the
+discount does not.
+
 ### Normalisation checklist
 
 - [ ] Identify the capacity unit type (PTU, throughput unit, scale tier unit)

--- a/skills/cloud-finops/references/finops-kubernetes.md
+++ b/skills/cloud-finops/references/finops-kubernetes.md
@@ -297,28 +297,34 @@ governing how aggressively Karpenter replaces nodes.
 Tune up or down based on the observed pod-disruption rate vs the savings
 delivered.
 
-#### Waste pattern: silent cross-AZ node drift from Spot replacement
+#### Waste pattern: silent cross-AZ drift after Spot exhaustion
 
-When Karpenter replaces a Spot node whose original availability zone has
-exhausted Spot capacity, it may provision the replacement in a different AZ.
-This is a legitimate resilience behaviour, but it can silently shift a
-workload's pods across zones and generate cross-AZ data transfer charges that
-appear on the bill with no corresponding health or utilisation alert. The cost
-lands in networking, disconnected from any Karpenter or Spot signal.
+When Spot capacity runs out in one zone, Karpenter keeps the cluster healthy by
+placing new nodes wherever capacity exists: the busy zone goes first, so the
+replacements land in the other zones, often as On-Demand fallback. Nothing
+fails, but calls that used to stay zone-local now cross zones and are billed
+at the Regional data transfer rate in each direction. The cost lands in
+networking, disconnected from any Karpenter or Spot signal, and no health or
+utilisation alert fires.
 
-As of March 2026, this is a named detection pattern:
+Detection and mitigation (a named pattern since September 2026):
 
-- **Detect** nodes that changed AZ following a Spot interruption or
-  replacement, and correlate the timing with cross-AZ data transfer cost
-  spikes on the same cluster.
-- **Mitigate** with NodePool AZ-affinity or topology spread constraints where
-  the workload's cross-AZ chatter is expensive enough to outweigh the
-  resilience benefit of free AZ selection. This is a per-workload trade-off,
-  not a cluster-wide default.
-- **Monitor** cross-AZ traffic as a companion signal to Spot interruption
-  handling, so a spike is attributable to the replacement event that caused
-  it. See the Spot best practices in `finops-aws-commitments.md` and the
-  networking patterns in `finops-aws-patterns.md`.
+- **Detect** by alerting on the On-Demand to Spot ratio, on nodes per zone,
+  and on `DataTransfer-Regional-Bytes` usage on the cluster's accounts, then
+  correlate a spike with the Spot exhaustion event that caused it.
+- **Reduce the trigger**: widen the NodePool's instance families and sizes so
+  more Spot pools qualify and the fallback fires less often.
+- **Keep traffic local**: set `trafficDistribution: PreferClose` on Services
+  so requests prefer same-zone endpoints, and use topology spread constraints
+  to keep pods spread evenly. Even spread on its own does not help; it only
+  makes you pay the cross-zone rate consistently. Zones are a filter for
+  Karpenter, not a preference, so pinning a NodePool to one zone trades away
+  the resilience that makes Spot workable.
+- See the Spot best practices in `finops-aws-commitments.md` and the
+  networking patterns in `finops-aws-patterns.md`. Source: AWS Fundamentals,
+  "Networking Is Still Hard" (Tobias Schmidt, 8 September 2026),
+  https://awsfundamentals.com/blog/cross-az-traffic-karpenter - a practitioner
+  write-up, not AWS documentation.
 
 ### Pod Disruption Budgets are non-negotiable
 

--- a/skills/cloud-finops/references/finops-kubernetes.md
+++ b/skills/cloud-finops/references/finops-kubernetes.md
@@ -297,6 +297,29 @@ governing how aggressively Karpenter replaces nodes.
 Tune up or down based on the observed pod-disruption rate vs the savings
 delivered.
 
+#### Waste pattern: silent cross-AZ node drift from Spot replacement
+
+When Karpenter replaces a Spot node whose original availability zone has
+exhausted Spot capacity, it may provision the replacement in a different AZ.
+This is a legitimate resilience behaviour, but it can silently shift a
+workload's pods across zones and generate cross-AZ data transfer charges that
+appear on the bill with no corresponding health or utilisation alert. The cost
+lands in networking, disconnected from any Karpenter or Spot signal.
+
+As of March 2026, this is a named detection pattern:
+
+- **Detect** nodes that changed AZ following a Spot interruption or
+  replacement, and correlate the timing with cross-AZ data transfer cost
+  spikes on the same cluster.
+- **Mitigate** with NodePool AZ-affinity or topology spread constraints where
+  the workload's cross-AZ chatter is expensive enough to outweigh the
+  resilience benefit of free AZ selection. This is a per-workload trade-off,
+  not a cluster-wide default.
+- **Monitor** cross-AZ traffic as a companion signal to Spot interruption
+  handling, so a spike is attributable to the replacement event that caused
+  it. See the Spot best practices in `finops-aws-commitments.md` and the
+  networking patterns in `finops-aws-patterns.md`.
+
 ### Pod Disruption Budgets are non-negotiable
 
 Every workload with an SLO must have a PDB. No exceptions. PDBs are how the
@@ -460,7 +483,11 @@ own. It belongs to the Platform team's budget, not the application teams'.
   K8s allocation is one source feeding the broader allocation pipeline
 - `finops-tagging.md` - tag (label) hygiene is the prerequisite
 - `finops-aws-commitments.md` - EKS-specific commitment options; Karpenter
-  integration with EC2 Savings Plans and Compute Savings Plans
+  integration with EC2 Savings Plans and Compute Savings Plans; Spot best
+  practices and cross-AZ traffic monitoring as a companion signal to Spot
+  interruption handling
+- `finops-aws-patterns.md` - networking patterns, including cross-AZ data
+  transfer cost attribution for Spot-driven node AZ drift
 - `finops-azure.md` - AKS-specific deep cuts (Node Auto Provisioning,
   Azure Linux 2 retirement, MIG / MPS / DRA for GPU partitioning)
 - `finops-gcp.md` - GKE-specific options (Spot VMs, Autopilot vs Standard,

--- a/skills/cloud-finops/references/finops-tagging.md
+++ b/skills/cloud-finops/references/finops-tagging.md
@@ -210,13 +210,18 @@ agent that finds resources missing required tags, generates a patch template, an
 on approval - the same read-freely / write-behind-confirmation guardrail described above.
 See `finops-azure.md` ("Agentic FinOps on Azure") for the full treatment.
 
-As of September 2026, the Azure Resource Manager MCP Server (public preview) also
-extends this agentic pattern beyond tag hygiene into cost analysis and optimisation:
-it now exposes cost query and pricing tools by default, with optional tools for cost
-forecasting, budgets and alerts, reservations, Savings Plans, and Advisor
-recommendations, plus idle AKS capacity identification. This enables agents to
-analyse spend and estimate deployment costs natively, under the same identity-scoped,
-read-freely / write-behind-confirmation guardrails ([FinOps Weekly](https://finopsweekly.com/news/azure-updates-2026-09-03/)).
+Since August 2026, the Azure Resource Manager MCP server (preview) also extends this
+agentic pattern beyond tag hygiene into cost analysis: its Cost Management and Pricing
+tools (cost queries, AKS cost by cluster, namespace and active-versus-idle capacity,
+retail prices, price sheet download) are enabled by default, and an optional Cost
+Management toolset (forecasting, dimensions, budgets, alerts, reservation and Savings
+Plan insights) is switched on per client with the `x-mcp-toolset: CostManagement`
+header. This enables agents to analyse spend and estimate deployment costs natively,
+under the same identity-scoped, read-freely / write-behind-confirmation guardrails.
+Do not confuse it with the separate Azure MCP Server, which has its own pricing and
+Advisor tools. Sources: https://github.com/Azure/Azure-Resource-Manager-MCP (README),
+https://techcommunity.microsoft.com/blog/finopsblog/cost-management-with-azure-resource-manager-mcp/4550182
+(Microsoft FinOps blog, 25 August 2026).
 
 ---
 

--- a/skills/cloud-finops/references/finops-tagging.md
+++ b/skills/cloud-finops/references/finops-tagging.md
@@ -210,6 +210,14 @@ agent that finds resources missing required tags, generates a patch template, an
 on approval - the same read-freely / write-behind-confirmation guardrail described above.
 See `finops-azure.md` ("Agentic FinOps on Azure") for the full treatment.
 
+As of September 2026, the Azure Resource Manager MCP Server (public preview) also
+extends this agentic pattern beyond tag hygiene into cost analysis and optimisation:
+it now exposes cost query and pricing tools by default, with optional tools for cost
+forecasting, budgets and alerts, reservations, Savings Plans, and Advisor
+recommendations, plus idle AKS capacity identification. This enables agents to
+analyse spend and estimate deployment costs natively, under the same identity-scoped,
+read-freely / write-behind-confirmation guardrails ([FinOps Weekly](https://finopsweekly.com/news/azure-updates-2026-09-03/)).
+
 ---
 
 ## Tagging maturity progression

--- a/skills/cloud-finops/references/optimnow-methodology.md
+++ b/skills/cloud-finops/references/optimnow-methodology.md
@@ -93,7 +93,9 @@ this organisation at this stage?"
 ### Visibility before optimisation
 Cost visibility is a prerequisite, not a phase. You cannot rightsize what you cannot see.
 You cannot allocate savings to a team that has no cost attribution. This principle prevents
-the common mistake of jumping to optimisation before the foundation is in place.
+the common mistake of jumping to optimisation before the foundation is in place. An
+unallocated euro has no owner, and unowned spend only grows - which is why allocation,
+not tooling, is the first deliverable.
 
 Corollary: **physical tagging must precede virtual tagging**. Virtual tagging (applying
 metadata in the billing layer without changing resource tags) is powerful but fragile if


### PR DESCRIPTION
## Content update - 9 Sep 2026

Closes https://github.com/OptimNow/cloud-finops-skills/issues/191

### Changes applied

- **Amazon CloudFront announces API support for flat-rate pricing plans** (NEW_FEATURE)
  - Files: `finops-aws.md`
  - AWS now supports managing CloudFront flat-rate pricing plans programmatically via CLI, SDKs, CloudFormation, CDK, or the new PricingPlanManager API, instead of requiring console-only management. Paid plans support a two-phase create-then-approve activation flow to prevent unintended billing commitment, which is particularly useful for IaC and agent-driven provisioning workflows. This improves governance and automation potential for a flat-rate cost-control instrument already referenced in finops-aws.md.

- **How to programmatically manage account access with AWS Budgets alerts** (NEW_FEATURE)
  - Files: `finops-aws.md`
  - AWS published guidance on building a programmatic "circuit breaker" that uses AWS Budgets Actions to automatically restrict or revoke developer access (via IAM Identity Center permission set assignments, SCPs, or EC2 stop actions) when budget thresholds are exceeded, while maintaining an audit trail. This extends AWS Budgets Actions beyond simple SCP/EC2 stop actions to IAM Identity Center permission management, giving FinOps teams a stronger automated governance/guardrail mechanism for cost control.

- **Automating filtered Cost and Usage Report exports with AWS Data Exports** (NEW_FEATURE)
  - Files: `finops-aws.md`
  - AWS Data Exports now supports SQL-based row filtering at the source for CUR 2.0 data, in addition to existing column selection, letting teams produce pre-filtered per-account or per-service datasets without building custom Lambda/Glue/Athena pipelines. This reduces the operational overhead of sharing scoped cost data with partners, cost centers, or auditors, and is directly relevant to FinOps data-pipeline design.

- **AI Provider Cost Updates 2026-09-04 | AI Economics News** (NEW_FEATURE)
  - Files: `finops-ai-dev-tools.md`, `finops-anthropic.md`
  - Claude Code v2.1.251 introduces a spend-limit bar in the UI and a rate_limits.spend_limit status field, plus prompt-cache visibility monitoring. This gives FinOps teams clearer native signals for tracking token spend against caps and observing cache efficiency, reducing reliance on third-party tools like ClaudeXray/LiteLLM purely for budget-cap visibility.

- **AZURE Updates 2026-09-03 | Cloud Provider News** (NEW_FEATURE)
  - Files: `finops-tagging.md`, `finops-azure.md`, `finops-azure-commitments.md`
  - Azure Resource Manager MCP Server (public preview) now includes cost query and pricing tools by default, with optional capabilities for cost forecasting, budgets/alerts, reservations, Savings Plans, and Advisor recommendations, plus idle AKS capacity identification - enabling AI agents to analyze spend and estimate deployment costs natively. This expands the agentic governance pattern already noted in finops-tagging.md (tag hygiene) to broader cost management and optimization tooling on Azure.

- **GCP Updates 2026-09-03 | Cloud Provider News** (NEW_FEATURE)
  - Files: `finops-gcp.md`, `finops-for-ai.md`
  - BigQuery has restored daily token quotas for its generative AI SQL functions, allowing teams to cap daily token consumption directly at the platform level. This gives FinOps and data teams a proactive guardrail against unexpected GenAI spend spikes from BigQuery-based AI workloads, complementing existing budget alerts and anomaly detection.

- **GCP Updates 2026-08-27 | Cloud Provider News** (NEW_FEATURE)
  - Files: `finops-gcp.md`, `finops-vertexai.md`, `finops-agentic.md`
  - 

- **AWS Updates 2026-08-27 | Cloud Provider News** (NEW_FEATURE)
  - Files: `finops-bedrock.md`, `finops-anomaly-management.md`
  - 

- **Networking Is Still Hard** (BEST_PRACTICE)
  - Files: `finops-kubernetes.md`, `finops-aws-patterns.md`, `finops-aws.md`
  - Karpenter's Spot-driven node replacement can silently shift nodes across availability zones when Spot capacity in the original AZ is exhausted, generating cross-AZ data transfer costs that show up on the bill with no corresponding health or utilization alert. This is a specific, previously-undocumented waste pattern relevant to Karpenter consolidation/disruption tuning and AWS cross-AZ network cost allocation.

---
_Generated by the FinOps content update pipeline._

---

## Post-execute review (9 September 2026)

This run stands in for the 1 September scheduled scan, which fired while the machine was offline (all 30 sources failed DNS resolution and the run reported "no new items"). Lookback was widened to 25 days to cover the gap. Nine items approved, six rejected (two GPT-6 Astra duplicates with no published pricing, a G6e instance-list note, an AgentCore Memory item that speculated about billing, a Kinesis marketing claim, and a Claude Code slash-command UX note).

### Corrections applied after the execute pass

Every applied item was checked against its provider primary source before this PR was left for review. The applier got these wrong:

- **Data Exports row filtering** is a November 2023 capability; the 26 August 2026 AWS post is a how-to, not an announcement. Reworded.
- **Budgets "circuit breaker"**: IAM Identity Center permission-set revocation is a Lambda on a Budgets alert, not a native Budgets Action. Reworded.
- **Karpenter cross-AZ pattern**: mechanism and mitigation rewritten to match the source (Spot exhaustion sends new nodes to other zones; fix with `trafficDistribution: PreferClose`, spread constraints and wider instance pools, not NodePool AZ-affinity). Third-party source flagged as such.
- **Azure Resource Manager MCP**: default versus optional toolsets per the server README; the Advisor claim is caveated; a citation to "Microsoft Learn" with no URL was replaced with the README and the Microsoft FinOps blog post. The change dates from August, not September.
- **BigQuery daily token quotas**: primary docs and release note added (GA 8 June, disabled 15 June, restored 31 August 2026); function names corrected to `AI.GENERATE_TEXT`; the defaults are very high, so the stricter override is the actual control.
- **Gemini Enterprise Pay-as-you-go**: exact edition name, billing basis (compute and tokens at standard API rates, no base fee), eligibility caveat; the "AI Cost Summary Agent" conflation removed.
- **Cost Anomaly Detection for third-party Bedrock models**: dated 19 August 2026 with the What's New link and the managed-monitor nuance.
- **CloudFront flat-rate API**: the two-phase flow is optional and paid plans only.
- **Claude Code v2.1.251**: the spend-limit bar and `rate_limits.spend_limit` are gateway-only and percentage-based; the prompt-cache line lives in `/cost` and `/usage`. Dated 28 August 2026.
- Three invented "as of March 2026" dates removed.

### Pricing re-verification pass: cluster 1 (model vendors and dev tools)

`finops-anthropic.md`, `finops-ai-dev-tools.md`, `finops-for-ai.md`, `finops-agentic.md`, checked against primary sources on 9 September 2026. Fixed: the Sonnet 5 introductory rate is now permanent (the 1 September increase was cancelled) in three places; Fable 5.1 cache reads at 0.025x; Claude Code per-developer cost figures; the mid-tier ratio (0.4x); the tier table (Sonnet 2x); the OpenAI spread and input-to-output ratio wording; two worked examples whose arithmetic did not hold; the 30x variance re-attributed to Bai et al.; Vercel removed from the x402 Foundation member list.

### Left for the maintainer

Unverifiable against a primary source, so not changed: in `finops-for-ai.md` the $1,600 to $8,800 variance example, the 40-60% harness share, the three-layer per-conversation figures, the TCA and "quarter of spend" claims (from the Tokenomics Brief; not on the foundation's site as of today), the AWS-reported token-engineering percentages, the 90% shadow-AI figure, and the 15-25% egress and 30-40% abandoned-experiment heuristics; in `finops-agentic.md` the Pay-i 3.5-models and 6.67%/month figures (traceable only to a Forrester interview). The Azure MCP edit to `finops-azure.md` was rejected by the double-horizontal-rule guard because of a pre-existing artefact before the footer; the artefact is removed in this PR and the Azure content landed in `finops-tagging.md` and `finops-azure-commitments.md` only.
