### PR TITLE
Prefect Horizon entrypoint for the hosted connector

### DIFF
--- a/horizon_server.py
+++ b/horizon_server.py
@@ -1,0 +1,47 @@
+"""Prefect Horizon entrypoint for the hosted `cloud-finops-mcp` connector.
+
+Horizon runs FastMCP 2.x-or-later server objects from the `fastmcp` package.
+`cloud-finops-mcp` is written against the official `mcp` SDK's FastMCP
+(``mcp.server.fastmcp``), which Horizon does not load directly. This file
+bridges the two: it builds a `fastmcp` proxy server that spawns the published
+`cloud-finops-mcp` console script over stdio and relays every tool, resource
+and prompt call unchanged (tool results and `_meta` pass through untouched).
+
+The package is installed from PyPI at the version pinned in `requirements.txt`,
+so the content served here is exactly the released bundle - the same rule as
+every other distribution channel. Bump the pin in the release PR.
+
+Entrypoint for Horizon: ``horizon_server.py:mcp``.
+Local check: ``fastmcp run horizon_server.py:mcp --transport http --port 8765``.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from fastmcp import FastMCP
+
+# Spawn the package through the interpreter that runs this proxy, not through a
+# bare `cloud-finops-mcp` on PATH: on a machine with several installs the bare
+# name resolved to an older one (33 references instead of 35) during the local
+# check on 2026-09-09.
+BACKEND = {
+    "mcpServers": {
+        "cloud-finops": {
+            "command": sys.executable,
+            "args": ["-m", "cloud_finops_mcp"],
+        }
+    }
+}
+
+
+def _build() -> FastMCP:
+    try:  # fastmcp >= 4 exposes a module-level factory
+        from fastmcp.server import create_proxy  # type: ignore[attr-defined]
+
+        return create_proxy(BACKEND, name="cloud-finops")
+    except ImportError:  # fastmcp 2.x / 3.x
+        return FastMCP.as_proxy(BACKEND, name="cloud-finops")
+
+
+mcp = _build()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+# Prefect Horizon deployment of the hosted connector (see horizon_server.py).
+# Horizon reads this file at the repo root. Nothing else in the repo uses it.
+#
+# fastmcp 4.x depends on the mcp 2.x SDK, which cloud-finops-mcp does not yet
+# support (it pins mcp>=1.28,<2), so stay on the 3.x line until that pin moves.
+fastmcp>=3,<4
+# Exact published wheel: the content served is the released bundle, nothing
+# newer. Bump this pin in the release PR alongside the four version fields.
+cloud-finops-mcp==1.36.0


### PR DESCRIPTION
## Why

The Alpic Free plan's request quota (10,000/month, shared by the whole team) is exhausted: every OptimNow connector on Alpic answers HTTP 402 until the billing period resets. This adds a zero-cost hosting path for the Python connector on Prefect Horizon (Personal tier).

## What

- `horizon_server.py`: Horizon only runs `fastmcp`-package servers, and `cloud-finops-mcp` is built on the official SDK's FastMCP. The entrypoint builds a `fastmcp` proxy over the published wheel, spawned through the running interpreter (a bare command name resolved to an older install during the local check). Tools, resources, prompts, tool results and `_meta` pass through unchanged.
- `requirements.txt` (repo root, Horizon reads it there): `fastmcp>=3,<4` (4.x needs the mcp 2 SDK, which the package does not support yet) and `cloud-finops-mcp==1.36.0`. Bump the pin in each release PR.

Verified locally over streamable HTTP with `fastmcp run horizon_server.py:mcp --transport http`: six tools, 35 references, 1.36.0 content, widget `_meta` and the six `ui://` resources relayed.

## What this PR does not do yet

The connector URL constant in `server.py` (which derives the MCP Apps `ui.domain`), README, INSTALLATION.md, the PyPI README, server.json and alpic.json are untouched. They move only once the Horizon deployment is confirmed reachable by an unauthenticated client.

## Deployment steps (maintainer)

1. Sign in at horizon.prefect.io with GitHub, connect this repository.
2. Entrypoint: `horizon_server.py:mcp`. Horizon detects `requirements.txt` at the root.
3. **Decisive check:** look for an authentication toggle on the deployed server. The Personal tier ships "Horizon OAuth", guest access is listed only on Enterprise, and a third-party tutorial states auth cannot be disabled on the free tier. If the server cannot be made public, Horizon is not usable for this connector and this PR should be closed.
4. If it can, call the URL (`https://<name>.fastmcp.app/mcp`) with an MCP client and confirm `list_references` returns 35; then a follow-up commit moves the connector URL and docs.